### PR TITLE
Add sqlc.nembed

### DIFF
--- a/internal/codegen/golang/query.go
+++ b/internal/codegen/golang/query.go
@@ -2,6 +2,7 @@ package golang
 
 import (
 	"fmt"
+	"strconv"
 	"strings"
 
 	"github.com/kyleconroy/sqlc/internal/metadata"
@@ -178,16 +179,16 @@ func (v QueryValue) DeclareNullableEmbeds() string {
 	return "\n" + strings.Join(out, "\n")
 }
 
-func (v QueryValue) NullableIndices() [][]int {
-	var out [][]int
+func (v QueryValue) NullableIndices() []string {
+	var out []string
 	fieldIdx := 0
 	if v.Struct != nil {
 		for _, f := range v.Struct.Fields {
 			if len(f.EmbedFields) > 0 {
-				var nullableIndices []int
+				var nullableIndices string
 				for range f.EmbedFields {
 					if !f.Column.NotNull {
-						nullableIndices = append(nullableIndices, fieldIdx)
+						nullableIndices += strconv.Itoa(fieldIdx) + ","
 					}
 					fieldIdx++
 				}

--- a/internal/codegen/golang/result.go
+++ b/internal/codegen/golang/result.go
@@ -382,6 +382,9 @@ func columnsToStruct(req *plugin.CodeGenRequest, name string, columns []goColumn
 			f.Type = goType(req, c.Column)
 		} else {
 			f.Type = c.embed.modelType
+			if !c.NotNull {
+				f.Type = fmt.Sprintf("*%s", c.embed.modelType)
+			}
 			f.EmbedFields = c.embed.fields
 		}
 

--- a/internal/codegen/golang/templates/pgx/queryCode.tmpl
+++ b/internal/codegen/golang/templates/pgx/queryCode.tmpl
@@ -28,15 +28,50 @@ type {{.Ret.Type}} struct { {{- range .Ret.Struct.Fields}}
 {{end -}}
 {{- if $.EmitMethodsWithDBArgument -}}
 func (q *Queries) {{.MethodName}}(ctx context.Context, db DBTX, {{.Arg.Pair}}) ({{.Ret.DefineType}}, error) {
-	row := db.QueryRow(ctx, {{.ConstantName}}, {{.Arg.Params}})
+	rows, err := db.Query(ctx, {{.ConstantName}}, {{.Arg.Params}})
 {{- else -}}
 func (q *Queries) {{.MethodName}}(ctx context.Context, {{.Arg.Pair}}) ({{.Ret.DefineType}}, error) {
-	row := q.db.QueryRow(ctx, {{.ConstantName}}, {{.Arg.Params}})
+	rows, err := q.db.Query(ctx, {{.ConstantName}}, {{.Arg.Params}})
 {{- end}}
 	{{- if ne .Arg.Pair .Ret.Pair }}
 	var {{.Ret.Name}} {{.Ret.Type}}
 	{{- end}}
-	err := row.Scan({{.Ret.Scan}})
+    if err != nil {
+        return {{.Ret.ReturnName}}, err
+    }
+    {{- .Ret.DeclareNullableEmbeds}}
+    var cols []interface{}
+    cols = append(cols, {{.Ret.Scan}})
+	defer rows.Close()
+    // This effectively duplicates the behaviour of Row.Scan, which we can't use (because it doesn't
+    // provide Values).
+	if !rows.Next() {
+		if rows.Err() == nil {
+			return {{.Ret.ReturnName}}, pgx.ErrNoRows
+		}
+		return {{.Ret.ReturnName}}, rows.Err()
+	}
+    {{if .Ret.NullableIndices -}}
+    vals, verr := rows.Values()
+    if verr != nil {
+        return {{.Ret.ReturnName}}, verr
+    }
+    {{- range $nembed := .Ret.NullableIndices}}
+    if 
+    {{- range $nembed}}
+      vals[{{.}}] == nil &&
+    {{- end -}}
+    true {
+    {{range $nembed}}
+      cols[{{.}}] = nil
+    {{- end}}
+    }
+    {{- end -}}
+    {{- end}}
+    if err := rows.Scan(cols...); err != nil {
+        return {{.Ret.ReturnName}}, err
+    }
+    {{- .Ret.AssignNullableEmbeds}}
 	return {{.Ret.ReturnName}}, err
 }
 {{end}}

--- a/internal/codegen/golang/templates/pgx/queryCode.tmpl
+++ b/internal/codegen/golang/templates/pgx/queryCode.tmpl
@@ -40,8 +40,9 @@ func (q *Queries) {{.MethodName}}(ctx context.Context, {{.Arg.Pair}}) ({{.Ret.De
         return {{.Ret.ReturnName}}, err
     }
     {{- .Ret.DeclareNullableEmbeds}}
-    var cols []interface{}
-    cols = append(cols, {{.Ret.Scan}})
+    cols := []interface{}{
+    {{- .Ret.Scan -}}
+    }
 	defer rows.Close()
     // This effectively duplicates the behaviour of Row.Scan, which we can't use (because it doesn't
     // provide Values).
@@ -56,18 +57,9 @@ func (q *Queries) {{.MethodName}}(ctx context.Context, {{.Arg.Pair}}) ({{.Ret.De
     if verr != nil {
         return {{.Ret.ReturnName}}, verr
     }
-    {{- range $nembed := .Ret.NullableIndices}}
-    if 
-    {{- range $nembed}}
-      vals[{{.}}] == nil &&
-    {{- end -}}
-    true {
-    {{range $nembed}}
-      cols[{{.}}] = nil
-    {{- end}}
-    }
-    {{- end -}}
-    {{- end}}
+    nullableIndices := [][]int{ {{- range .Ret.NullableIndices}}[]int{ {{- . -}}}, {{- end -}} }
+    setEmbedsNil(vals, cols, nullableIndices)
+    {{end -}}
     if err := rows.Scan(cols...); err != nil {
         return {{.Ret.ReturnName}}, err
     }

--- a/internal/codegen/golang/templates/template.tmpl
+++ b/internal/codegen/golang/templates/template.tmpl
@@ -157,6 +157,26 @@ import (
     "github.com/jackc/pgx/v5"
 )
 
+// TODO: naming feels off
+func setEmbedsNil(dbVals []interface{}, fields []interface{}, nullableIndices [][]int) {
+    for _, nembed := range nullableIndices {
+        setNil := true
+        for _, idx := range nembed {
+            // Any non-NULL value in the query result will cause a Scan attempt into the
+            // intermediate struct.
+            if dbVals[idx] != nil {
+                setNil = false
+                break
+            }
+        }
+        if setNil {
+            for _, idx := range nembed {
+                fields[idx] = nil
+            }
+        }
+    }
+}
+
 {{template "queryCode" . }}
 {{end}}
 

--- a/internal/codegen/golang/templates/template.tmpl
+++ b/internal/codegen/golang/templates/template.tmpl
@@ -153,6 +153,8 @@ import (
 	{{range .}}{{.}}
 	{{end}}
 	{{end}}
+    // Obviously, this is temporary
+    "github.com/jackc/pgx/v5"
 )
 
 {{template "queryCode" . }}

--- a/internal/compiler/output_columns.go
+++ b/internal/compiler/output_columns.go
@@ -263,6 +263,7 @@ func (c *Compiler) outputColumns(qc *QueryCatalog, node ast.Node) ([]*Column, er
 					cols = append(cols, &Column{
 						Name:       embed.Table.Name,
 						EmbedTable: embed.Table,
+						NotNull:    !embed.Nullable,
 					})
 					continue
 				}

--- a/internal/sql/validate/func_call.go
+++ b/internal/sql/validate/func_call.go
@@ -31,10 +31,10 @@ func (v *funcCallVisitor) Visit(node ast.Node) astutils.Visitor {
 		return v
 	}
 
-	// Custom validation for sqlc.arg, sqlc.narg and sqlc.slice
+	// Custom validation for `sqlc.` functions.
 	// TODO: Replace this once type-checking is implemented
 	if fn.Schema == "sqlc" {
-		if !(fn.Name == "arg" || fn.Name == "narg" || fn.Name == "slice" || fn.Name == "embed") {
+		if !(fn.Name == "arg" || fn.Name == "narg" || fn.Name == "slice" || fn.Name == "embed" || fn.Name == "nembed") {
 			v.err = sqlerr.FunctionNotFound("sqlc." + fn.Name)
 			return nil
 		}
@@ -57,8 +57,7 @@ func (v *funcCallVisitor) Visit(node ast.Node) astutils.Visitor {
 			return nil
 		}
 
-		// If we have sqlc.arg or sqlc.narg, there is no need to resolve the function call.
-		// It won't resolve anyway, sinc it is not a real function.
+		// Don't attempt to resolve `sqlc.` functions.
 		return nil
 	}
 


### PR DESCRIPTION
This:
- [x] adds `sqlc.nembed`, which declares an embed to be nullable.
- [x] checks returned query values associated with the `nembed`
  - If all are NULL, the struct pointer will be `nil`.
  - If at least one is NOT NULL, a scan into the struct will be attempted.
- [x] prevents scans of non-nullable fields in the case where the RHS of the join is NULL

Obviously, this is very rough, but I'm wondering if I can get a validation of the overall approach? Which is to say, "know where all the nullable embed column indices are, and check to see if they're all going to receive nil values". If so, I'll flesh it out and try to get the non-pgx drivers working... just wanted to check in before I spent more time on it.

I'm not wild about the extra complexity in the generated code and the template, but I'm not sure there's an easier way around it until `<future date>` when sqlc knows a bit more about joins. At least this approach is opt-in, and doesn't care about things like primary keys and what kind of join we're in.

Given the query:
```sql
-- name: GetUserRelationships :one
select sqlc.embed(u), sqlc.embed(b), sqlc.nembed(i) from users u
  left join buckets b on u.bucket_id = b.id
  left join images i on u.avatar_id = i.id
  where u.deleted_at is null
    and u.id = $1
  limit 1;
```

Produces sample output:
```go
const getUserRelationships = `-- name: GetUserRelationships :one
select u.id, u.auth_provider_type, u.auth_provider_identifier, u.avatar_id, u.bucket_id, u.email, u.name, u.created_at, u.updated_at, u.deleted_at, b.id, b.amount, b.created_at, b.updated_at, b.deleted_at, i.id, i.object_key, i.created_at from users u
  left join buckets b on u.bucket_id = b.id
  left join images i on u.avatar_id = i.id
  where u.deleted_at is null
    and u.id = $1
  limit 1
`

type GetUserRelationshipsRow struct {
	User   User   `db:"user" json:"user"`
	Bucket Bucket `db:"bucket" json:"bucket"`
	Image  *Image `db:"image" json:"image"`
}

func (q *Queries) GetUserRelationships(ctx context.Context, id hashid.HashID) (GetUserRelationshipsRow, error) {
	rows, err := q.db.Query(ctx, getUserRelationships, id)
	var i GetUserRelationshipsRow
	if err != nil {
		return i, err
	}
	var nImage Image
	cols := []interface{}{
		&i.User.ID,
		&i.User.AuthProviderType,
		&i.User.AuthProviderIdentifier,
		&i.User.AvatarID,
		&i.User.BucketID,
		&i.User.Email,
		&i.User.Name,
		&i.User.CreatedAt,
		&i.User.UpdatedAt,
		&i.User.DeletedAt,
		&i.Bucket.ID,
		&i.Bucket.Amount,
		&i.Bucket.CreatedAt,
		&i.Bucket.UpdatedAt,
		&i.Bucket.DeletedAt,
		&nImage.ID,
		&nImage.ObjectKey,
		&nImage.CreatedAt,
	}
	defer rows.Close()
	// This effectively duplicates the behaviour of Row.Scan, which we can't use (because it doesn't
	// provide Values).
	if !rows.Next() {
		if rows.Err() == nil {
			return i, pgx.ErrNoRows
		}
		return i, rows.Err()
	}
	vals, verr := rows.Values()
	if verr != nil {
		return i, verr
	}
	nullableIndices := [][]int{[]int{15, 16, 17}}
	setEmbedsNil(vals, cols, nullableIndices)
	if err := rows.Scan(cols...); err != nil {
		return i, err
	}
	i.Image = &nImage
	return i, err
}
```

Fixes #2348 