### PR TITLE
myriad formatting changes

### DIFF
--- a/internal/codegen/golang/field.go
+++ b/internal/codegen/golang/field.go
@@ -34,7 +34,7 @@ func TagsToString(tags map[string]string) string {
 	}
 	tagParts := make([]string, 0, len(tags))
 	for key, val := range tags {
-		tagParts = append(tagParts, fmt.Sprintf("%s:\"%s\"", key, val))
+		tagParts = append(tagParts, fmt.Sprintf("%s:%q", key, val))
 	}
 	sort.Strings(tagParts)
 	return strings.Join(tagParts, " ")

--- a/internal/codegen/golang/imports.go
+++ b/internal/codegen/golang/imports.go
@@ -21,9 +21,9 @@ type ImportSpec struct {
 
 func (s ImportSpec) String() string {
 	if s.ID != "" {
-		return fmt.Sprintf("%s \"%s\"", s.ID, s.Path)
+		return fmt.Sprintf("%s %q", s.ID, s.Path)
 	} else {
-		return fmt.Sprintf("\"%s\"", s.Path)
+		return fmt.Sprintf("%q", s.Path)
 	}
 }
 

--- a/internal/compiler/output_columns.go
+++ b/internal/compiler/output_columns.go
@@ -639,14 +639,14 @@ func outputColumnRefs(res *ast.ResTarget, tables []*Table, node *ast.ColumnRef) 
 	if found == 0 {
 		return nil, &sqlerr.Error{
 			Code:     "42703",
-			Message:  fmt.Sprintf("column \"%s\" does not exist", name),
+			Message:  fmt.Sprintf("column %q does not exist", name),
 			Location: res.Location,
 		}
 	}
 	if found > 1 {
 		return nil, &sqlerr.Error{
 			Code:     "42703",
-			Message:  fmt.Sprintf("column reference \"%s\" is ambiguous", name),
+			Message:  fmt.Sprintf("column reference %q is ambiguous", name),
 			Location: res.Location,
 		}
 	}
@@ -702,14 +702,14 @@ func findColumnForRef(ref *ast.ColumnRef, tables []*Table, targetList *ast.List)
 	if found == 0 {
 		return &sqlerr.Error{
 			Code:     "42703",
-			Message:  fmt.Sprintf("column reference \"%s\" not found", name),
+			Message:  fmt.Sprintf("column reference %q not found", name),
 			Location: ref.Location,
 		}
 	}
 	if found > 1 {
 		return &sqlerr.Error{
 			Code:     "42703",
-			Message:  fmt.Sprintf("column reference \"%s\" is ambiguous", name),
+			Message:  fmt.Sprintf("column reference %q is ambiguous", name),
 			Location: ref.Location,
 		}
 	}

--- a/internal/compiler/resolve.go
+++ b/internal/compiler/resolve.go
@@ -188,7 +188,7 @@ func (comp *Compiler) resolveCatalogRefs(qc *QueryCatalog, rvs []*ast.RangeVar, 
 						if !located {
 							return nil, &sqlerr.Error{
 								Code:     "42703",
-								Message:  fmt.Sprintf("table alias \"%s\" does not exist", alias),
+								Message:  fmt.Sprintf("table alias %q does not exist", alias),
 								Location: node.Location,
 							}
 						}
@@ -231,14 +231,14 @@ func (comp *Compiler) resolveCatalogRefs(qc *QueryCatalog, rvs []*ast.RangeVar, 
 				if found == 0 {
 					return nil, &sqlerr.Error{
 						Code:     "42703",
-						Message:  fmt.Sprintf("column \"%s\" does not exist", key),
+						Message:  fmt.Sprintf("column %q does not exist", key),
 						Location: node.Location,
 					}
 				}
 				if found > 1 {
 					return nil, &sqlerr.Error{
 						Code:     "42703",
-						Message:  fmt.Sprintf("column reference \"%s\" is ambiguous", key),
+						Message:  fmt.Sprintf("column reference %q is ambiguous", key),
 						Location: node.Location,
 					}
 				}
@@ -471,7 +471,7 @@ func (comp *Compiler) resolveCatalogRefs(qc *QueryCatalog, rvs []*ast.RangeVar, 
 			} else {
 				return nil, &sqlerr.Error{
 					Code:     "42703",
-					Message:  fmt.Sprintf("column \"%s\" does not exist", key),
+					Message:  fmt.Sprintf("column %q does not exist", key),
 					Location: n.Location,
 				}
 			}
@@ -587,20 +587,20 @@ func (comp *Compiler) resolveCatalogRefs(qc *QueryCatalog, rvs []*ast.RangeVar, 
 			if found == 0 {
 				return nil, &sqlerr.Error{
 					Code:     "42703",
-					Message:  fmt.Sprintf("396: column \"%s\" does not exist", key),
+					Message:  fmt.Sprintf("396: column %q does not exist", key),
 					Location: location,
 				}
 			}
 			if found > 1 {
 				return nil, &sqlerr.Error{
 					Code:     "42703",
-					Message:  fmt.Sprintf("in same name column reference \"%s\" is ambiguous", key),
+					Message:  fmt.Sprintf("in same name column reference %q is ambiguous", key),
 					Location: location,
 				}
 			}
 
 		default:
-			fmt.Printf("unsupported reference type: %T", n)
+			fmt.Printf("unsupported reference type: %T\n", n)
 		}
 	}
 	return a, nil

--- a/internal/sql/catalog/table.go
+++ b/internal/sql/catalog/table.go
@@ -267,7 +267,7 @@ func (c *Catalog) createTable(stmt *ast.CreateTableStmt) error {
 				seen[col.Name] = notNull || col.IsNotNull
 				if a, ok := coltype[col.Name]; ok {
 					if !sameType(&a, &col.Type) {
-						return fmt.Errorf("column \"%s\" has a type conflict", col.Name)
+						return fmt.Errorf("column %q has a type conflict", col.Name)
 					}
 				}
 				continue
@@ -298,7 +298,7 @@ func (c *Catalog) createTable(stmt *ast.CreateTableStmt) error {
 				seen[col.Colname] = notNull || col.IsNotNull
 				if a, ok := coltype[col.Colname]; ok {
 					if !sameType(&a, col.TypeName) {
-						return fmt.Errorf("column \"%s\" has a type conflict", col.Colname)
+						return fmt.Errorf("column %q has a type conflict", col.Colname)
 					}
 				}
 				continue

--- a/internal/sql/sqlerr/errors.go
+++ b/internal/sql/sqlerr/errors.go
@@ -35,7 +35,7 @@ func ColumnExists(rel, col string) *Error {
 	return &Error{
 		Err:     Exists,
 		Code:    "42701",
-		Message: fmt.Sprintf("column \"%s\" of relation \"%s\"", col, rel),
+		Message: fmt.Sprintf("column %q of relation %q", col, rel),
 	}
 }
 
@@ -43,7 +43,7 @@ func ColumnNotFound(rel, col string) *Error {
 	return &Error{
 		Err:     NotFound,
 		Code:    "42703",
-		Message: fmt.Sprintf("column \"%s\" of relation \"%s\"", col, rel),
+		Message: fmt.Sprintf("column %q of relation %q", col, rel),
 	}
 }
 
@@ -51,7 +51,7 @@ func RelationExists(rel string) *Error {
 	return &Error{
 		Err:     Exists,
 		Code:    "42P07",
-		Message: fmt.Sprintf("relation \"%s\"", rel),
+		Message: fmt.Sprintf("relation %q", rel),
 	}
 }
 
@@ -59,7 +59,7 @@ func RelationNotFound(rel string) *Error {
 	return &Error{
 		Err:     NotFound,
 		Code:    "42P01",
-		Message: fmt.Sprintf("relation \"%s\"", rel),
+		Message: fmt.Sprintf("relation %q", rel),
 	}
 }
 
@@ -67,7 +67,7 @@ func SchemaExists(name string) *Error {
 	return &Error{
 		Err:     Exists,
 		Code:    "42P06",
-		Message: fmt.Sprintf("schema \"%s\"", name),
+		Message: fmt.Sprintf("schema %q", name),
 	}
 }
 
@@ -75,7 +75,7 @@ func SchemaNotFound(sch string) *Error {
 	return &Error{
 		Err:     NotFound,
 		Code:    "3F000",
-		Message: fmt.Sprintf("schema \"%s\"", sch),
+		Message: fmt.Sprintf("schema %q", sch),
 	}
 }
 
@@ -83,7 +83,7 @@ func TypeExists(typ string) *Error {
 	return &Error{
 		Err:     Exists,
 		Code:    "42710",
-		Message: fmt.Sprintf("type \"%s\"", typ),
+		Message: fmt.Sprintf("type %q", typ),
 	}
 }
 
@@ -91,7 +91,7 @@ func TypeNotFound(typ string) *Error {
 	return &Error{
 		Err:     NotFound,
 		Code:    "42704",
-		Message: fmt.Sprintf("type \"%s\"", typ),
+		Message: fmt.Sprintf("type %q", typ),
 	}
 }
 
@@ -99,13 +99,13 @@ func FunctionNotFound(fun string) *Error {
 	return &Error{
 		Err:     NotFound,
 		Code:    "42704",
-		Message: fmt.Sprintf("function \"%s\"", fun),
+		Message: fmt.Sprintf("function %q", fun),
 	}
 }
 
 func FunctionNotUnique(fn string) *Error {
 	return &Error{
 		Err:     NotUnique,
-		Message: fmt.Sprintf("function name \"%s\"", fn),
+		Message: fmt.Sprintf("function name %q", fn),
 	}
 }

--- a/internal/tools/sqlc-pg-gen/main.go
+++ b/internal/tools/sqlc-pg-gen/main.go
@@ -13,7 +13,7 @@ import (
 	"strings"
 	"text/template"
 
-	pgx "github.com/jackc/pgx/v4"
+	"github.com/jackc/pgx/v4"
 )
 
 // https://dba.stackexchange.com/questions/255412/how-to-select-functions-that-belong-in-a-given-extension-in-postgresql
@@ -308,8 +308,7 @@ func run(ctx context.Context) error {
 			funcName += strings.Title(part)
 		}
 
-		_, err := conn.Exec(ctx, fmt.Sprintf("CREATE EXTENSION IF NOT EXISTS \"%s\"", extension))
-		if err != nil {
+		if _, err := conn.Exec(ctx, fmt.Sprintf("CREATE EXTENSION IF NOT EXISTS %q", extension)); err != nil {
 			return fmt.Errorf("error creating %s: %s", extension, err)
 		}
 


### PR DESCRIPTION
Changes:
- while doing some local debugging, I observed a lot of use of `\"%s\"` to quote strings in `Sprintf` calls. Go [formally supports the `%q` formatting directive](https://pkg.go.dev/fmt#hdr-Printing) for double quoting strings, so I replaced those.
- I added a newline to the nil reference callout.