### PR TITLE
Enable custom handling of prepared queries

### DIFF
--- a/internal/codegen/golang/templates/stdlib/dbCode.tmpl
+++ b/internal/codegen/golang/templates/stdlib/dbCode.tmpl
@@ -16,6 +16,12 @@ func New(db DBTX) *Queries {
 }
 
 {{if .EmitPreparedQueries}}
+type PreparedStmtInterceptor interface {
+	ExecContext(context.Context, *sql.Stmt, *sql.Tx, ...interface{}) (sql.Result, error)
+	QueryContext(context.Context, *sql.Stmt, *sql.Tx, ...interface{}) (*sql.Rows, error)
+	QueryRowContext(context.Context, *sql.Stmt, *sql.Tx, ...interface{}) *sql.Row
+}
+
 func Prepare(ctx context.Context, db DBTX) (*Queries, error) {
 	q := Queries{db: db}
 	var err error
@@ -44,6 +50,8 @@ func (q *Queries) Close() error {
 
 func (q *Queries) exec(ctx context.Context, stmt *sql.Stmt, query string, args ...interface{}) (sql.Result, error) {
 	switch {
+	case q.interceptor != nil:
+		return q.interceptor.ExecContext(ctx, stmt, q.tx, args...)
 	case stmt != nil && q.tx != nil:
 		return q.tx.StmtContext(ctx, stmt).ExecContext(ctx, args...)
 	case stmt != nil:
@@ -55,6 +63,8 @@ func (q *Queries) exec(ctx context.Context, stmt *sql.Stmt, query string, args .
 
 func (q *Queries) query(ctx context.Context, stmt *sql.Stmt, query string, args ...interface{}) (*sql.Rows, error) {
 	switch {
+	case q.interceptor != nil:
+		return q.interceptor.QueryContext(ctx, stmt, q.tx, args...)
 	case stmt != nil && q.tx != nil:
 		return q.tx.StmtContext(ctx, stmt).QueryContext(ctx, args...)
 	case stmt != nil:
@@ -66,6 +76,8 @@ func (q *Queries) query(ctx context.Context, stmt *sql.Stmt, query string, args 
 
 func (q *Queries) queryRow(ctx context.Context, stmt *sql.Stmt, query string, args ...interface{}) (*sql.Row) {
 	switch {
+	case q.interceptor != nil:
+		return q.interceptor.QueryRowContext(ctx, stmt, q.tx, args...)
 	case stmt != nil && q.tx != nil:
 		return q.tx.StmtContext(ctx, stmt).QueryRowContext(ctx, args...)
 	case stmt != nil:
@@ -83,6 +95,7 @@ type Queries struct {
 
     {{- if .EmitPreparedQueries}}
 	tx         *sql.Tx
+	interceptor PreparedStmtInterceptor
 	{{- range .GoQueries}}
 	{{.FieldName}}  *sql.Stmt
 	{{- end}}
@@ -101,5 +114,18 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 		{{- end}}
 	}
 }
+
+{{ if .EmitPreparedQueries}}
+func (q *Queries) WithInterceptor(interceptor PreparedStmtInterceptor, tx *sql.Tx) *Queries {
+	return &Queries{
+		db: tx,
+		tx: tx,
+		interceptor: interceptor,
+		{{- range .GoQueries}}
+		{{.FieldName}}: q.{{.FieldName}},
+		{{- end}}
+	}
+}
+{{- end}}
 {{end}}
 {{end}}

--- a/internal/endtoend/testdata/sqlc_slice_prepared/sqlite/go/db.go
+++ b/internal/endtoend/testdata/sqlc_slice_prepared/sqlite/go/db.go
@@ -21,6 +21,12 @@ func New(db DBTX) *Queries {
 	return &Queries{db: db}
 }
 
+type PreparedStmtInterceptor interface {
+	ExecContext(context.Context, *sql.Stmt, *sql.Tx, ...interface{}) (sql.Result, error)
+	QueryContext(context.Context, *sql.Stmt, *sql.Tx, ...interface{}) (*sql.Rows, error)
+	QueryRowContext(context.Context, *sql.Stmt, *sql.Tx, ...interface{}) *sql.Row
+}
+
 func Prepare(ctx context.Context, db DBTX) (*Queries, error) {
 	q := Queries{db: db}
 	var err error
@@ -42,6 +48,8 @@ func (q *Queries) Close() error {
 
 func (q *Queries) exec(ctx context.Context, stmt *sql.Stmt, query string, args ...interface{}) (sql.Result, error) {
 	switch {
+	case q.interceptor != nil:
+		return q.interceptor.ExecContext(ctx, stmt, q.tx, args...)
 	case stmt != nil && q.tx != nil:
 		return q.tx.StmtContext(ctx, stmt).ExecContext(ctx, args...)
 	case stmt != nil:
@@ -53,6 +61,8 @@ func (q *Queries) exec(ctx context.Context, stmt *sql.Stmt, query string, args .
 
 func (q *Queries) query(ctx context.Context, stmt *sql.Stmt, query string, args ...interface{}) (*sql.Rows, error) {
 	switch {
+	case q.interceptor != nil:
+		return q.interceptor.QueryContext(ctx, stmt, q.tx, args...)
 	case stmt != nil && q.tx != nil:
 		return q.tx.StmtContext(ctx, stmt).QueryContext(ctx, args...)
 	case stmt != nil:
@@ -64,6 +74,8 @@ func (q *Queries) query(ctx context.Context, stmt *sql.Stmt, query string, args 
 
 func (q *Queries) queryRow(ctx context.Context, stmt *sql.Stmt, query string, args ...interface{}) *sql.Row {
 	switch {
+	case q.interceptor != nil:
+		return q.interceptor.QueryRowContext(ctx, stmt, q.tx, args...)
 	case stmt != nil && q.tx != nil:
 		return q.tx.StmtContext(ctx, stmt).QueryRowContext(ctx, args...)
 	case stmt != nil:
@@ -76,6 +88,7 @@ func (q *Queries) queryRow(ctx context.Context, stmt *sql.Stmt, query string, ar
 type Queries struct {
 	db                 DBTX
 	tx                 *sql.Tx
+	interceptor        PreparedStmtInterceptor
 	funcParamIdentStmt *sql.Stmt
 }
 
@@ -83,6 +96,15 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 	return &Queries{
 		db:                 tx,
 		tx:                 tx,
+		funcParamIdentStmt: q.funcParamIdentStmt,
+	}
+}
+
+func (q *Queries) WithInterceptor(interceptor PreparedStmtInterceptor, tx *sql.Tx) *Queries {
+	return &Queries{
+		db:                 tx,
+		tx:                 tx,
+		interceptor:        interceptor,
 		funcParamIdentStmt: q.funcParamIdentStmt,
 	}
 }


### PR DESCRIPTION
Without prepared queries, one can use arbitrary wrappers as a DBTX. For example to measure query timing.

With prepared queries however, only DBTX.PrepareContext() is called, which must return a *sql.Stmt. That is a concrete type and there's no easy way to create one yourself with any overrides.

Even more difficult is when in a transaction, when we call (*sql.Tx).StmtContext() which also must return a *sql.Stmt. *sql.Tx is also a concrete type here that can't be overwritten.

Because a Go interface { StmtContext(ctx, *sql.Stmt) AnotherInterface } wouldn't match *sql.Tx, we can't easily just intercept even that.

So the best way I can think of is allowing a custom interceptor which people can use to do whatever they want in their wrapping.