### PR TITLE
fix(ci): bump go version for govulncheck in ci.yml

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
     - uses: actions/checkout@v3
     - uses: actions/setup-go@v4
       with:
-        go-version: '1.20.6'
+        go-version: '1.20.7'
     - run: go build ./...
 
   darwin-build:
@@ -22,7 +22,7 @@ jobs:
     - uses: actions/checkout@v3
     - uses: actions/setup-go@v4
       with:
-        go-version: '1.20.6'
+        go-version: '1.20.7'
     - run: go build ./...
 
   build:
@@ -53,7 +53,7 @@ jobs:
     - uses: actions/checkout@v3
     - uses: actions/setup-go@v4
       with:
-        go-version: '1.20.6'
+        go-version: '1.20.7'
 
     - name: gotestsum
       run: go install gotest.tools/gotestsum@latest
@@ -92,6 +92,6 @@ jobs:
     - uses: actions/checkout@v3
     - uses: actions/setup-go@v4
       with:
-        go-version: '1.20.6'
+        go-version: '1.20.7'
     - run: go install golang.org/x/vuln/cmd/govulncheck@latest
     - run: govulncheck ./...

--- a/.github/workflows/gen.yml
+++ b/.github/workflows/gen.yml
@@ -20,7 +20,7 @@ jobs:
     - uses: actions/checkout@v3
     - uses: actions/setup-go@v4
       with:
-        go-version: '1.20.6'
+        go-version: '1.20.7'
     - run: go build -o sqlc-pg-gen ./internal/tools/sqlc-pg-gen
     - run: mkdir -p gen/contrib
     - run: ./sqlc-pg-gen gen


### PR DESCRIPTION
So this technically "fixes" the issue of our govulncheck CI check failing, but brings up a question: should we really be soft-blocking a merge when this CI check fails? And if not, what's the point of running this check in CI, and should we just run it somewhere else.