### PR TITLE
fix(compiler): Detect invalid INSERT expression

### DIFF
--- a/internal/compiler/parse.go
+++ b/internal/compiler/parse.go
@@ -79,7 +79,10 @@ func (c *Compiler) parseQuery(stmt ast.Node, src string, o opts.Parser) (*Query,
 
 	raw, namedParams, edits := rewrite.NamedParameters(c.conf.Engine, raw, numbers, dollar)
 	rvs := rangeVars(raw.Stmt)
-	refs := findParameters(raw.Stmt)
+	refs, err := findParameters(raw.Stmt)
+	if err != nil {
+		return nil, err
+	}
 	if o.UsePositionalParameters {
 		edits, err = rewriteNumberedParameters(refs, raw, rawSQL)
 		if err != nil {

--- a/internal/endtoend/testdata/insert_select_invalid/mysql/query.sql
+++ b/internal/endtoend/testdata/insert_select_invalid/mysql/query.sql
@@ -1,0 +1,5 @@
+CREATE TABLE foo (bar text);
+
+-- name: InsertFoo :exec
+INSERT INTO foo (bar)
+SELECT 1, ?, ?;

--- a/internal/endtoend/testdata/insert_select_invalid/mysql/sqlc.json
+++ b/internal/endtoend/testdata/insert_select_invalid/mysql/sqlc.json
@@ -1,0 +1,12 @@
+{
+  "version": "1",
+  "packages": [
+    {
+      "engine": "mysql",
+      "path": "go",
+      "name": "querytest",
+      "schema": "query.sql",
+      "queries": "query.sql"
+    }
+  ]
+}

--- a/internal/endtoend/testdata/insert_select_invalid/mysql/stderr.txt
+++ b/internal/endtoend/testdata/insert_select_invalid/mysql/stderr.txt
@@ -1,0 +1,2 @@
+# package querytest
+query.sql:4:1: INSERT has more expressions than target columns

--- a/internal/endtoend/testdata/insert_select_invalid/postgresql/pgx/query.sql
+++ b/internal/endtoend/testdata/insert_select_invalid/postgresql/pgx/query.sql
@@ -1,0 +1,5 @@
+CREATE TABLE foo (bar text);
+
+-- name: InsertFoo :exec
+INSERT INTO foo (bar)
+SELECT 1, $1, $2;

--- a/internal/endtoend/testdata/insert_select_invalid/postgresql/pgx/sqlc.json
+++ b/internal/endtoend/testdata/insert_select_invalid/postgresql/pgx/sqlc.json
@@ -1,0 +1,13 @@
+{
+  "version": "1",
+  "packages": [
+    {
+      "path": "go",
+      "engine": "postgresql",
+      "sql_package": "pgx/v4",
+      "name": "querytest",
+      "schema": "query.sql",
+      "queries": "query.sql"
+    }
+  ]
+}

--- a/internal/endtoend/testdata/insert_select_invalid/postgresql/pgx/stderr.txt
+++ b/internal/endtoend/testdata/insert_select_invalid/postgresql/pgx/stderr.txt
@@ -1,0 +1,2 @@
+# package querytest
+query.sql:4:1: INSERT has more expressions than target columns

--- a/internal/endtoend/testdata/insert_select_invalid/postgresql/stdlib/query.sql
+++ b/internal/endtoend/testdata/insert_select_invalid/postgresql/stdlib/query.sql
@@ -1,0 +1,5 @@
+CREATE TABLE foo (bar text);
+
+-- name: InsertFoo :exec
+INSERT INTO foo (bar)
+SELECT 1, $1, $2;

--- a/internal/endtoend/testdata/insert_select_invalid/postgresql/stdlib/sqlc.json
+++ b/internal/endtoend/testdata/insert_select_invalid/postgresql/stdlib/sqlc.json
@@ -1,0 +1,12 @@
+{
+  "version": "1",
+  "packages": [
+    {
+      "engine": "postgresql",
+      "path": "go",
+      "name": "querytest",
+      "schema": "query.sql",
+      "queries": "query.sql"
+    }
+  ]
+}

--- a/internal/endtoend/testdata/insert_select_invalid/postgresql/stdlib/stderr.txt
+++ b/internal/endtoend/testdata/insert_select_invalid/postgresql/stdlib/stderr.txt
@@ -1,0 +1,2 @@
+# package querytest
+query.sql:4:1: INSERT has more expressions than target columns


### PR DESCRIPTION
Return an error if you're trying to insert too many columns for the
given table. Before the same query would have panicked.

Fixes #1207 