### PR TITLE
fix(compiler): Fix to not scan children under ast.RangeSubselect when retrieving table listing

### DIFF
--- a/internal/endtoend/testdata/select_star/mysql/go/query.sql.go
+++ b/internal/endtoend/testdata/select_star/mysql/go/query.sql.go
@@ -40,3 +40,30 @@ func (q *Queries) GetAll(ctx context.Context) ([]User, error) {
 	}
 	return items, nil
 }
+
+const getIDAll = `-- name: GetIDAll :many
+SELECT id FROM (SELECT id FROM users) t
+`
+
+func (q *Queries) GetIDAll(ctx context.Context) ([]int32, error) {
+	rows, err := q.db.QueryContext(ctx, getIDAll)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []int32
+	for rows.Next() {
+		var id int32
+		if err := rows.Scan(&id); err != nil {
+			return nil, err
+		}
+		items = append(items, id)
+	}
+	if err := rows.Close(); err != nil {
+		return nil, err
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}

--- a/internal/endtoend/testdata/select_star/mysql/query.sql
+++ b/internal/endtoend/testdata/select_star/mysql/query.sql
@@ -1,2 +1,5 @@
 /* name: GetAll :many */
 SELECT * FROM users;
+
+/* name: GetIDAll :many */
+SELECT * FROM (SELECT id FROM users) t;

--- a/internal/endtoend/testdata/select_star/postgresql/pgx/v4/go/query.sql.go
+++ b/internal/endtoend/testdata/select_star/postgresql/pgx/v4/go/query.sql.go
@@ -37,3 +37,27 @@ func (q *Queries) GetAll(ctx context.Context) ([]User, error) {
 	}
 	return items, nil
 }
+
+const getIDAll = `-- name: GetIDAll :many
+SELECT id FROM (SELECT id FROM users) t
+`
+
+func (q *Queries) GetIDAll(ctx context.Context) ([]int32, error) {
+	rows, err := q.db.Query(ctx, getIDAll)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []int32
+	for rows.Next() {
+		var id int32
+		if err := rows.Scan(&id); err != nil {
+			return nil, err
+		}
+		items = append(items, id)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}

--- a/internal/endtoend/testdata/select_star/postgresql/pgx/v4/query.sql
+++ b/internal/endtoend/testdata/select_star/postgresql/pgx/v4/query.sql
@@ -1,2 +1,5 @@
 -- name: GetAll :many
 SELECT * FROM users;
+
+/* name: GetIDAll :many */
+SELECT * FROM (SELECT id FROM users) t;

--- a/internal/endtoend/testdata/select_star/postgresql/pgx/v5/go/query.sql.go
+++ b/internal/endtoend/testdata/select_star/postgresql/pgx/v5/go/query.sql.go
@@ -37,3 +37,27 @@ func (q *Queries) GetAll(ctx context.Context) ([]User, error) {
 	}
 	return items, nil
 }
+
+const getIDAll = `-- name: GetIDAll :many
+SELECT id FROM (SELECT id FROM users) t
+`
+
+func (q *Queries) GetIDAll(ctx context.Context) ([]int32, error) {
+	rows, err := q.db.Query(ctx, getIDAll)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []int32
+	for rows.Next() {
+		var id int32
+		if err := rows.Scan(&id); err != nil {
+			return nil, err
+		}
+		items = append(items, id)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}

--- a/internal/endtoend/testdata/select_star/postgresql/pgx/v5/query.sql
+++ b/internal/endtoend/testdata/select_star/postgresql/pgx/v5/query.sql
@@ -1,2 +1,5 @@
 -- name: GetAll :many
 SELECT * FROM users;
+
+/* name: GetIDAll :many */
+SELECT * FROM (SELECT id FROM users) t;

--- a/internal/endtoend/testdata/select_star/postgresql/stdlib/go/query.sql.go
+++ b/internal/endtoend/testdata/select_star/postgresql/stdlib/go/query.sql.go
@@ -40,3 +40,30 @@ func (q *Queries) GetAll(ctx context.Context) ([]User, error) {
 	}
 	return items, nil
 }
+
+const getIDAll = `-- name: GetIDAll :many
+SELECT id FROM (SELECT id FROM users) t
+`
+
+func (q *Queries) GetIDAll(ctx context.Context) ([]int32, error) {
+	rows, err := q.db.QueryContext(ctx, getIDAll)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []int32
+	for rows.Next() {
+		var id int32
+		if err := rows.Scan(&id); err != nil {
+			return nil, err
+		}
+		items = append(items, id)
+	}
+	if err := rows.Close(); err != nil {
+		return nil, err
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}

--- a/internal/endtoend/testdata/select_star/postgresql/stdlib/query.sql
+++ b/internal/endtoend/testdata/select_star/postgresql/stdlib/query.sql
@@ -1,2 +1,5 @@
 -- name: GetAll :many
 SELECT * FROM users;
+
+/* name: GetIDAll :many */
+SELECT * FROM (SELECT id FROM users) t;

--- a/internal/endtoend/testdata/select_star/sqlite/go/query.sql.go
+++ b/internal/endtoend/testdata/select_star/sqlite/go/query.sql.go
@@ -40,3 +40,30 @@ func (q *Queries) GetAll(ctx context.Context) ([]User, error) {
 	}
 	return items, nil
 }
+
+const getIDAll = `-- name: GetIDAll :many
+SELECT id FROM (SELECT id FROM users) t
+`
+
+func (q *Queries) GetIDAll(ctx context.Context) ([]int64, error) {
+	rows, err := q.db.QueryContext(ctx, getIDAll)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []int64
+	for rows.Next() {
+		var id int64
+		if err := rows.Scan(&id); err != nil {
+			return nil, err
+		}
+		items = append(items, id)
+	}
+	if err := rows.Close(); err != nil {
+		return nil, err
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}

--- a/internal/endtoend/testdata/select_star/sqlite/query.sql
+++ b/internal/endtoend/testdata/select_star/sqlite/query.sql
@@ -1,2 +1,5 @@
 -- name: GetAll :many
 SELECT * FROM users;
+
+/* name: GetIDAll :many */
+SELECT * FROM (SELECT id FROM users) t;


### PR DESCRIPTION
close #2569
close #1722

astutils.Search does not stop traversing in the middle, so it returns redundant table nodes under ast.RangeSubselect.
I solved this problem by adding a visitor to ast.RangeSubselect that does not traverse the child nodes of ast.RangeSubselect.