### PR TITLE
Allow flag emitPointersForNull to all drivers

### DIFF
--- a/internal/codegen/golang/postgresql_type.go
+++ b/internal/codegen/golang/postgresql_type.go
@@ -37,7 +37,7 @@ func postgresType(req *plugin.CodeGenRequest, col *plugin.Column) string {
 	columnType := sdk.DataType(col.Type)
 	notNull := col.NotNull || col.IsArray
 	driver := parseDriver(req.Settings.Go.SqlPackage)
-	emitPointersForNull := driver.IsPGX() && req.Settings.Go.EmitPointersForNullTypes
+	emitPointersForNull := req.Settings.Go.EmitPointersForNullTypes
 
 	switch columnType {
 	case "serial", "serial4", "pg_catalog.serial4":

--- a/internal/endtoend/testdata/emit_pointers_for_null_types/stdlib/go/models.go
+++ b/internal/endtoend/testdata/emit_pointers_for_null_types/stdlib/go/models.go
@@ -5,18 +5,17 @@
 package datatype
 
 import (
-	"database/sql"
 	"time"
 
 	"github.com/sqlc-dev/pqtype"
 )
 
 type DtCharacter struct {
-	A sql.NullString
-	B sql.NullString
-	C sql.NullString
-	D sql.NullString
-	E sql.NullString
+	A *string
+	B *string
+	C *string
+	D *string
+	E *string
 }
 
 type DtCharacterNotNull struct {
@@ -28,14 +27,14 @@ type DtCharacterNotNull struct {
 }
 
 type DtDatetime struct {
-	A sql.NullTime
-	B sql.NullTime
-	C sql.NullTime
-	D sql.NullTime
-	E sql.NullTime
-	F sql.NullTime
-	G sql.NullTime
-	H sql.NullTime
+	A *time.Time
+	B *time.Time
+	C *time.Time
+	D *time.Time
+	E *time.Time
+	F *time.Time
+	G *time.Time
+	H *time.Time
 }
 
 type DtDatetimeNotNull struct {
@@ -62,19 +61,19 @@ type DtNetTypesNotNull struct {
 }
 
 type DtNumeric struct {
-	A sql.NullInt16
-	B sql.NullInt32
-	C sql.NullInt64
-	D sql.NullString
-	E sql.NullString
-	F sql.NullFloat64
-	G sql.NullFloat64
-	H sql.NullInt16
-	I sql.NullInt32
-	J sql.NullInt64
-	K sql.NullInt16
-	L sql.NullInt32
-	M sql.NullInt64
+	A *int16
+	B *int32
+	C *int64
+	D *string
+	E *string
+	F *float32
+	G *float64
+	H *int16
+	I *int32
+	J *int64
+	K *int16
+	L *int32
+	M *int64
 }
 
 type DtNumericNotNull struct {


### PR DESCRIPTION
Here is a proposition to fix the issue #2589 simply allow to use pointers for all drivers.
If this is not possible, I'm curious to understand why :)