### PR TITLE
[DRAFT] Support for PostgreSQL "RECORD" return types

### DIFF
--- a/internal/compiler/output_columns.go
+++ b/internal/compiler/output_columns.go
@@ -515,13 +515,30 @@ func (c *Compiler) sourceTables(qc *QueryCatalog, node ast.Node) ([]*Table, erro
 			}
 
 			fn, err := qc.GetFunc(funcCall.Func)
-			if err != nil {
+			if err == nil {
+				table := &Table{
+					Rel: &ast.TableName{
+						Catalog: fn.ReturnTable.Rel.Catalog,
+						Schema:  fn.ReturnTable.Rel.Schema,
+						//Name:    fn.ReturnType.Name,
+						Name: fn.ReturnTable.Rel.Name,
+					},
+				}
+
+				for _, c := range fn.Columns {
+					table.Columns = append(table.Columns, &Column{
+						Name:     c.Name,
+						DataType: c.DataType,
+					})
+				}
+				tables = append(tables, table)
 				continue
 			}
 			table, err := qc.GetTable(&ast.TableName{
 				Catalog: fn.ReturnType.Catalog,
 				Schema:  fn.ReturnType.Schema,
-				Name:    fn.ReturnType.Name,
+				//Name:    fn.ReturnType.Name,
+				Name: fn.Rel.Name,
 			})
 			if err != nil {
 				if n.Alias == nil || len(n.Alias.Colnames.Items) == 0 {

--- a/internal/compiler/query.go
+++ b/internal/compiler/query.go
@@ -5,8 +5,10 @@ import (
 )
 
 type Function struct {
-	Rel        *ast.FuncName
-	ReturnType *ast.TypeName
+	Rel         *ast.FuncName
+	ReturnType  *ast.TypeName
+	Columns     []*Column
+	ReturnTable *Table
 }
 
 type Table struct {

--- a/internal/compiler/query_catalog.go
+++ b/internal/compiler/query_catalog.go
@@ -87,8 +87,21 @@ func (qc QueryCatalog) GetFunc(rel *ast.FuncName) (*Function, error) {
 	if len(funcs) == 0 {
 		return nil, fmt.Errorf("function not found: %s", rel.Name)
 	}
+
+	var funcRecord *Table
+	var cols []*Column
+	rt := funcs[0].ReturnTable
+	if rt != nil {
+		for _, c := range rt.Columns {
+			cols = append(cols, ConvertColumn(rt.Rel, c))
+		}
+		funcRecord = &Table{Rel: rt.Rel, Columns: cols}
+	}
+
 	return &Function{
-		Rel:        rel,
-		ReturnType: funcs[0].ReturnType,
+		Rel:         rel,
+		ReturnType:  funcs[0].ReturnType,
+		ReturnTable: funcRecord,
+		Columns:     cols,
 	}, nil
 }

--- a/internal/sql/ast/create_function_stmt.go
+++ b/internal/sql/ast/create_function_stmt.go
@@ -6,8 +6,9 @@ type CreateFunctionStmt struct {
 	ReturnType *TypeName
 	Func       *FuncName
 	// TODO: Undertand these two fields
-	Options    *List
-	WithClause *List
+	Options     *List
+	WithClause  *List
+	ReturnTable *CreateTableStmt
 }
 
 func (n *CreateFunctionStmt) Pos() int {


### PR DESCRIPTION
In this draft change, we've added support for PostgreSQL functions that return the "RECORD" data type.