### PR TITLE
Add `AdditionalQuery` as function parameter for `:one` and `:many` queries

### DIFF
--- a/examples/authors/mysql/db.go
+++ b/examples/authors/mysql/db.go
@@ -29,3 +29,8 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/examples/authors/mysql/db.go
+++ b/examples/authors/mysql/db.go
@@ -32,5 +32,5 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/examples/authors/mysql/query.sql.go
+++ b/examples/authors/mysql/query.sql.go
@@ -24,7 +24,10 @@ type CreateAuthorParams struct {
 }
 
 func (q *Queries) CreateAuthor(ctx context.Context, arg CreateAuthorParams) (sql.Result, error) {
-	return q.db.ExecContext(ctx, createAuthor, arg.Name, arg.Bio)
+	query := createAuthor
+	queryParams := []interface{}{arg.Name, arg.Bio}
+
+	return q.db.ExecContext(ctx, query, queryParams...)
 }
 
 const deleteAuthor = `-- name: DeleteAuthor :exec
@@ -33,7 +36,10 @@ WHERE id = ?
 `
 
 func (q *Queries) DeleteAuthor(ctx context.Context, id int64) error {
-	_, err := q.db.ExecContext(ctx, deleteAuthor, id)
+	query := deleteAuthor
+	queryParams := []interface{}{id}
+
+	_, err := q.db.ExecContext(ctx, query, queryParams...)
 	return err
 }
 
@@ -42,8 +48,16 @@ SELECT id, name, bio FROM authors
 WHERE id = ? LIMIT 1
 `
 
-func (q *Queries) GetAuthor(ctx context.Context, id int64) (Author, error) {
-	row := q.db.QueryRowContext(ctx, getAuthor, id)
+func (q *Queries) GetAuthor(ctx context.Context, id int64, aq ...AdditionalQuery) (Author, error) {
+	query := getAuthor
+	queryParams := []interface{}{id}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	row := q.db.QueryRowContext(ctx, query, queryParams...)
 	var i Author
 	err := row.Scan(&i.ID, &i.Name, &i.Bio)
 	return i, err
@@ -54,8 +68,16 @@ SELECT id, name, bio FROM authors
 ORDER BY name
 `
 
-func (q *Queries) ListAuthors(ctx context.Context) ([]Author, error) {
-	rows, err := q.db.QueryContext(ctx, listAuthors)
+func (q *Queries) ListAuthors(ctx context.Context, aq ...AdditionalQuery) ([]Author, error) {
+	query := listAuthors
+	queryParams := []interface{}{}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.QueryContext(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}

--- a/examples/authors/postgresql/db.go
+++ b/examples/authors/postgresql/db.go
@@ -29,3 +29,8 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/examples/authors/postgresql/db.go
+++ b/examples/authors/postgresql/db.go
@@ -32,5 +32,5 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/examples/authors/sqlite/db.go
+++ b/examples/authors/sqlite/db.go
@@ -29,3 +29,8 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/examples/authors/sqlite/db.go
+++ b/examples/authors/sqlite/db.go
@@ -32,5 +32,5 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/examples/authors/sqlite/query.sql.go
+++ b/examples/authors/sqlite/query.sql.go
@@ -24,7 +24,10 @@ type CreateAuthorParams struct {
 }
 
 func (q *Queries) CreateAuthor(ctx context.Context, arg CreateAuthorParams) (sql.Result, error) {
-	return q.db.ExecContext(ctx, createAuthor, arg.Name, arg.Bio)
+	query := createAuthor
+	queryParams := []interface{}{arg.Name, arg.Bio}
+
+	return q.db.ExecContext(ctx, query, queryParams...)
 }
 
 const deleteAuthor = `-- name: DeleteAuthor :exec
@@ -33,7 +36,10 @@ WHERE id = ?
 `
 
 func (q *Queries) DeleteAuthor(ctx context.Context, id int64) error {
-	_, err := q.db.ExecContext(ctx, deleteAuthor, id)
+	query := deleteAuthor
+	queryParams := []interface{}{id}
+
+	_, err := q.db.ExecContext(ctx, query, queryParams...)
 	return err
 }
 
@@ -42,8 +48,16 @@ SELECT id, name, bio FROM authors
 WHERE id = ? LIMIT 1
 `
 
-func (q *Queries) GetAuthor(ctx context.Context, id int64) (Author, error) {
-	row := q.db.QueryRowContext(ctx, getAuthor, id)
+func (q *Queries) GetAuthor(ctx context.Context, id int64, aq ...AdditionalQuery) (Author, error) {
+	query := getAuthor
+	queryParams := []interface{}{id}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	row := q.db.QueryRowContext(ctx, query, queryParams...)
 	var i Author
 	err := row.Scan(&i.ID, &i.Name, &i.Bio)
 	return i, err
@@ -54,8 +68,16 @@ SELECT id, name, bio FROM authors
 ORDER BY name
 `
 
-func (q *Queries) ListAuthors(ctx context.Context) ([]Author, error) {
-	rows, err := q.db.QueryContext(ctx, listAuthors)
+func (q *Queries) ListAuthors(ctx context.Context, aq ...AdditionalQuery) ([]Author, error) {
+	query := listAuthors
+	queryParams := []interface{}{}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.QueryContext(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}

--- a/examples/batch/postgresql/db.go
+++ b/examples/batch/postgresql/db.go
@@ -31,3 +31,8 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/examples/batch/postgresql/db.go
+++ b/examples/batch/postgresql/db.go
@@ -34,5 +34,5 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/examples/batch/postgresql/querier.go
+++ b/examples/batch/postgresql/querier.go
@@ -12,13 +12,13 @@ import (
 
 type Querier interface {
 	BooksByYear(ctx context.Context, year []int32) *BooksByYearBatchResults
-	CreateAuthor(ctx context.Context, name string) (Author, error)
+	CreateAuthor(ctx context.Context, name string, aq ...AdditionalQuery) (Author, error)
 	CreateBook(ctx context.Context, arg []CreateBookParams) *CreateBookBatchResults
 	DeleteBook(ctx context.Context, bookID []int32) *DeleteBookBatchResults
 	DeleteBookExecResult(ctx context.Context, bookID int32) (pgconn.CommandTag, error)
 	DeleteBookNamedFunc(ctx context.Context, bookID []int32) *DeleteBookNamedFuncBatchResults
 	DeleteBookNamedSign(ctx context.Context, bookID []int32) *DeleteBookNamedSignBatchResults
-	GetAuthor(ctx context.Context, authorID int32) (Author, error)
+	GetAuthor(ctx context.Context, authorID int32, aq ...AdditionalQuery) (Author, error)
 	GetBiography(ctx context.Context, authorID []int32) *GetBiographyBatchResults
 	UpdateBook(ctx context.Context, arg []UpdateBookParams) *UpdateBookBatchResults
 }

--- a/examples/batch/postgresql/query.sql.go
+++ b/examples/batch/postgresql/query.sql.go
@@ -16,8 +16,10 @@ INSERT INTO authors (name) VALUES ($1)
 RETURNING author_id, name, biography
 `
 
-func (q *Queries) CreateAuthor(ctx context.Context, name string) (Author, error) {
-	row := q.db.QueryRow(ctx, createAuthor, name)
+func (q *Queries) CreateAuthor(ctx context.Context, name string, aq ...AdditionalQuery) (Author, error) {
+	query := createAuthor
+	queryParams := []interface{}{name}
+	row := q.db.QueryRow(ctx, query, queryParams...)
 	var i Author
 	err := row.Scan(&i.AuthorID, &i.Name, &i.Biography)
 	return i, err
@@ -37,8 +39,10 @@ SELECT author_id, name, biography FROM authors
 WHERE author_id = $1
 `
 
-func (q *Queries) GetAuthor(ctx context.Context, authorID int32) (Author, error) {
-	row := q.db.QueryRow(ctx, getAuthor, authorID)
+func (q *Queries) GetAuthor(ctx context.Context, authorID int32, aq ...AdditionalQuery) (Author, error) {
+	query := getAuthor
+	queryParams := []interface{}{authorID}
+	row := q.db.QueryRow(ctx, query, queryParams...)
 	var i Author
 	err := row.Scan(&i.AuthorID, &i.Name, &i.Biography)
 	return i, err

--- a/examples/booktest/mysql/db.go
+++ b/examples/booktest/mysql/db.go
@@ -29,3 +29,8 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/examples/booktest/mysql/db.go
+++ b/examples/booktest/mysql/db.go
@@ -32,5 +32,5 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/examples/booktest/postgresql/db.go
+++ b/examples/booktest/postgresql/db.go
@@ -29,3 +29,8 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/examples/booktest/postgresql/db.go
+++ b/examples/booktest/postgresql/db.go
@@ -32,5 +32,5 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/examples/booktest/sqlite/db.go
+++ b/examples/booktest/sqlite/db.go
@@ -29,3 +29,8 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/examples/booktest/sqlite/db.go
+++ b/examples/booktest/sqlite/db.go
@@ -32,5 +32,5 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/examples/booktest/sqlite/query.sql.go
+++ b/examples/booktest/sqlite/query.sql.go
@@ -31,7 +31,7 @@ type BooksByTagsRow struct {
 	Tag    string
 }
 
-func (q *Queries) BooksByTags(ctx context.Context, tags []string) ([]BooksByTagsRow, error) {
+func (q *Queries) BooksByTags(ctx context.Context, tags []string, aq ...AdditionalQuery) ([]BooksByTagsRow, error) {
 	query := booksByTags
 	var queryParams []interface{}
 	if len(tags) > 0 {
@@ -42,6 +42,12 @@ func (q *Queries) BooksByTags(ctx context.Context, tags []string) ([]BooksByTags
 	} else {
 		query = strings.Replace(query, "/*SLICE:tags*/?", "NULL", 1)
 	}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
 	rows, err := q.db.QueryContext(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
@@ -80,8 +86,16 @@ type BooksByTitleYearParams struct {
 	Yr    int64
 }
 
-func (q *Queries) BooksByTitleYear(ctx context.Context, arg BooksByTitleYearParams) ([]Book, error) {
-	rows, err := q.db.QueryContext(ctx, booksByTitleYear, arg.Title, arg.Yr)
+func (q *Queries) BooksByTitleYear(ctx context.Context, arg BooksByTitleYearParams, aq ...AdditionalQuery) ([]Book, error) {
+	query := booksByTitleYear
+	queryParams := []interface{}{arg.Title, arg.Yr}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.QueryContext(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}
@@ -117,8 +131,16 @@ INSERT INTO authors (name) VALUES (?)
 RETURNING author_id, name
 `
 
-func (q *Queries) CreateAuthor(ctx context.Context, name string) (Author, error) {
-	row := q.db.QueryRowContext(ctx, createAuthor, name)
+func (q *Queries) CreateAuthor(ctx context.Context, name string, aq ...AdditionalQuery) (Author, error) {
+	query := createAuthor
+	queryParams := []interface{}{name}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	row := q.db.QueryRowContext(ctx, query, queryParams...)
 	var i Author
 	err := row.Scan(&i.AuthorID, &i.Name)
 	return i, err
@@ -155,8 +177,9 @@ type CreateBookParams struct {
 	Tag       string
 }
 
-func (q *Queries) CreateBook(ctx context.Context, arg CreateBookParams) (Book, error) {
-	row := q.db.QueryRowContext(ctx, createBook,
+func (q *Queries) CreateBook(ctx context.Context, arg CreateBookParams, aq ...AdditionalQuery) (Book, error) {
+	query := createBook
+	queryParams := []interface{}{
 		arg.AuthorID,
 		arg.Isbn,
 		arg.BookType,
@@ -164,7 +187,14 @@ func (q *Queries) CreateBook(ctx context.Context, arg CreateBookParams) (Book, e
 		arg.Yr,
 		arg.Available,
 		arg.Tag,
-	)
+	}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	row := q.db.QueryRowContext(ctx, query, queryParams...)
 	var i Book
 	err := row.Scan(
 		&i.BookID,
@@ -190,7 +220,10 @@ type DeleteAuthorBeforeYearParams struct {
 }
 
 func (q *Queries) DeleteAuthorBeforeYear(ctx context.Context, arg DeleteAuthorBeforeYearParams) error {
-	_, err := q.db.ExecContext(ctx, deleteAuthorBeforeYear, arg.Yr, arg.AuthorID)
+	query := deleteAuthorBeforeYear
+	queryParams := []interface{}{arg.Yr, arg.AuthorID}
+
+	_, err := q.db.ExecContext(ctx, query, queryParams...)
 	return err
 }
 
@@ -200,7 +233,10 @@ WHERE book_id = ?
 `
 
 func (q *Queries) DeleteBook(ctx context.Context, bookID int64) error {
-	_, err := q.db.ExecContext(ctx, deleteBook, bookID)
+	query := deleteBook
+	queryParams := []interface{}{bookID}
+
+	_, err := q.db.ExecContext(ctx, query, queryParams...)
 	return err
 }
 
@@ -209,8 +245,16 @@ SELECT author_id, name FROM authors
 WHERE author_id = ?
 `
 
-func (q *Queries) GetAuthor(ctx context.Context, authorID int64) (Author, error) {
-	row := q.db.QueryRowContext(ctx, getAuthor, authorID)
+func (q *Queries) GetAuthor(ctx context.Context, authorID int64, aq ...AdditionalQuery) (Author, error) {
+	query := getAuthor
+	queryParams := []interface{}{authorID}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	row := q.db.QueryRowContext(ctx, query, queryParams...)
 	var i Author
 	err := row.Scan(&i.AuthorID, &i.Name)
 	return i, err
@@ -221,8 +265,16 @@ SELECT book_id, author_id, isbn, book_type, title, yr, available, tag FROM books
 WHERE book_id = ?
 `
 
-func (q *Queries) GetBook(ctx context.Context, bookID int64) (Book, error) {
-	row := q.db.QueryRowContext(ctx, getBook, bookID)
+func (q *Queries) GetBook(ctx context.Context, bookID int64, aq ...AdditionalQuery) (Book, error) {
+	query := getBook
+	queryParams := []interface{}{bookID}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	row := q.db.QueryRowContext(ctx, query, queryParams...)
 	var i Book
 	err := row.Scan(
 		&i.BookID,
@@ -250,7 +302,10 @@ type UpdateBookParams struct {
 }
 
 func (q *Queries) UpdateBook(ctx context.Context, arg UpdateBookParams) error {
-	_, err := q.db.ExecContext(ctx, updateBook, arg.Title, arg.Tag, arg.BookID)
+	query := updateBook
+	queryParams := []interface{}{arg.Title, arg.Tag, arg.BookID}
+
+	_, err := q.db.ExecContext(ctx, query, queryParams...)
 	return err
 }
 
@@ -268,11 +323,14 @@ type UpdateBookISBNParams struct {
 }
 
 func (q *Queries) UpdateBookISBN(ctx context.Context, arg UpdateBookISBNParams) error {
-	_, err := q.db.ExecContext(ctx, updateBookISBN,
+	query := updateBookISBN
+	queryParams := []interface{}{
 		arg.Title,
 		arg.Tag,
 		arg.BookID,
 		arg.Isbn,
-	)
+	}
+
+	_, err := q.db.ExecContext(ctx, query, queryParams...)
 	return err
 }

--- a/examples/jets/postgresql/db.go
+++ b/examples/jets/postgresql/db.go
@@ -29,3 +29,8 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/examples/jets/postgresql/db.go
+++ b/examples/jets/postgresql/db.go
@@ -32,5 +32,5 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/examples/jets/postgresql/query-building.sql.go
+++ b/examples/jets/postgresql/query-building.sql.go
@@ -13,8 +13,16 @@ const countPilots = `-- name: CountPilots :one
 SELECT COUNT(*) FROM pilots
 `
 
-func (q *Queries) CountPilots(ctx context.Context) (int64, error) {
-	row := q.db.QueryRowContext(ctx, countPilots)
+func (q *Queries) CountPilots(ctx context.Context, aq ...AdditionalQuery) (int64, error) {
+	query := countPilots
+	queryParams := []interface{}{}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	row := q.db.QueryRowContext(ctx, query, queryParams...)
 	var count int64
 	err := row.Scan(&count)
 	return count, err
@@ -25,7 +33,10 @@ DELETE FROM pilots WHERE id = $1
 `
 
 func (q *Queries) DeletePilot(ctx context.Context, id int32) error {
-	_, err := q.db.ExecContext(ctx, deletePilot, id)
+	query := deletePilot
+	queryParams := []interface{}{id}
+
+	_, err := q.db.ExecContext(ctx, query, queryParams...)
 	return err
 }
 
@@ -33,8 +44,16 @@ const listPilots = `-- name: ListPilots :many
 SELECT id, name FROM pilots LIMIT 5
 `
 
-func (q *Queries) ListPilots(ctx context.Context) ([]Pilot, error) {
-	rows, err := q.db.QueryContext(ctx, listPilots)
+func (q *Queries) ListPilots(ctx context.Context, aq ...AdditionalQuery) ([]Pilot, error) {
+	query := listPilots
+	queryParams := []interface{}{}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.QueryContext(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}

--- a/examples/ondeck/mysql/city.sql.go
+++ b/examples/ondeck/mysql/city.sql.go
@@ -25,7 +25,10 @@ type CreateCityParams struct {
 }
 
 func (q *Queries) CreateCity(ctx context.Context, arg CreateCityParams) error {
-	_, err := q.exec(ctx, q.createCityStmt, createCity, arg.Name, arg.Slug)
+	query := createCity
+	queryParams := []interface{}{arg.Name, arg.Slug}
+
+	_, err := q.exec(ctx, q.createCityStmt, query, queryParams...)
 	return err
 }
 
@@ -35,8 +38,16 @@ FROM city
 WHERE slug = ?
 `
 
-func (q *Queries) GetCity(ctx context.Context, slug string) (City, error) {
-	row := q.queryRow(ctx, q.getCityStmt, getCity, slug)
+func (q *Queries) GetCity(ctx context.Context, slug string, aq ...AdditionalQuery) (City, error) {
+	query := getCity
+	queryParams := []interface{}{slug}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	row := q.queryRow(ctx, q.getCityStmt, query, queryParams...)
 	var i City
 	err := row.Scan(&i.Slug, &i.Name)
 	return i, err
@@ -48,8 +59,16 @@ FROM city
 ORDER BY name
 `
 
-func (q *Queries) ListCities(ctx context.Context) ([]City, error) {
-	rows, err := q.query(ctx, q.listCitiesStmt, listCities)
+func (q *Queries) ListCities(ctx context.Context, aq ...AdditionalQuery) ([]City, error) {
+	query := listCities
+	queryParams := []interface{}{}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.query(ctx, q.listCitiesStmt, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}
@@ -83,6 +102,9 @@ type UpdateCityNameParams struct {
 }
 
 func (q *Queries) UpdateCityName(ctx context.Context, arg UpdateCityNameParams) error {
-	_, err := q.exec(ctx, q.updateCityNameStmt, updateCityName, arg.Name, arg.Slug)
+	query := updateCityName
+	queryParams := []interface{}{arg.Name, arg.Slug}
+
+	_, err := q.exec(ctx, q.updateCityNameStmt, query, queryParams...)
 	return err
 }

--- a/examples/ondeck/mysql/db.go
+++ b/examples/ondeck/mysql/db.go
@@ -179,5 +179,5 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/examples/ondeck/mysql/db.go
+++ b/examples/ondeck/mysql/db.go
@@ -176,3 +176,8 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 		venueCountByCityStmt: q.venueCountByCityStmt,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/examples/ondeck/mysql/querier.go
+++ b/examples/ondeck/mysql/querier.go
@@ -13,13 +13,13 @@ type Querier interface {
 	CreateCity(ctx context.Context, arg CreateCityParams) error
 	CreateVenue(ctx context.Context, arg CreateVenueParams) (sql.Result, error)
 	DeleteVenue(ctx context.Context, arg DeleteVenueParams) error
-	GetCity(ctx context.Context, slug string) (City, error)
-	GetVenue(ctx context.Context, arg GetVenueParams) (Venue, error)
-	ListCities(ctx context.Context) ([]City, error)
-	ListVenues(ctx context.Context, city string) ([]Venue, error)
+	GetCity(ctx context.Context, slug string, aq ...AdditionalQuery) (City, error)
+	GetVenue(ctx context.Context, arg GetVenueParams, aq ...AdditionalQuery) (Venue, error)
+	ListCities(ctx context.Context, aq ...AdditionalQuery) ([]City, error)
+	ListVenues(ctx context.Context, city string, aq ...AdditionalQuery) ([]Venue, error)
 	UpdateCityName(ctx context.Context, arg UpdateCityNameParams) error
 	UpdateVenueName(ctx context.Context, arg UpdateVenueNameParams) error
-	VenueCountByCity(ctx context.Context) ([]VenueCountByCityRow, error)
+	VenueCountByCity(ctx context.Context, aq ...AdditionalQuery) ([]VenueCountByCityRow, error)
 }
 
 var _ Querier = (*Queries)(nil)

--- a/examples/ondeck/postgresql/db.go
+++ b/examples/ondeck/postgresql/db.go
@@ -179,5 +179,5 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/examples/ondeck/postgresql/db.go
+++ b/examples/ondeck/postgresql/db.go
@@ -176,3 +176,8 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 		venueCountByCityStmt: q.venueCountByCityStmt,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/examples/ondeck/postgresql/querier.go
+++ b/examples/ondeck/postgresql/querier.go
@@ -12,16 +12,16 @@ type Querier interface {
 	// Create a new city. The slug must be unique.
 	// This is the second line of the comment
 	// This is the third line
-	CreateCity(ctx context.Context, arg CreateCityParams) (City, error)
-	CreateVenue(ctx context.Context, arg CreateVenueParams) (int32, error)
+	CreateCity(ctx context.Context, arg CreateCityParams, aq ...AdditionalQuery) (City, error)
+	CreateVenue(ctx context.Context, arg CreateVenueParams, aq ...AdditionalQuery) (int32, error)
 	DeleteVenue(ctx context.Context, slug string) error
-	GetCity(ctx context.Context, slug string) (City, error)
-	GetVenue(ctx context.Context, arg GetVenueParams) (Venue, error)
-	ListCities(ctx context.Context) ([]City, error)
-	ListVenues(ctx context.Context, city string) ([]Venue, error)
+	GetCity(ctx context.Context, slug string, aq ...AdditionalQuery) (City, error)
+	GetVenue(ctx context.Context, arg GetVenueParams, aq ...AdditionalQuery) (Venue, error)
+	ListCities(ctx context.Context, aq ...AdditionalQuery) ([]City, error)
+	ListVenues(ctx context.Context, city string, aq ...AdditionalQuery) ([]Venue, error)
 	UpdateCityName(ctx context.Context, arg UpdateCityNameParams) error
-	UpdateVenueName(ctx context.Context, arg UpdateVenueNameParams) (int32, error)
-	VenueCountByCity(ctx context.Context) ([]VenueCountByCityRow, error)
+	UpdateVenueName(ctx context.Context, arg UpdateVenueNameParams, aq ...AdditionalQuery) (int32, error)
+	VenueCountByCity(ctx context.Context, aq ...AdditionalQuery) ([]VenueCountByCityRow, error)
 }
 
 var _ Querier = (*Queries)(nil)

--- a/examples/ondeck/postgresql/venue.sql.go
+++ b/examples/ondeck/postgresql/venue.sql.go
@@ -43,8 +43,9 @@ type CreateVenueParams struct {
 	Tags            []string `json:"tags"`
 }
 
-func (q *Queries) CreateVenue(ctx context.Context, arg CreateVenueParams) (int32, error) {
-	row := q.queryRow(ctx, q.createVenueStmt, createVenue,
+func (q *Queries) CreateVenue(ctx context.Context, arg CreateVenueParams, aq ...AdditionalQuery) (int32, error) {
+	query := createVenue
+	queryParams := []interface{}{
 		arg.Slug,
 		arg.Name,
 		arg.City,
@@ -52,7 +53,14 @@ func (q *Queries) CreateVenue(ctx context.Context, arg CreateVenueParams) (int32
 		arg.Status,
 		pq.Array(arg.Statuses),
 		pq.Array(arg.Tags),
-	)
+	}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	row := q.queryRow(ctx, q.createVenueStmt, query, queryParams...)
 	var id int32
 	err := row.Scan(&id)
 	return id, err
@@ -64,7 +72,10 @@ WHERE slug = $1 AND slug = $1
 `
 
 func (q *Queries) DeleteVenue(ctx context.Context, slug string) error {
-	_, err := q.exec(ctx, q.deleteVenueStmt, deleteVenue, slug)
+	query := deleteVenue
+	queryParams := []interface{}{slug}
+
+	_, err := q.exec(ctx, q.deleteVenueStmt, query, queryParams...)
 	return err
 }
 
@@ -79,8 +90,16 @@ type GetVenueParams struct {
 	City string `json:"city"`
 }
 
-func (q *Queries) GetVenue(ctx context.Context, arg GetVenueParams) (Venue, error) {
-	row := q.queryRow(ctx, q.getVenueStmt, getVenue, arg.Slug, arg.City)
+func (q *Queries) GetVenue(ctx context.Context, arg GetVenueParams, aq ...AdditionalQuery) (Venue, error) {
+	query := getVenue
+	queryParams := []interface{}{arg.Slug, arg.City}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	row := q.queryRow(ctx, q.getVenueStmt, query, queryParams...)
 	var i Venue
 	err := row.Scan(
 		&i.ID,
@@ -104,8 +123,16 @@ WHERE city = $1
 ORDER BY name
 `
 
-func (q *Queries) ListVenues(ctx context.Context, city string) ([]Venue, error) {
-	rows, err := q.query(ctx, q.listVenuesStmt, listVenues, city)
+func (q *Queries) ListVenues(ctx context.Context, city string, aq ...AdditionalQuery) ([]Venue, error) {
+	query := listVenues
+	queryParams := []interface{}{city}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.query(ctx, q.listVenuesStmt, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}
@@ -150,8 +177,16 @@ type UpdateVenueNameParams struct {
 	Name string `json:"name"`
 }
 
-func (q *Queries) UpdateVenueName(ctx context.Context, arg UpdateVenueNameParams) (int32, error) {
-	row := q.queryRow(ctx, q.updateVenueNameStmt, updateVenueName, arg.Slug, arg.Name)
+func (q *Queries) UpdateVenueName(ctx context.Context, arg UpdateVenueNameParams, aq ...AdditionalQuery) (int32, error) {
+	query := updateVenueName
+	queryParams := []interface{}{arg.Slug, arg.Name}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	row := q.queryRow(ctx, q.updateVenueNameStmt, query, queryParams...)
 	var id int32
 	err := row.Scan(&id)
 	return id, err
@@ -171,8 +206,16 @@ type VenueCountByCityRow struct {
 	Count int64  `json:"count"`
 }
 
-func (q *Queries) VenueCountByCity(ctx context.Context) ([]VenueCountByCityRow, error) {
-	rows, err := q.query(ctx, q.venueCountByCityStmt, venueCountByCity)
+func (q *Queries) VenueCountByCity(ctx context.Context, aq ...AdditionalQuery) ([]VenueCountByCityRow, error) {
+	query := venueCountByCity
+	queryParams := []interface{}{}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.query(ctx, q.venueCountByCityStmt, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}

--- a/examples/ondeck/sqlite/city.sql.go
+++ b/examples/ondeck/sqlite/city.sql.go
@@ -25,7 +25,10 @@ type CreateCityParams struct {
 }
 
 func (q *Queries) CreateCity(ctx context.Context, arg CreateCityParams) error {
-	_, err := q.exec(ctx, q.createCityStmt, createCity, arg.Name, arg.Slug)
+	query := createCity
+	queryParams := []interface{}{arg.Name, arg.Slug}
+
+	_, err := q.exec(ctx, q.createCityStmt, query, queryParams...)
 	return err
 }
 
@@ -35,8 +38,16 @@ FROM city
 WHERE slug = ?
 `
 
-func (q *Queries) GetCity(ctx context.Context, slug string) (City, error) {
-	row := q.queryRow(ctx, q.getCityStmt, getCity, slug)
+func (q *Queries) GetCity(ctx context.Context, slug string, aq ...AdditionalQuery) (City, error) {
+	query := getCity
+	queryParams := []interface{}{slug}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	row := q.queryRow(ctx, q.getCityStmt, query, queryParams...)
 	var i City
 	err := row.Scan(&i.Slug, &i.Name)
 	return i, err
@@ -48,8 +59,16 @@ FROM city
 ORDER BY name
 `
 
-func (q *Queries) ListCities(ctx context.Context) ([]City, error) {
-	rows, err := q.query(ctx, q.listCitiesStmt, listCities)
+func (q *Queries) ListCities(ctx context.Context, aq ...AdditionalQuery) ([]City, error) {
+	query := listCities
+	queryParams := []interface{}{}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.query(ctx, q.listCitiesStmt, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}
@@ -83,6 +102,9 @@ type UpdateCityNameParams struct {
 }
 
 func (q *Queries) UpdateCityName(ctx context.Context, arg UpdateCityNameParams) error {
-	_, err := q.exec(ctx, q.updateCityNameStmt, updateCityName, arg.Name, arg.Slug)
+	query := updateCityName
+	queryParams := []interface{}{arg.Name, arg.Slug}
+
+	_, err := q.exec(ctx, q.updateCityNameStmt, query, queryParams...)
 	return err
 }

--- a/examples/ondeck/sqlite/db.go
+++ b/examples/ondeck/sqlite/db.go
@@ -179,5 +179,5 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/examples/ondeck/sqlite/db.go
+++ b/examples/ondeck/sqlite/db.go
@@ -176,3 +176,8 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 		venueCountByCityStmt: q.venueCountByCityStmt,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/examples/ondeck/sqlite/querier.go
+++ b/examples/ondeck/sqlite/querier.go
@@ -13,13 +13,13 @@ type Querier interface {
 	CreateCity(ctx context.Context, arg CreateCityParams) error
 	CreateVenue(ctx context.Context, arg CreateVenueParams) (sql.Result, error)
 	DeleteVenue(ctx context.Context, arg DeleteVenueParams) error
-	GetCity(ctx context.Context, slug string) (City, error)
-	GetVenue(ctx context.Context, arg GetVenueParams) (Venue, error)
-	ListCities(ctx context.Context) ([]City, error)
-	ListVenues(ctx context.Context, city string) ([]Venue, error)
+	GetCity(ctx context.Context, slug string, aq ...AdditionalQuery) (City, error)
+	GetVenue(ctx context.Context, arg GetVenueParams, aq ...AdditionalQuery) (Venue, error)
+	ListCities(ctx context.Context, aq ...AdditionalQuery) ([]City, error)
+	ListVenues(ctx context.Context, city string, aq ...AdditionalQuery) ([]Venue, error)
 	UpdateCityName(ctx context.Context, arg UpdateCityNameParams) error
 	UpdateVenueName(ctx context.Context, arg UpdateVenueNameParams) error
-	VenueCountByCity(ctx context.Context) ([]VenueCountByCityRow, error)
+	VenueCountByCity(ctx context.Context, aq ...AdditionalQuery) ([]VenueCountByCityRow, error)
 }
 
 var _ Querier = (*Queries)(nil)

--- a/internal/codegen/golang/templates/pgx/dbCode.tmpl
+++ b/internal/codegen/golang/templates/pgx/dbCode.tmpl
@@ -37,7 +37,7 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }
 
 {{end}}

--- a/internal/codegen/golang/templates/pgx/dbCode.tmpl
+++ b/internal/codegen/golang/templates/pgx/dbCode.tmpl
@@ -34,4 +34,10 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 	}
 }
 {{end}}
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}
+
 {{end}}

--- a/internal/codegen/golang/templates/pgx/interfaceCode.tmpl
+++ b/internal/codegen/golang/templates/pgx/interfaceCode.tmpl
@@ -5,20 +5,20 @@
         {{- if and (eq .Cmd ":one") ($dbtxParam) }}
             {{range .Comments}}//{{.}}
             {{end -}}
-            {{.MethodName}}(ctx context.Context, db DBTX, {{.Arg.Pair}}) ({{.Ret.DefineType}}, error)
+            {{.MethodName}}(ctx context.Context, db DBTX, {{.Arg.Pair}} {{- if ne .Arg.Pair ""}}, {{end -}} aq ...AdditionalQuery) ({{.Ret.DefineType}}, error)
         {{- else if eq .Cmd ":one" }}
             {{range .Comments}}//{{.}}
             {{end -}}
-            {{.MethodName}}(ctx context.Context, {{.Arg.Pair}}) ({{.Ret.DefineType}}, error)
+            {{.MethodName}}(ctx context.Context, {{.Arg.Pair}} {{- if ne .Arg.Pair ""}}, {{end -}} aq ...AdditionalQuery) ({{.Ret.DefineType}}, error)
         {{- end}}
         {{- if and (eq .Cmd ":many") ($dbtxParam) }}
             {{range .Comments}}//{{.}}
             {{end -}}
-            {{.MethodName}}(ctx context.Context, db DBTX, {{.Arg.Pair}}) ([]{{.Ret.DefineType}}, error)
+            {{.MethodName}}(ctx context.Context, db DBTX, {{.Arg.Pair}} {{- if ne .Arg.Pair ""}}, {{end -}} aq ...AdditionalQuery) ([]{{.Ret.DefineType}}, error)
         {{- else if eq .Cmd ":many" }}
             {{range .Comments}}//{{.}}
             {{end -}}
-            {{.MethodName}}(ctx context.Context, {{.Arg.Pair}}) ([]{{.Ret.DefineType}}, error)
+            {{.MethodName}}(ctx context.Context, {{.Arg.Pair}} {{- if ne .Arg.Pair ""}}, {{end -}} aq ...AdditionalQuery) ([]{{.Ret.DefineType}}, error)
         {{- end}}
         {{- if and (eq .Cmd ":exec") ($dbtxParam) }}
             {{range .Comments}}//{{.}}

--- a/internal/codegen/golang/templates/pgx/queryCode.tmpl
+++ b/internal/codegen/golang/templates/pgx/queryCode.tmpl
@@ -27,11 +27,22 @@ type {{.Ret.Type}} struct { {{- range .Ret.Struct.Fields}}
 {{range .Comments}}//{{.}}
 {{end -}}
 {{- if $.EmitMethodsWithDBArgument -}}
-func (q *Queries) {{.MethodName}}(ctx context.Context, db DBTX, {{.Arg.Pair}}) ({{.Ret.DefineType}}, error) {
-	row := db.QueryRow(ctx, {{.ConstantName}}, {{.Arg.Params}})
+func (q *Queries) {{.MethodName}}(ctx context.Context, db DBTX, {{.Arg.Pair}} {{- if ne .Arg.Pair ""}}, {{end -}} aq ...AdditionalQuery) ({{.Ret.DefineType}}, error) {
 {{- else -}}
-func (q *Queries) {{.MethodName}}(ctx context.Context, {{.Arg.Pair}}) ({{.Ret.DefineType}}, error) {
-	row := q.db.QueryRow(ctx, {{.ConstantName}}, {{.Arg.Params}})
+func (q *Queries) {{.MethodName}}(ctx context.Context, {{.Arg.Pair}} {{- if ne .Arg.Pair ""}}, {{end -}} aq ...AdditionalQuery) ({{.Ret.DefineType}}, error) {
+{{- end -}}
+    query := {{.ConstantName}}
+	queryParams := []interface{}{ {{.Arg.Params}} }
+	{{ if eq .Cmd ":many" }}
+		if len(aq) > 0 {
+			query += " " + aq[0].SQL
+			queryParams = append(queryParams, aq[0].Args...)
+		}
+	{{ end }}
+{{- if $.EmitMethodsWithDBArgument -}}
+	row := db.QueryRow(ctx, query, queryParams...)
+{{- else -}}
+	row := q.db.QueryRow(ctx, query, queryParams...)
 {{- end}}
 	{{- if ne .Arg.Pair .Ret.Pair }}
 	var {{.Ret.Name}} {{.Ret.Type}}
@@ -45,11 +56,22 @@ func (q *Queries) {{.MethodName}}(ctx context.Context, {{.Arg.Pair}}) ({{.Ret.De
 {{range .Comments}}//{{.}}
 {{end -}}
 {{- if $.EmitMethodsWithDBArgument -}}
-func (q *Queries) {{.MethodName}}(ctx context.Context, db DBTX, {{.Arg.Pair}}) ([]{{.Ret.DefineType}}, error) {
-	rows, err := db.Query(ctx, {{.ConstantName}}, {{.Arg.Params}})
+func (q *Queries) {{.MethodName}}(ctx context.Context, db DBTX, {{.Arg.Pair}} {{- if ne .Arg.Pair ""}}, {{end -}} aq ...AdditionalQuery) ([]{{.Ret.DefineType}}, error) {
 {{- else -}}
-func (q *Queries) {{.MethodName}}(ctx context.Context, {{.Arg.Pair}}) ([]{{.Ret.DefineType}}, error) {
-	rows, err := q.db.Query(ctx, {{.ConstantName}}, {{.Arg.Params}})
+func (q *Queries) {{.MethodName}}(ctx context.Context, {{.Arg.Pair}} {{- if ne .Arg.Pair ""}}, {{end -}} aq ...AdditionalQuery) ([]{{.Ret.DefineType}}, error) {
+{{- end -}}
+    query := {{.ConstantName}}
+	queryParams := []interface{}{ {{.Arg.Params}} }
+	{{ if eq .Cmd ":many" }}
+		if len(aq) > 0 {
+			query += " " + aq[0].SQL
+			queryParams = append(queryParams, aq[0].Args...)
+		}
+	{{ end }}
+{{ if $.EmitMethodsWithDBArgument -}}
+	rows, err := db.Query(ctx, query, queryParams...)
+{{- else -}}
+	rows, err := q.db.Query(ctx, query, queryParams...)
 {{- end}}
 	if err != nil {
 		return nil, err

--- a/internal/codegen/golang/templates/stdlib/dbCode.tmpl
+++ b/internal/codegen/golang/templates/stdlib/dbCode.tmpl
@@ -102,4 +102,10 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 	}
 }
 {{end}}
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}
+
 {{end}}

--- a/internal/codegen/golang/templates/stdlib/dbCode.tmpl
+++ b/internal/codegen/golang/templates/stdlib/dbCode.tmpl
@@ -105,7 +105,7 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }
 
 {{end}}

--- a/internal/codegen/golang/templates/stdlib/interfaceCode.tmpl
+++ b/internal/codegen/golang/templates/stdlib/interfaceCode.tmpl
@@ -5,20 +5,20 @@
         {{- if and (eq .Cmd ":one") ($dbtxParam) }}
             {{range .Comments}}//{{.}}
             {{end -}}
-            {{.MethodName}}(ctx context.Context, db DBTX, {{.Arg.Pair}}) ({{.Ret.DefineType}}, error)
+            {{.MethodName}}(ctx context.Context, db DBTX, {{.Arg.Pair}} {{- if ne .Arg.Pair ""}}, {{end -}} aq ...AdditionalQuery) ({{.Ret.DefineType}}, error)
         {{- else if eq .Cmd ":one"}}
             {{range .Comments}}//{{.}}
             {{end -}}
-            {{.MethodName}}(ctx context.Context, {{.Arg.Pair}}) ({{.Ret.DefineType}}, error)
+            {{.MethodName}}(ctx context.Context, {{.Arg.Pair}} {{- if ne .Arg.Pair ""}}, {{end -}} aq ...AdditionalQuery) ({{.Ret.DefineType}}, error)
         {{- end}}
         {{- if and (eq .Cmd ":many") ($dbtxParam) }}
             {{range .Comments}}//{{.}}
             {{end -}}
-            {{.MethodName}}(ctx context.Context, db DBTX, {{.Arg.Pair}}) ([]{{.Ret.DefineType}}, error)
+            {{.MethodName}}(ctx context.Context, db DBTX, {{.Arg.Pair}} {{- if ne .Arg.Pair ""}}, {{end -}} aq ...AdditionalQuery) ([]{{.Ret.DefineType}}, error)
         {{- else if eq .Cmd ":many"}}
             {{range .Comments}}//{{.}}
             {{end -}}
-            {{.MethodName}}(ctx context.Context, {{.Arg.Pair}}) ([]{{.Ret.DefineType}}, error)
+            {{.MethodName}}(ctx context.Context, {{.Arg.Pair}} {{- if ne .Arg.Pair ""}}, {{end -}} aq ...AdditionalQuery) ([]{{.Ret.DefineType}}, error)
         {{- end}}
         {{- if and (eq .Cmd ":exec") ($dbtxParam) }}
             {{range .Comments}}//{{.}}

--- a/internal/codegen/golang/templates/stdlib/queryCode.tmpl
+++ b/internal/codegen/golang/templates/stdlib/queryCode.tmpl
@@ -22,7 +22,7 @@ type {{.Ret.Type}} struct { {{- range .Ret.Struct.Fields}}
 {{if eq .Cmd ":one"}}
 {{range .Comments}}//{{.}}
 {{end -}}
-func (q *Queries) {{.MethodName}}(ctx context.Context, {{ dbarg }} {{.Arg.Pair}}) ({{.Ret.DefineType}}, error) {
+func (q *Queries) {{.MethodName}}(ctx context.Context, {{ dbarg }} {{.Arg.Pair}} {{- if ne .Arg.Pair ""}}, {{end -}} aq ...AdditionalQuery) ({{.Ret.DefineType}}, error) {
     {{- template "queryCodeStdExec" . }}
 	{{- if ne .Arg.Pair .Ret.Pair }}
 	var {{.Ret.Name}} {{.Ret.Type}}
@@ -35,7 +35,7 @@ func (q *Queries) {{.MethodName}}(ctx context.Context, {{ dbarg }} {{.Arg.Pair}}
 {{if eq .Cmd ":many"}}
 {{range .Comments}}//{{.}}
 {{end -}}
-func (q *Queries) {{.MethodName}}(ctx context.Context, {{ dbarg }} {{.Arg.Pair}}) ([]{{.Ret.DefineType}}, error) {
+func (q *Queries) {{.MethodName}}(ctx context.Context, {{ dbarg }} {{.Arg.Pair}} {{- if ne .Arg.Pair ""}}, {{end -}} aq ...AdditionalQuery) ([]{{.Ret.DefineType}}, error) {
     {{- template "queryCodeStdExec" . }}
     if err != nil {
         return nil, err
@@ -109,8 +109,8 @@ func (q *Queries) {{.MethodName}}(ctx context.Context, {{ dbarg }} {{.Arg.Pair}}
 {{end}}
 
 {{define "queryCodeStdExec"}}
+    query := {{.ConstantName}}
     {{- if .Arg.HasSqlcSlices }}
-        query := {{.ConstantName}}
         var queryParams []interface{}
         {{- if .Arg.Struct }}
             {{- $arg := .Arg }}
@@ -142,14 +142,32 @@ func (q *Queries) {{.MethodName}}(ctx context.Context, {{ dbarg }} {{.Arg.Pair}}
               query = strings.Replace(query, "/*SLICE:{{.Arg.Column.Name}}*/?", "NULL", 1)
             }
         {{- end }}
-        {{- if emitPreparedQueries }}
-        {{ queryRetval . }} {{ queryMethod . }}(ctx, nil, query, queryParams...)
-        {{- else}}
-        {{ queryRetval . }} {{ queryMethod . }}(ctx, query, queryParams...)
+
+        {{ if or (eq .Cmd ":many") (eq .Cmd ":one") }}
+            if len(aq) > 0 {
+                query += " " + aq[0].SQL
+                queryParams = append(queryParams, aq[0].Args...)
+            }
+        {{- end }}
+        
+        {{ if emitPreparedQueries }}
+            {{ queryRetval . }} {{ queryMethod . }}(ctx, nil, query, queryParams...)
+        {{- else }}
+            {{ queryRetval . }} {{ queryMethod . }}(ctx, query, queryParams...)
         {{- end -}}
-    {{- else if emitPreparedQueries }}
-        {{- queryRetval . }} {{ queryMethod . }}(ctx, q.{{.FieldName}}, {{.ConstantName}}, {{.Arg.Params}})
-    {{- else}}
-        {{- queryRetval . }} {{ queryMethod . }}(ctx, {{.ConstantName}}, {{.Arg.Params}})
+    {{- else }}
+        queryParams := []interface{}{ {{.Arg.Params}} }
+        {{ if or (eq .Cmd ":many") (eq .Cmd ":one") }}
+            if len(aq) > 0 {
+                query += " " + aq[0].SQL
+                queryParams = append(queryParams, aq[0].Args...)
+            }
+        {{- end }}
+
+        {{ if emitPreparedQueries }}
+            {{- queryRetval . }} {{ queryMethod . }}(ctx, q.{{.FieldName}}, query, queryParams...)
+        {{- else}}
+            {{- queryRetval . }} {{ queryMethod . }}(ctx, query, queryParams...)
+        {{- end -}}
     {{- end -}}
 {{end}}

--- a/internal/endtoend/testdata/alias/mysql/go/db.go
+++ b/internal/endtoend/testdata/alias/mysql/go/db.go
@@ -29,3 +29,8 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/alias/mysql/go/db.go
+++ b/internal/endtoend/testdata/alias/mysql/go/db.go
@@ -32,5 +32,5 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/alias/mysql/go/query.sql.go
+++ b/internal/endtoend/testdata/alias/mysql/go/query.sql.go
@@ -15,6 +15,9 @@ WHERE b.id = ?
 `
 
 func (q *Queries) AliasBar(ctx context.Context, id uint64) error {
-	_, err := q.db.ExecContext(ctx, aliasBar, id)
+	query := aliasBar
+	queryParams := []interface{}{id}
+
+	_, err := q.db.ExecContext(ctx, query, queryParams...)
 	return err
 }

--- a/internal/endtoend/testdata/alias/postgresql/pgx/v4/go/db.go
+++ b/internal/endtoend/testdata/alias/postgresql/pgx/v4/go/db.go
@@ -33,5 +33,5 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/alias/postgresql/pgx/v4/go/db.go
+++ b/internal/endtoend/testdata/alias/postgresql/pgx/v4/go/db.go
@@ -30,3 +30,8 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/alias/postgresql/pgx/v5/go/db.go
+++ b/internal/endtoend/testdata/alias/postgresql/pgx/v5/go/db.go
@@ -33,5 +33,5 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/alias/postgresql/pgx/v5/go/db.go
+++ b/internal/endtoend/testdata/alias/postgresql/pgx/v5/go/db.go
@@ -30,3 +30,8 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/alias/postgresql/stdlib/go/db.go
+++ b/internal/endtoend/testdata/alias/postgresql/stdlib/go/db.go
@@ -29,3 +29,8 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/alias/postgresql/stdlib/go/db.go
+++ b/internal/endtoend/testdata/alias/postgresql/stdlib/go/db.go
@@ -32,5 +32,5 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/alias/postgresql/stdlib/go/query.sql.go
+++ b/internal/endtoend/testdata/alias/postgresql/stdlib/go/query.sql.go
@@ -15,6 +15,9 @@ WHERE b.id = $1
 `
 
 func (q *Queries) AliasBar(ctx context.Context, id int32) error {
-	_, err := q.db.ExecContext(ctx, aliasBar, id)
+	query := aliasBar
+	queryParams := []interface{}{id}
+
+	_, err := q.db.ExecContext(ctx, query, queryParams...)
 	return err
 }

--- a/internal/endtoend/testdata/alias/sqlite/go/db.go
+++ b/internal/endtoend/testdata/alias/sqlite/go/db.go
@@ -29,3 +29,8 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/alias/sqlite/go/db.go
+++ b/internal/endtoend/testdata/alias/sqlite/go/db.go
@@ -32,5 +32,5 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/alias/sqlite/go/query.sql.go
+++ b/internal/endtoend/testdata/alias/sqlite/go/query.sql.go
@@ -15,6 +15,9 @@ WHERE b.id = ?
 `
 
 func (q *Queries) AliasBar(ctx context.Context, id int64) error {
-	_, err := q.db.ExecContext(ctx, aliasBar, id)
+	query := aliasBar
+	queryParams := []interface{}{id}
+
+	_, err := q.db.ExecContext(ctx, query, queryParams...)
 	return err
 }

--- a/internal/endtoend/testdata/any/pgx/v4/go/db.go
+++ b/internal/endtoend/testdata/any/pgx/v4/go/db.go
@@ -33,5 +33,5 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/any/pgx/v4/go/db.go
+++ b/internal/endtoend/testdata/any/pgx/v4/go/db.go
@@ -30,3 +30,8 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/any/pgx/v4/go/query.sql.go
+++ b/internal/endtoend/testdata/any/pgx/v4/go/query.sql.go
@@ -15,8 +15,16 @@ FROM bar
 WHERE foo = ANY($1::bigserial[])
 `
 
-func (q *Queries) Any(ctx context.Context, dollar_1 []int64) ([]int64, error) {
-	rows, err := q.db.Query(ctx, any, dollar_1)
+func (q *Queries) Any(ctx context.Context, dollar_1 []int64, aq ...AdditionalQuery) ([]int64, error) {
+	query := any
+	queryParams := []interface{}{dollar_1}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.Query(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/endtoend/testdata/any/pgx/v5/go/db.go
+++ b/internal/endtoend/testdata/any/pgx/v5/go/db.go
@@ -33,5 +33,5 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/any/pgx/v5/go/db.go
+++ b/internal/endtoend/testdata/any/pgx/v5/go/db.go
@@ -30,3 +30,8 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/any/pgx/v5/go/query.sql.go
+++ b/internal/endtoend/testdata/any/pgx/v5/go/query.sql.go
@@ -15,8 +15,16 @@ FROM bar
 WHERE foo = ANY($1::bigserial[])
 `
 
-func (q *Queries) Any(ctx context.Context, dollar_1 []int64) ([]int64, error) {
-	rows, err := q.db.Query(ctx, any, dollar_1)
+func (q *Queries) Any(ctx context.Context, dollar_1 []int64, aq ...AdditionalQuery) ([]int64, error) {
+	query := any
+	queryParams := []interface{}{dollar_1}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.Query(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/endtoend/testdata/any/stdlib/go/db.go
+++ b/internal/endtoend/testdata/any/stdlib/go/db.go
@@ -29,3 +29,8 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/any/stdlib/go/db.go
+++ b/internal/endtoend/testdata/any/stdlib/go/db.go
@@ -32,5 +32,5 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/any/stdlib/go/query.sql.go
+++ b/internal/endtoend/testdata/any/stdlib/go/query.sql.go
@@ -17,8 +17,16 @@ FROM bar
 WHERE foo = ANY($1::bigserial[])
 `
 
-func (q *Queries) Any(ctx context.Context, dollar_1 []int64) ([]int64, error) {
-	rows, err := q.db.QueryContext(ctx, any, pq.Array(dollar_1))
+func (q *Queries) Any(ctx context.Context, dollar_1 []int64, aq ...AdditionalQuery) ([]int64, error) {
+	query := any
+	queryParams := []interface{}{pq.Array(dollar_1)}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.QueryContext(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/endtoend/testdata/array_in/pgx/v4/go/db.go
+++ b/internal/endtoend/testdata/array_in/pgx/v4/go/db.go
@@ -33,5 +33,5 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/array_in/pgx/v4/go/db.go
+++ b/internal/endtoend/testdata/array_in/pgx/v4/go/db.go
@@ -30,3 +30,8 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/array_in/pgx/v4/go/query.sql.go
+++ b/internal/endtoend/testdata/array_in/pgx/v4/go/query.sql.go
@@ -20,8 +20,16 @@ type InParams struct {
 	ID_2 int32
 }
 
-func (q *Queries) In(ctx context.Context, arg InParams) ([]int32, error) {
-	rows, err := q.db.Query(ctx, in, arg.ID, arg.ID_2)
+func (q *Queries) In(ctx context.Context, arg InParams, aq ...AdditionalQuery) ([]int32, error) {
+	query := in
+	queryParams := []interface{}{arg.ID, arg.ID_2}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.Query(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/endtoend/testdata/array_in/pgx/v5/go/db.go
+++ b/internal/endtoend/testdata/array_in/pgx/v5/go/db.go
@@ -33,5 +33,5 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/array_in/pgx/v5/go/db.go
+++ b/internal/endtoend/testdata/array_in/pgx/v5/go/db.go
@@ -30,3 +30,8 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/array_in/pgx/v5/go/query.sql.go
+++ b/internal/endtoend/testdata/array_in/pgx/v5/go/query.sql.go
@@ -20,8 +20,16 @@ type InParams struct {
 	ID_2 int32
 }
 
-func (q *Queries) In(ctx context.Context, arg InParams) ([]int32, error) {
-	rows, err := q.db.Query(ctx, in, arg.ID, arg.ID_2)
+func (q *Queries) In(ctx context.Context, arg InParams, aq ...AdditionalQuery) ([]int32, error) {
+	query := in
+	queryParams := []interface{}{arg.ID, arg.ID_2}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.Query(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/endtoend/testdata/array_in/stdlib/go/db.go
+++ b/internal/endtoend/testdata/array_in/stdlib/go/db.go
@@ -29,3 +29,8 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/array_in/stdlib/go/db.go
+++ b/internal/endtoend/testdata/array_in/stdlib/go/db.go
@@ -32,5 +32,5 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/array_in/stdlib/go/query.sql.go
+++ b/internal/endtoend/testdata/array_in/stdlib/go/query.sql.go
@@ -20,8 +20,16 @@ type InParams struct {
 	ID_2 int32
 }
 
-func (q *Queries) In(ctx context.Context, arg InParams) ([]int32, error) {
-	rows, err := q.db.QueryContext(ctx, in, arg.ID, arg.ID_2)
+func (q *Queries) In(ctx context.Context, arg InParams, aq ...AdditionalQuery) ([]int32, error) {
+	query := in
+	queryParams := []interface{}{arg.ID, arg.ID_2}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.QueryContext(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/endtoend/testdata/array_text/pgx/v4/go/db.go
+++ b/internal/endtoend/testdata/array_text/pgx/v4/go/db.go
@@ -33,5 +33,5 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/array_text/pgx/v4/go/db.go
+++ b/internal/endtoend/testdata/array_text/pgx/v4/go/db.go
@@ -30,3 +30,8 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/array_text/pgx/v4/go/query.sql.go
+++ b/internal/endtoend/testdata/array_text/pgx/v4/go/query.sql.go
@@ -13,8 +13,16 @@ const textArray = `-- name: TextArray :many
 SELECT tags FROM bar
 `
 
-func (q *Queries) TextArray(ctx context.Context) ([][]string, error) {
-	rows, err := q.db.Query(ctx, textArray)
+func (q *Queries) TextArray(ctx context.Context, aq ...AdditionalQuery) ([][]string, error) {
+	query := textArray
+	queryParams := []interface{}{}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.Query(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/endtoend/testdata/array_text/pgx/v5/go/db.go
+++ b/internal/endtoend/testdata/array_text/pgx/v5/go/db.go
@@ -33,5 +33,5 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/array_text/pgx/v5/go/db.go
+++ b/internal/endtoend/testdata/array_text/pgx/v5/go/db.go
@@ -30,3 +30,8 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/array_text/pgx/v5/go/query.sql.go
+++ b/internal/endtoend/testdata/array_text/pgx/v5/go/query.sql.go
@@ -13,8 +13,16 @@ const textArray = `-- name: TextArray :many
 SELECT tags FROM bar
 `
 
-func (q *Queries) TextArray(ctx context.Context) ([][]string, error) {
-	rows, err := q.db.Query(ctx, textArray)
+func (q *Queries) TextArray(ctx context.Context, aq ...AdditionalQuery) ([][]string, error) {
+	query := textArray
+	queryParams := []interface{}{}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.Query(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/endtoend/testdata/array_text/stdlib/go/db.go
+++ b/internal/endtoend/testdata/array_text/stdlib/go/db.go
@@ -29,3 +29,8 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/array_text/stdlib/go/db.go
+++ b/internal/endtoend/testdata/array_text/stdlib/go/db.go
@@ -32,5 +32,5 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/array_text/stdlib/go/query.sql.go
+++ b/internal/endtoend/testdata/array_text/stdlib/go/query.sql.go
@@ -15,8 +15,16 @@ const textArray = `-- name: TextArray :many
 SELECT tags FROM bar
 `
 
-func (q *Queries) TextArray(ctx context.Context) ([][]string, error) {
-	rows, err := q.db.QueryContext(ctx, textArray)
+func (q *Queries) TextArray(ctx context.Context, aq ...AdditionalQuery) ([][]string, error) {
+	query := textArray
+	queryParams := []interface{}{}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.QueryContext(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/endtoend/testdata/array_text_join/pgx/v4/go/db.go
+++ b/internal/endtoend/testdata/array_text_join/pgx/v4/go/db.go
@@ -33,5 +33,5 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/array_text_join/pgx/v4/go/db.go
+++ b/internal/endtoend/testdata/array_text_join/pgx/v4/go/db.go
@@ -30,3 +30,8 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/array_text_join/pgx/v4/go/query.sql.go
+++ b/internal/endtoend/testdata/array_text_join/pgx/v4/go/query.sql.go
@@ -15,8 +15,16 @@ FROM foo
 JOIN bar ON foo.bar = bar.id
 `
 
-func (q *Queries) JoinTextArray(ctx context.Context) ([][]string, error) {
-	rows, err := q.db.Query(ctx, joinTextArray)
+func (q *Queries) JoinTextArray(ctx context.Context, aq ...AdditionalQuery) ([][]string, error) {
+	query := joinTextArray
+	queryParams := []interface{}{}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.Query(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/endtoend/testdata/array_text_join/pgx/v5/go/db.go
+++ b/internal/endtoend/testdata/array_text_join/pgx/v5/go/db.go
@@ -33,5 +33,5 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/array_text_join/pgx/v5/go/db.go
+++ b/internal/endtoend/testdata/array_text_join/pgx/v5/go/db.go
@@ -30,3 +30,8 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/array_text_join/pgx/v5/go/query.sql.go
+++ b/internal/endtoend/testdata/array_text_join/pgx/v5/go/query.sql.go
@@ -15,8 +15,16 @@ FROM foo
 JOIN bar ON foo.bar = bar.id
 `
 
-func (q *Queries) JoinTextArray(ctx context.Context) ([][]string, error) {
-	rows, err := q.db.Query(ctx, joinTextArray)
+func (q *Queries) JoinTextArray(ctx context.Context, aq ...AdditionalQuery) ([][]string, error) {
+	query := joinTextArray
+	queryParams := []interface{}{}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.Query(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/endtoend/testdata/array_text_join/stdlib/go/db.go
+++ b/internal/endtoend/testdata/array_text_join/stdlib/go/db.go
@@ -29,3 +29,8 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/array_text_join/stdlib/go/db.go
+++ b/internal/endtoend/testdata/array_text_join/stdlib/go/db.go
@@ -32,5 +32,5 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/array_text_join/stdlib/go/query.sql.go
+++ b/internal/endtoend/testdata/array_text_join/stdlib/go/query.sql.go
@@ -17,8 +17,16 @@ FROM foo
 JOIN bar ON foo.bar = bar.id
 `
 
-func (q *Queries) JoinTextArray(ctx context.Context) ([][]string, error) {
-	rows, err := q.db.QueryContext(ctx, joinTextArray)
+func (q *Queries) JoinTextArray(ctx context.Context, aq ...AdditionalQuery) ([][]string, error) {
+	query := joinTextArray
+	queryParams := []interface{}{}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.QueryContext(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/endtoend/testdata/batch/postgresql/pgx/v4/go/db.go
+++ b/internal/endtoend/testdata/batch/postgresql/pgx/v4/go/db.go
@@ -31,3 +31,8 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/batch/postgresql/pgx/v4/go/db.go
+++ b/internal/endtoend/testdata/batch/postgresql/pgx/v4/go/db.go
@@ -34,5 +34,5 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/batch/postgresql/pgx/v5/go/db.go
+++ b/internal/endtoend/testdata/batch/postgresql/pgx/v5/go/db.go
@@ -31,3 +31,8 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/batch/postgresql/pgx/v5/go/db.go
+++ b/internal/endtoend/testdata/batch/postgresql/pgx/v5/go/db.go
@@ -34,5 +34,5 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/batch_imports/postgresql/pgx/v4/go/db.go
+++ b/internal/endtoend/testdata/batch_imports/postgresql/pgx/v4/go/db.go
@@ -31,3 +31,8 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/batch_imports/postgresql/pgx/v4/go/db.go
+++ b/internal/endtoend/testdata/batch_imports/postgresql/pgx/v4/go/db.go
@@ -34,5 +34,5 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/batch_imports/postgresql/pgx/v5/go/db.go
+++ b/internal/endtoend/testdata/batch_imports/postgresql/pgx/v5/go/db.go
@@ -31,3 +31,8 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/batch_imports/postgresql/pgx/v5/go/db.go
+++ b/internal/endtoend/testdata/batch_imports/postgresql/pgx/v5/go/db.go
@@ -34,5 +34,5 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/between_args/mysql/go/db.go
+++ b/internal/endtoend/testdata/between_args/mysql/go/db.go
@@ -29,3 +29,8 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/between_args/mysql/go/db.go
+++ b/internal/endtoend/testdata/between_args/mysql/go/db.go
@@ -32,5 +32,5 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/between_args/mysql/go/query.sql.go
+++ b/internal/endtoend/testdata/between_args/mysql/go/query.sql.go
@@ -20,8 +20,16 @@ type GetBetweenPricesParams struct {
 	ToPrice   int32
 }
 
-func (q *Queries) GetBetweenPrices(ctx context.Context, arg GetBetweenPricesParams) ([]Product, error) {
-	rows, err := q.db.QueryContext(ctx, getBetweenPrices, arg.FromPrice, arg.ToPrice)
+func (q *Queries) GetBetweenPrices(ctx context.Context, arg GetBetweenPricesParams, aq ...AdditionalQuery) ([]Product, error) {
+	query := getBetweenPrices
+	queryParams := []interface{}{arg.FromPrice, arg.ToPrice}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.QueryContext(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}
@@ -54,8 +62,16 @@ type GetBetweenPricesNamedParams struct {
 	MaxPrice int32
 }
 
-func (q *Queries) GetBetweenPricesNamed(ctx context.Context, arg GetBetweenPricesNamedParams) ([]Product, error) {
-	rows, err := q.db.QueryContext(ctx, getBetweenPricesNamed, arg.MinPrice, arg.MaxPrice)
+func (q *Queries) GetBetweenPricesNamed(ctx context.Context, arg GetBetweenPricesNamedParams, aq ...AdditionalQuery) ([]Product, error) {
+	query := getBetweenPricesNamed
+	queryParams := []interface{}{arg.MinPrice, arg.MaxPrice}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.QueryContext(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}
@@ -88,8 +104,16 @@ type GetBetweenPricesTableParams struct {
 	ToPrice   int32
 }
 
-func (q *Queries) GetBetweenPricesTable(ctx context.Context, arg GetBetweenPricesTableParams) ([]Product, error) {
-	rows, err := q.db.QueryContext(ctx, getBetweenPricesTable, arg.FromPrice, arg.ToPrice)
+func (q *Queries) GetBetweenPricesTable(ctx context.Context, arg GetBetweenPricesTableParams, aq ...AdditionalQuery) ([]Product, error) {
+	query := getBetweenPricesTable
+	queryParams := []interface{}{arg.FromPrice, arg.ToPrice}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.QueryContext(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}
@@ -122,8 +146,16 @@ type GetBetweenPricesTableAliasParams struct {
 	ToPrice   int32
 }
 
-func (q *Queries) GetBetweenPricesTableAlias(ctx context.Context, arg GetBetweenPricesTableAliasParams) ([]Product, error) {
-	rows, err := q.db.QueryContext(ctx, getBetweenPricesTableAlias, arg.FromPrice, arg.ToPrice)
+func (q *Queries) GetBetweenPricesTableAlias(ctx context.Context, arg GetBetweenPricesTableAliasParams, aq ...AdditionalQuery) ([]Product, error) {
+	query := getBetweenPricesTableAlias
+	queryParams := []interface{}{arg.FromPrice, arg.ToPrice}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.QueryContext(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/endtoend/testdata/between_args/sqlite/go/db.go
+++ b/internal/endtoend/testdata/between_args/sqlite/go/db.go
@@ -29,3 +29,8 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/between_args/sqlite/go/db.go
+++ b/internal/endtoend/testdata/between_args/sqlite/go/db.go
@@ -32,5 +32,5 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/between_args/sqlite/go/query.sql.go
+++ b/internal/endtoend/testdata/between_args/sqlite/go/query.sql.go
@@ -20,8 +20,16 @@ type GetBetweenPricesParams struct {
 	ToPrice   int64
 }
 
-func (q *Queries) GetBetweenPrices(ctx context.Context, arg GetBetweenPricesParams) ([]Product, error) {
-	rows, err := q.db.QueryContext(ctx, getBetweenPrices, arg.FromPrice, arg.ToPrice)
+func (q *Queries) GetBetweenPrices(ctx context.Context, arg GetBetweenPricesParams, aq ...AdditionalQuery) ([]Product, error) {
+	query := getBetweenPrices
+	queryParams := []interface{}{arg.FromPrice, arg.ToPrice}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.QueryContext(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}
@@ -54,8 +62,16 @@ type GetBetweenPricesTableParams struct {
 	ToPrice   int64
 }
 
-func (q *Queries) GetBetweenPricesTable(ctx context.Context, arg GetBetweenPricesTableParams) ([]Product, error) {
-	rows, err := q.db.QueryContext(ctx, getBetweenPricesTable, arg.FromPrice, arg.ToPrice)
+func (q *Queries) GetBetweenPricesTable(ctx context.Context, arg GetBetweenPricesTableParams, aq ...AdditionalQuery) ([]Product, error) {
+	query := getBetweenPricesTable
+	queryParams := []interface{}{arg.FromPrice, arg.ToPrice}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.QueryContext(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}
@@ -88,8 +104,16 @@ type GetBetweenPricesTableAliasParams struct {
 	ToPrice   int64
 }
 
-func (q *Queries) GetBetweenPricesTableAlias(ctx context.Context, arg GetBetweenPricesTableAliasParams) ([]Product, error) {
-	rows, err := q.db.QueryContext(ctx, getBetweenPricesTableAlias, arg.FromPrice, arg.ToPrice)
+func (q *Queries) GetBetweenPricesTableAlias(ctx context.Context, arg GetBetweenPricesTableAliasParams, aq ...AdditionalQuery) ([]Product, error) {
+	query := getBetweenPricesTableAlias
+	queryParams := []interface{}{arg.FromPrice, arg.ToPrice}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.QueryContext(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/endtoend/testdata/builtins/postgresql/go/db.go
+++ b/internal/endtoend/testdata/builtins/postgresql/go/db.go
@@ -29,3 +29,8 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/builtins/postgresql/go/db.go
+++ b/internal/endtoend/testdata/builtins/postgresql/go/db.go
@@ -32,5 +32,5 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/builtins/sqlite/go/aggfunc.sql.go
+++ b/internal/endtoend/testdata/builtins/sqlite/go/aggfunc.sql.go
@@ -14,8 +14,16 @@ const getAvg = `-- name: GetAvg :one
 SELECT avg(int_val) FROM test
 `
 
-func (q *Queries) GetAvg(ctx context.Context) (sql.NullFloat64, error) {
-	row := q.db.QueryRowContext(ctx, getAvg)
+func (q *Queries) GetAvg(ctx context.Context, aq ...AdditionalQuery) (sql.NullFloat64, error) {
+	query := getAvg
+	queryParams := []interface{}{}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	row := q.db.QueryRowContext(ctx, query, queryParams...)
 	var avg sql.NullFloat64
 	err := row.Scan(&avg)
 	return avg, err
@@ -25,8 +33,16 @@ const getCount = `-- name: GetCount :one
 SELECT count(*) FROM test
 `
 
-func (q *Queries) GetCount(ctx context.Context) (int64, error) {
-	row := q.db.QueryRowContext(ctx, getCount)
+func (q *Queries) GetCount(ctx context.Context, aq ...AdditionalQuery) (int64, error) {
+	query := getCount
+	queryParams := []interface{}{}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	row := q.db.QueryRowContext(ctx, query, queryParams...)
 	var count int64
 	err := row.Scan(&count)
 	return count, err
@@ -36,8 +52,16 @@ const getCountId = `-- name: GetCountId :one
 SELECT count(id) FROM test
 `
 
-func (q *Queries) GetCountId(ctx context.Context) (int64, error) {
-	row := q.db.QueryRowContext(ctx, getCountId)
+func (q *Queries) GetCountId(ctx context.Context, aq ...AdditionalQuery) (int64, error) {
+	query := getCountId
+	queryParams := []interface{}{}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	row := q.db.QueryRowContext(ctx, query, queryParams...)
 	var count int64
 	err := row.Scan(&count)
 	return count, err
@@ -47,8 +71,16 @@ const getGroupConcatInt = `-- name: GetGroupConcatInt :one
 SELECT group_concat(int_val) FROM test
 `
 
-func (q *Queries) GetGroupConcatInt(ctx context.Context) (string, error) {
-	row := q.db.QueryRowContext(ctx, getGroupConcatInt)
+func (q *Queries) GetGroupConcatInt(ctx context.Context, aq ...AdditionalQuery) (string, error) {
+	query := getGroupConcatInt
+	queryParams := []interface{}{}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	row := q.db.QueryRowContext(ctx, query, queryParams...)
 	var group_concat string
 	err := row.Scan(&group_concat)
 	return group_concat, err
@@ -58,8 +90,16 @@ const getGroupConcatInt2 = `-- name: GetGroupConcatInt2 :one
 SELECT group_concat(1, ':') FROM test
 `
 
-func (q *Queries) GetGroupConcatInt2(ctx context.Context) (string, error) {
-	row := q.db.QueryRowContext(ctx, getGroupConcatInt2)
+func (q *Queries) GetGroupConcatInt2(ctx context.Context, aq ...AdditionalQuery) (string, error) {
+	query := getGroupConcatInt2
+	queryParams := []interface{}{}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	row := q.db.QueryRowContext(ctx, query, queryParams...)
 	var group_concat string
 	err := row.Scan(&group_concat)
 	return group_concat, err
@@ -69,8 +109,16 @@ const getGroupConcatText = `-- name: GetGroupConcatText :one
 SELECT group_concat(text_val) FROM test
 `
 
-func (q *Queries) GetGroupConcatText(ctx context.Context) (string, error) {
-	row := q.db.QueryRowContext(ctx, getGroupConcatText)
+func (q *Queries) GetGroupConcatText(ctx context.Context, aq ...AdditionalQuery) (string, error) {
+	query := getGroupConcatText
+	queryParams := []interface{}{}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	row := q.db.QueryRowContext(ctx, query, queryParams...)
 	var group_concat string
 	err := row.Scan(&group_concat)
 	return group_concat, err
@@ -80,8 +128,16 @@ const getGroupConcatText2 = `-- name: GetGroupConcatText2 :one
 SELECT group_concat(text_val, ':') FROM test
 `
 
-func (q *Queries) GetGroupConcatText2(ctx context.Context) (string, error) {
-	row := q.db.QueryRowContext(ctx, getGroupConcatText2)
+func (q *Queries) GetGroupConcatText2(ctx context.Context, aq ...AdditionalQuery) (string, error) {
+	query := getGroupConcatText2
+	queryParams := []interface{}{}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	row := q.db.QueryRowContext(ctx, query, queryParams...)
 	var group_concat string
 	err := row.Scan(&group_concat)
 	return group_concat, err
@@ -91,8 +147,16 @@ const getMaxInt = `-- name: GetMaxInt :one
 SELECT max(int_val) FROM test
 `
 
-func (q *Queries) GetMaxInt(ctx context.Context) (interface{}, error) {
-	row := q.db.QueryRowContext(ctx, getMaxInt)
+func (q *Queries) GetMaxInt(ctx context.Context, aq ...AdditionalQuery) (interface{}, error) {
+	query := getMaxInt
+	queryParams := []interface{}{}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	row := q.db.QueryRowContext(ctx, query, queryParams...)
 	var max interface{}
 	err := row.Scan(&max)
 	return max, err
@@ -102,8 +166,16 @@ const getMaxText = `-- name: GetMaxText :one
 SELECT max(text_val) FROM test
 `
 
-func (q *Queries) GetMaxText(ctx context.Context) (interface{}, error) {
-	row := q.db.QueryRowContext(ctx, getMaxText)
+func (q *Queries) GetMaxText(ctx context.Context, aq ...AdditionalQuery) (interface{}, error) {
+	query := getMaxText
+	queryParams := []interface{}{}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	row := q.db.QueryRowContext(ctx, query, queryParams...)
 	var max interface{}
 	err := row.Scan(&max)
 	return max, err
@@ -113,8 +185,16 @@ const getMinInt = `-- name: GetMinInt :one
 SELECT min(int_val) FROM test
 `
 
-func (q *Queries) GetMinInt(ctx context.Context) (interface{}, error) {
-	row := q.db.QueryRowContext(ctx, getMinInt)
+func (q *Queries) GetMinInt(ctx context.Context, aq ...AdditionalQuery) (interface{}, error) {
+	query := getMinInt
+	queryParams := []interface{}{}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	row := q.db.QueryRowContext(ctx, query, queryParams...)
 	var min interface{}
 	err := row.Scan(&min)
 	return min, err
@@ -124,8 +204,16 @@ const getMinText = `-- name: GetMinText :one
 SELECT min(text_val) FROM test
 `
 
-func (q *Queries) GetMinText(ctx context.Context) (interface{}, error) {
-	row := q.db.QueryRowContext(ctx, getMinText)
+func (q *Queries) GetMinText(ctx context.Context, aq ...AdditionalQuery) (interface{}, error) {
+	query := getMinText
+	queryParams := []interface{}{}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	row := q.db.QueryRowContext(ctx, query, queryParams...)
 	var min interface{}
 	err := row.Scan(&min)
 	return min, err
@@ -135,8 +223,16 @@ const getSumInt = `-- name: GetSumInt :one
 SELECT sum(int_val) FROM test
 `
 
-func (q *Queries) GetSumInt(ctx context.Context) (sql.NullFloat64, error) {
-	row := q.db.QueryRowContext(ctx, getSumInt)
+func (q *Queries) GetSumInt(ctx context.Context, aq ...AdditionalQuery) (sql.NullFloat64, error) {
+	query := getSumInt
+	queryParams := []interface{}{}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	row := q.db.QueryRowContext(ctx, query, queryParams...)
 	var sum sql.NullFloat64
 	err := row.Scan(&sum)
 	return sum, err
@@ -146,8 +242,16 @@ const getSumText = `-- name: GetSumText :one
 SELECT sum(text_val) FROM test
 `
 
-func (q *Queries) GetSumText(ctx context.Context) (sql.NullFloat64, error) {
-	row := q.db.QueryRowContext(ctx, getSumText)
+func (q *Queries) GetSumText(ctx context.Context, aq ...AdditionalQuery) (sql.NullFloat64, error) {
+	query := getSumText
+	queryParams := []interface{}{}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	row := q.db.QueryRowContext(ctx, query, queryParams...)
 	var sum sql.NullFloat64
 	err := row.Scan(&sum)
 	return sum, err
@@ -157,8 +261,16 @@ const getTotalInt = `-- name: GetTotalInt :one
 SELECT total(int_val) FROM test
 `
 
-func (q *Queries) GetTotalInt(ctx context.Context) (float64, error) {
-	row := q.db.QueryRowContext(ctx, getTotalInt)
+func (q *Queries) GetTotalInt(ctx context.Context, aq ...AdditionalQuery) (float64, error) {
+	query := getTotalInt
+	queryParams := []interface{}{}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	row := q.db.QueryRowContext(ctx, query, queryParams...)
 	var total float64
 	err := row.Scan(&total)
 	return total, err

--- a/internal/endtoend/testdata/builtins/sqlite/go/db.go
+++ b/internal/endtoend/testdata/builtins/sqlite/go/db.go
@@ -29,3 +29,8 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/builtins/sqlite/go/db.go
+++ b/internal/endtoend/testdata/builtins/sqlite/go/db.go
@@ -32,5 +32,5 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/builtins/sqlite/go/mathfunc.sql.go
+++ b/internal/endtoend/testdata/builtins/sqlite/go/mathfunc.sql.go
@@ -13,8 +13,16 @@ const getAcos = `-- name: GetAcos :one
 select acos(1.0)
 `
 
-func (q *Queries) GetAcos(ctx context.Context) (float64, error) {
-	row := q.db.QueryRowContext(ctx, getAcos)
+func (q *Queries) GetAcos(ctx context.Context, aq ...AdditionalQuery) (float64, error) {
+	query := getAcos
+	queryParams := []interface{}{}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	row := q.db.QueryRowContext(ctx, query, queryParams...)
 	var acos float64
 	err := row.Scan(&acos)
 	return acos, err
@@ -24,8 +32,16 @@ const getAcosh = `-- name: GetAcosh :one
 select acosh(1.0)
 `
 
-func (q *Queries) GetAcosh(ctx context.Context) (float64, error) {
-	row := q.db.QueryRowContext(ctx, getAcosh)
+func (q *Queries) GetAcosh(ctx context.Context, aq ...AdditionalQuery) (float64, error) {
+	query := getAcosh
+	queryParams := []interface{}{}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	row := q.db.QueryRowContext(ctx, query, queryParams...)
 	var acosh float64
 	err := row.Scan(&acosh)
 	return acosh, err
@@ -35,8 +51,16 @@ const getAsin = `-- name: GetAsin :one
 select asin(1.0)
 `
 
-func (q *Queries) GetAsin(ctx context.Context) (float64, error) {
-	row := q.db.QueryRowContext(ctx, getAsin)
+func (q *Queries) GetAsin(ctx context.Context, aq ...AdditionalQuery) (float64, error) {
+	query := getAsin
+	queryParams := []interface{}{}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	row := q.db.QueryRowContext(ctx, query, queryParams...)
 	var asin float64
 	err := row.Scan(&asin)
 	return asin, err
@@ -46,8 +70,16 @@ const getAsinh = `-- name: GetAsinh :one
 select asinh(1.0)
 `
 
-func (q *Queries) GetAsinh(ctx context.Context) (float64, error) {
-	row := q.db.QueryRowContext(ctx, getAsinh)
+func (q *Queries) GetAsinh(ctx context.Context, aq ...AdditionalQuery) (float64, error) {
+	query := getAsinh
+	queryParams := []interface{}{}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	row := q.db.QueryRowContext(ctx, query, queryParams...)
 	var asinh float64
 	err := row.Scan(&asinh)
 	return asinh, err
@@ -57,8 +89,16 @@ const getAtan = `-- name: GetAtan :one
 select atan(1.0)
 `
 
-func (q *Queries) GetAtan(ctx context.Context) (float64, error) {
-	row := q.db.QueryRowContext(ctx, getAtan)
+func (q *Queries) GetAtan(ctx context.Context, aq ...AdditionalQuery) (float64, error) {
+	query := getAtan
+	queryParams := []interface{}{}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	row := q.db.QueryRowContext(ctx, query, queryParams...)
 	var atan float64
 	err := row.Scan(&atan)
 	return atan, err
@@ -68,8 +108,16 @@ const getAtan2 = `-- name: GetAtan2 :one
 select atan2(1.0, 0.5)
 `
 
-func (q *Queries) GetAtan2(ctx context.Context) (float64, error) {
-	row := q.db.QueryRowContext(ctx, getAtan2)
+func (q *Queries) GetAtan2(ctx context.Context, aq ...AdditionalQuery) (float64, error) {
+	query := getAtan2
+	queryParams := []interface{}{}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	row := q.db.QueryRowContext(ctx, query, queryParams...)
 	var atan2 float64
 	err := row.Scan(&atan2)
 	return atan2, err
@@ -79,8 +127,16 @@ const getAtanh = `-- name: GetAtanh :one
 select atanh(1.0)
 `
 
-func (q *Queries) GetAtanh(ctx context.Context) (float64, error) {
-	row := q.db.QueryRowContext(ctx, getAtanh)
+func (q *Queries) GetAtanh(ctx context.Context, aq ...AdditionalQuery) (float64, error) {
+	query := getAtanh
+	queryParams := []interface{}{}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	row := q.db.QueryRowContext(ctx, query, queryParams...)
 	var atanh float64
 	err := row.Scan(&atanh)
 	return atanh, err
@@ -90,8 +146,16 @@ const getCeil = `-- name: GetCeil :one
 select ceil(1.0)
 `
 
-func (q *Queries) GetCeil(ctx context.Context) (int64, error) {
-	row := q.db.QueryRowContext(ctx, getCeil)
+func (q *Queries) GetCeil(ctx context.Context, aq ...AdditionalQuery) (int64, error) {
+	query := getCeil
+	queryParams := []interface{}{}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	row := q.db.QueryRowContext(ctx, query, queryParams...)
 	var ceil int64
 	err := row.Scan(&ceil)
 	return ceil, err
@@ -101,8 +165,16 @@ const getCeilin = `-- name: GetCeilin :one
 select ceiling(1.0)
 `
 
-func (q *Queries) GetCeilin(ctx context.Context) (int64, error) {
-	row := q.db.QueryRowContext(ctx, getCeilin)
+func (q *Queries) GetCeilin(ctx context.Context, aq ...AdditionalQuery) (int64, error) {
+	query := getCeilin
+	queryParams := []interface{}{}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	row := q.db.QueryRowContext(ctx, query, queryParams...)
 	var ceiling int64
 	err := row.Scan(&ceiling)
 	return ceiling, err
@@ -112,8 +184,16 @@ const getCos = `-- name: GetCos :one
 select cos(1.0)
 `
 
-func (q *Queries) GetCos(ctx context.Context) (float64, error) {
-	row := q.db.QueryRowContext(ctx, getCos)
+func (q *Queries) GetCos(ctx context.Context, aq ...AdditionalQuery) (float64, error) {
+	query := getCos
+	queryParams := []interface{}{}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	row := q.db.QueryRowContext(ctx, query, queryParams...)
 	var cos float64
 	err := row.Scan(&cos)
 	return cos, err
@@ -123,8 +203,16 @@ const getCosh = `-- name: GetCosh :one
 select cosh(1.0)
 `
 
-func (q *Queries) GetCosh(ctx context.Context) (float64, error) {
-	row := q.db.QueryRowContext(ctx, getCosh)
+func (q *Queries) GetCosh(ctx context.Context, aq ...AdditionalQuery) (float64, error) {
+	query := getCosh
+	queryParams := []interface{}{}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	row := q.db.QueryRowContext(ctx, query, queryParams...)
 	var cosh float64
 	err := row.Scan(&cosh)
 	return cosh, err
@@ -134,8 +222,16 @@ const getDegrees = `-- name: GetDegrees :one
 select degrees(1.0)
 `
 
-func (q *Queries) GetDegrees(ctx context.Context) (float64, error) {
-	row := q.db.QueryRowContext(ctx, getDegrees)
+func (q *Queries) GetDegrees(ctx context.Context, aq ...AdditionalQuery) (float64, error) {
+	query := getDegrees
+	queryParams := []interface{}{}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	row := q.db.QueryRowContext(ctx, query, queryParams...)
 	var degrees float64
 	err := row.Scan(&degrees)
 	return degrees, err
@@ -145,8 +241,16 @@ const getExp = `-- name: GetExp :one
 select exp(1.0)
 `
 
-func (q *Queries) GetExp(ctx context.Context) (float64, error) {
-	row := q.db.QueryRowContext(ctx, getExp)
+func (q *Queries) GetExp(ctx context.Context, aq ...AdditionalQuery) (float64, error) {
+	query := getExp
+	queryParams := []interface{}{}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	row := q.db.QueryRowContext(ctx, query, queryParams...)
 	var exp float64
 	err := row.Scan(&exp)
 	return exp, err
@@ -156,8 +260,16 @@ const getFloor = `-- name: GetFloor :one
 select floor(1.0)
 `
 
-func (q *Queries) GetFloor(ctx context.Context) (int64, error) {
-	row := q.db.QueryRowContext(ctx, getFloor)
+func (q *Queries) GetFloor(ctx context.Context, aq ...AdditionalQuery) (int64, error) {
+	query := getFloor
+	queryParams := []interface{}{}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	row := q.db.QueryRowContext(ctx, query, queryParams...)
 	var floor int64
 	err := row.Scan(&floor)
 	return floor, err
@@ -167,8 +279,16 @@ const getLn = `-- name: GetLn :one
 select ln(1.0)
 `
 
-func (q *Queries) GetLn(ctx context.Context) (float64, error) {
-	row := q.db.QueryRowContext(ctx, getLn)
+func (q *Queries) GetLn(ctx context.Context, aq ...AdditionalQuery) (float64, error) {
+	query := getLn
+	queryParams := []interface{}{}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	row := q.db.QueryRowContext(ctx, query, queryParams...)
 	var ln float64
 	err := row.Scan(&ln)
 	return ln, err
@@ -178,8 +298,16 @@ const getLog = `-- name: GetLog :one
 select log(1.0)
 `
 
-func (q *Queries) GetLog(ctx context.Context) (float64, error) {
-	row := q.db.QueryRowContext(ctx, getLog)
+func (q *Queries) GetLog(ctx context.Context, aq ...AdditionalQuery) (float64, error) {
+	query := getLog
+	queryParams := []interface{}{}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	row := q.db.QueryRowContext(ctx, query, queryParams...)
 	var log float64
 	err := row.Scan(&log)
 	return log, err
@@ -189,8 +317,16 @@ const getLog10 = `-- name: GetLog10 :one
 select log10(1.0)
 `
 
-func (q *Queries) GetLog10(ctx context.Context) (float64, error) {
-	row := q.db.QueryRowContext(ctx, getLog10)
+func (q *Queries) GetLog10(ctx context.Context, aq ...AdditionalQuery) (float64, error) {
+	query := getLog10
+	queryParams := []interface{}{}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	row := q.db.QueryRowContext(ctx, query, queryParams...)
 	var log10 float64
 	err := row.Scan(&log10)
 	return log10, err
@@ -200,8 +336,16 @@ const getLog2 = `-- name: GetLog2 :one
 select log2(1.0)
 `
 
-func (q *Queries) GetLog2(ctx context.Context) (float64, error) {
-	row := q.db.QueryRowContext(ctx, getLog2)
+func (q *Queries) GetLog2(ctx context.Context, aq ...AdditionalQuery) (float64, error) {
+	query := getLog2
+	queryParams := []interface{}{}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	row := q.db.QueryRowContext(ctx, query, queryParams...)
 	var log2 float64
 	err := row.Scan(&log2)
 	return log2, err
@@ -211,8 +355,16 @@ const getLogBase = `-- name: GetLogBase :one
 select log(1.0, 2.0)
 `
 
-func (q *Queries) GetLogBase(ctx context.Context) (float64, error) {
-	row := q.db.QueryRowContext(ctx, getLogBase)
+func (q *Queries) GetLogBase(ctx context.Context, aq ...AdditionalQuery) (float64, error) {
+	query := getLogBase
+	queryParams := []interface{}{}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	row := q.db.QueryRowContext(ctx, query, queryParams...)
 	var log float64
 	err := row.Scan(&log)
 	return log, err
@@ -222,8 +374,16 @@ const getMod = `-- name: GetMod :one
 select mod(1, 2)
 `
 
-func (q *Queries) GetMod(ctx context.Context) (float64, error) {
-	row := q.db.QueryRowContext(ctx, getMod)
+func (q *Queries) GetMod(ctx context.Context, aq ...AdditionalQuery) (float64, error) {
+	query := getMod
+	queryParams := []interface{}{}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	row := q.db.QueryRowContext(ctx, query, queryParams...)
 	var mod float64
 	err := row.Scan(&mod)
 	return mod, err
@@ -233,8 +393,16 @@ const getPi = `-- name: GetPi :one
 select pi()
 `
 
-func (q *Queries) GetPi(ctx context.Context) (float64, error) {
-	row := q.db.QueryRowContext(ctx, getPi)
+func (q *Queries) GetPi(ctx context.Context, aq ...AdditionalQuery) (float64, error) {
+	query := getPi
+	queryParams := []interface{}{}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	row := q.db.QueryRowContext(ctx, query, queryParams...)
 	var pi float64
 	err := row.Scan(&pi)
 	return pi, err
@@ -244,8 +412,16 @@ const getPow = `-- name: GetPow :one
 select pow(1, 2)
 `
 
-func (q *Queries) GetPow(ctx context.Context) (float64, error) {
-	row := q.db.QueryRowContext(ctx, getPow)
+func (q *Queries) GetPow(ctx context.Context, aq ...AdditionalQuery) (float64, error) {
+	query := getPow
+	queryParams := []interface{}{}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	row := q.db.QueryRowContext(ctx, query, queryParams...)
 	var pow float64
 	err := row.Scan(&pow)
 	return pow, err
@@ -255,8 +431,16 @@ const getPower = `-- name: GetPower :one
 select power(1, 2)
 `
 
-func (q *Queries) GetPower(ctx context.Context) (float64, error) {
-	row := q.db.QueryRowContext(ctx, getPower)
+func (q *Queries) GetPower(ctx context.Context, aq ...AdditionalQuery) (float64, error) {
+	query := getPower
+	queryParams := []interface{}{}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	row := q.db.QueryRowContext(ctx, query, queryParams...)
 	var power float64
 	err := row.Scan(&power)
 	return power, err
@@ -266,8 +450,16 @@ const getRadians = `-- name: GetRadians :one
 select radians(1)
 `
 
-func (q *Queries) GetRadians(ctx context.Context) (float64, error) {
-	row := q.db.QueryRowContext(ctx, getRadians)
+func (q *Queries) GetRadians(ctx context.Context, aq ...AdditionalQuery) (float64, error) {
+	query := getRadians
+	queryParams := []interface{}{}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	row := q.db.QueryRowContext(ctx, query, queryParams...)
 	var radians float64
 	err := row.Scan(&radians)
 	return radians, err
@@ -277,8 +469,16 @@ const getSin = `-- name: GetSin :one
 select sin(1.0)
 `
 
-func (q *Queries) GetSin(ctx context.Context) (float64, error) {
-	row := q.db.QueryRowContext(ctx, getSin)
+func (q *Queries) GetSin(ctx context.Context, aq ...AdditionalQuery) (float64, error) {
+	query := getSin
+	queryParams := []interface{}{}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	row := q.db.QueryRowContext(ctx, query, queryParams...)
 	var sin float64
 	err := row.Scan(&sin)
 	return sin, err
@@ -288,8 +488,16 @@ const getSinh = `-- name: GetSinh :one
 select sinh(1.0)
 `
 
-func (q *Queries) GetSinh(ctx context.Context) (float64, error) {
-	row := q.db.QueryRowContext(ctx, getSinh)
+func (q *Queries) GetSinh(ctx context.Context, aq ...AdditionalQuery) (float64, error) {
+	query := getSinh
+	queryParams := []interface{}{}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	row := q.db.QueryRowContext(ctx, query, queryParams...)
 	var sinh float64
 	err := row.Scan(&sinh)
 	return sinh, err
@@ -299,8 +507,16 @@ const getSqrt = `-- name: GetSqrt :one
 select sqrt(1.0)
 `
 
-func (q *Queries) GetSqrt(ctx context.Context) (float64, error) {
-	row := q.db.QueryRowContext(ctx, getSqrt)
+func (q *Queries) GetSqrt(ctx context.Context, aq ...AdditionalQuery) (float64, error) {
+	query := getSqrt
+	queryParams := []interface{}{}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	row := q.db.QueryRowContext(ctx, query, queryParams...)
 	var sqrt float64
 	err := row.Scan(&sqrt)
 	return sqrt, err
@@ -310,8 +526,16 @@ const getTan = `-- name: GetTan :one
 select tan(1.0)
 `
 
-func (q *Queries) GetTan(ctx context.Context) (float64, error) {
-	row := q.db.QueryRowContext(ctx, getTan)
+func (q *Queries) GetTan(ctx context.Context, aq ...AdditionalQuery) (float64, error) {
+	query := getTan
+	queryParams := []interface{}{}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	row := q.db.QueryRowContext(ctx, query, queryParams...)
 	var tan float64
 	err := row.Scan(&tan)
 	return tan, err
@@ -321,8 +545,16 @@ const getTrunc = `-- name: GetTrunc :one
 select trunc(1.0)
 `
 
-func (q *Queries) GetTrunc(ctx context.Context) (int64, error) {
-	row := q.db.QueryRowContext(ctx, getTrunc)
+func (q *Queries) GetTrunc(ctx context.Context, aq ...AdditionalQuery) (int64, error) {
+	query := getTrunc
+	queryParams := []interface{}{}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	row := q.db.QueryRowContext(ctx, query, queryParams...)
 	var trunc int64
 	err := row.Scan(&trunc)
 	return trunc, err

--- a/internal/endtoend/testdata/builtins/sqlite/go/scalarfunc.sql.go
+++ b/internal/endtoend/testdata/builtins/sqlite/go/scalarfunc.sql.go
@@ -14,8 +14,16 @@ const getAbs = `-- name: GetAbs :one
 SELECT abs(int_val) FROM test
 `
 
-func (q *Queries) GetAbs(ctx context.Context) (float64, error) {
-	row := q.db.QueryRowContext(ctx, getAbs)
+func (q *Queries) GetAbs(ctx context.Context, aq ...AdditionalQuery) (float64, error) {
+	query := getAbs
+	queryParams := []interface{}{}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	row := q.db.QueryRowContext(ctx, query, queryParams...)
 	var abs float64
 	err := row.Scan(&abs)
 	return abs, err
@@ -25,8 +33,16 @@ const getChanges = `-- name: GetChanges :one
 SELECT changes()
 `
 
-func (q *Queries) GetChanges(ctx context.Context) (int64, error) {
-	row := q.db.QueryRowContext(ctx, getChanges)
+func (q *Queries) GetChanges(ctx context.Context, aq ...AdditionalQuery) (int64, error) {
+	query := getChanges
+	queryParams := []interface{}{}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	row := q.db.QueryRowContext(ctx, query, queryParams...)
 	var changes int64
 	err := row.Scan(&changes)
 	return changes, err
@@ -36,8 +52,16 @@ const getChar1 = `-- name: GetChar1 :one
 SELECT char(65)
 `
 
-func (q *Queries) GetChar1(ctx context.Context) (string, error) {
-	row := q.db.QueryRowContext(ctx, getChar1)
+func (q *Queries) GetChar1(ctx context.Context, aq ...AdditionalQuery) (string, error) {
+	query := getChar1
+	queryParams := []interface{}{}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	row := q.db.QueryRowContext(ctx, query, queryParams...)
 	var char string
 	err := row.Scan(&char)
 	return char, err
@@ -47,8 +71,16 @@ const getChar3 = `-- name: GetChar3 :one
 SELECT char(65, 66, 67)
 `
 
-func (q *Queries) GetChar3(ctx context.Context) (string, error) {
-	row := q.db.QueryRowContext(ctx, getChar3)
+func (q *Queries) GetChar3(ctx context.Context, aq ...AdditionalQuery) (string, error) {
+	query := getChar3
+	queryParams := []interface{}{}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	row := q.db.QueryRowContext(ctx, query, queryParams...)
 	var char string
 	err := row.Scan(&char)
 	return char, err
@@ -58,8 +90,16 @@ const getCoalesce = `-- name: GetCoalesce :one
 SELECT coalesce(NULL, 1, 'test')
 `
 
-func (q *Queries) GetCoalesce(ctx context.Context) (interface{}, error) {
-	row := q.db.QueryRowContext(ctx, getCoalesce)
+func (q *Queries) GetCoalesce(ctx context.Context, aq ...AdditionalQuery) (interface{}, error) {
+	query := getCoalesce
+	queryParams := []interface{}{}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	row := q.db.QueryRowContext(ctx, query, queryParams...)
 	var coalesce interface{}
 	err := row.Scan(&coalesce)
 	return coalesce, err
@@ -69,8 +109,16 @@ const getFormat = `-- name: GetFormat :one
 SELECT format('Hello %s', 'world')
 `
 
-func (q *Queries) GetFormat(ctx context.Context) (sql.NullString, error) {
-	row := q.db.QueryRowContext(ctx, getFormat)
+func (q *Queries) GetFormat(ctx context.Context, aq ...AdditionalQuery) (sql.NullString, error) {
+	query := getFormat
+	queryParams := []interface{}{}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	row := q.db.QueryRowContext(ctx, query, queryParams...)
 	var format sql.NullString
 	err := row.Scan(&format)
 	return format, err
@@ -80,8 +128,16 @@ const getGlob = `-- name: GetGlob :one
 SELECT glob('a*c', 'abc')
 `
 
-func (q *Queries) GetGlob(ctx context.Context) (int64, error) {
-	row := q.db.QueryRowContext(ctx, getGlob)
+func (q *Queries) GetGlob(ctx context.Context, aq ...AdditionalQuery) (int64, error) {
+	query := getGlob
+	queryParams := []interface{}{}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	row := q.db.QueryRowContext(ctx, query, queryParams...)
 	var glob int64
 	err := row.Scan(&glob)
 	return glob, err
@@ -91,8 +147,16 @@ const getHex = `-- name: GetHex :one
 SELECT hex(123456)
 `
 
-func (q *Queries) GetHex(ctx context.Context) (string, error) {
-	row := q.db.QueryRowContext(ctx, getHex)
+func (q *Queries) GetHex(ctx context.Context, aq ...AdditionalQuery) (string, error) {
+	query := getHex
+	queryParams := []interface{}{}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	row := q.db.QueryRowContext(ctx, query, queryParams...)
 	var hex string
 	err := row.Scan(&hex)
 	return hex, err
@@ -102,8 +166,16 @@ const getIfnull = `-- name: GetIfnull :one
 SELECT ifnull(1, 2)
 `
 
-func (q *Queries) GetIfnull(ctx context.Context) (interface{}, error) {
-	row := q.db.QueryRowContext(ctx, getIfnull)
+func (q *Queries) GetIfnull(ctx context.Context, aq ...AdditionalQuery) (interface{}, error) {
+	query := getIfnull
+	queryParams := []interface{}{}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	row := q.db.QueryRowContext(ctx, query, queryParams...)
 	var ifnull interface{}
 	err := row.Scan(&ifnull)
 	return ifnull, err
@@ -113,8 +185,16 @@ const getIif = `-- name: GetIif :one
 SELECT iif(1, 2, 3)
 `
 
-func (q *Queries) GetIif(ctx context.Context) (interface{}, error) {
-	row := q.db.QueryRowContext(ctx, getIif)
+func (q *Queries) GetIif(ctx context.Context, aq ...AdditionalQuery) (interface{}, error) {
+	query := getIif
+	queryParams := []interface{}{}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	row := q.db.QueryRowContext(ctx, query, queryParams...)
 	var iif interface{}
 	err := row.Scan(&iif)
 	return iif, err
@@ -124,8 +204,16 @@ const getInstr = `-- name: GetInstr :one
 SELECT instr('hello', 'l')
 `
 
-func (q *Queries) GetInstr(ctx context.Context) (sql.NullInt64, error) {
-	row := q.db.QueryRowContext(ctx, getInstr)
+func (q *Queries) GetInstr(ctx context.Context, aq ...AdditionalQuery) (sql.NullInt64, error) {
+	query := getInstr
+	queryParams := []interface{}{}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	row := q.db.QueryRowContext(ctx, query, queryParams...)
 	var instr sql.NullInt64
 	err := row.Scan(&instr)
 	return instr, err
@@ -135,8 +223,16 @@ const getLastInsertRowID = `-- name: GetLastInsertRowID :one
 SELECT last_insert_rowid()
 `
 
-func (q *Queries) GetLastInsertRowID(ctx context.Context) (int64, error) {
-	row := q.db.QueryRowContext(ctx, getLastInsertRowID)
+func (q *Queries) GetLastInsertRowID(ctx context.Context, aq ...AdditionalQuery) (int64, error) {
+	query := getLastInsertRowID
+	queryParams := []interface{}{}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	row := q.db.QueryRowContext(ctx, query, queryParams...)
 	var last_insert_rowid int64
 	err := row.Scan(&last_insert_rowid)
 	return last_insert_rowid, err
@@ -146,8 +242,16 @@ const getLength = `-- name: GetLength :one
 SELECT length('12345')
 `
 
-func (q *Queries) GetLength(ctx context.Context) (sql.NullInt64, error) {
-	row := q.db.QueryRowContext(ctx, getLength)
+func (q *Queries) GetLength(ctx context.Context, aq ...AdditionalQuery) (sql.NullInt64, error) {
+	query := getLength
+	queryParams := []interface{}{}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	row := q.db.QueryRowContext(ctx, query, queryParams...)
 	var length sql.NullInt64
 	err := row.Scan(&length)
 	return length, err
@@ -157,8 +261,16 @@ const getLike2 = `-- name: GetLike2 :one
 SELECT like('%bc%', 'abcd')
 `
 
-func (q *Queries) GetLike2(ctx context.Context) (int64, error) {
-	row := q.db.QueryRowContext(ctx, getLike2)
+func (q *Queries) GetLike2(ctx context.Context, aq ...AdditionalQuery) (int64, error) {
+	query := getLike2
+	queryParams := []interface{}{}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	row := q.db.QueryRowContext(ctx, query, queryParams...)
 	var like int64
 	err := row.Scan(&like)
 	return like, err
@@ -168,8 +280,16 @@ const getLike3 = `-- name: GetLike3 :one
 SELECT like('$%1%', '%100', '$')
 `
 
-func (q *Queries) GetLike3(ctx context.Context) (int64, error) {
-	row := q.db.QueryRowContext(ctx, getLike3)
+func (q *Queries) GetLike3(ctx context.Context, aq ...AdditionalQuery) (int64, error) {
+	query := getLike3
+	queryParams := []interface{}{}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	row := q.db.QueryRowContext(ctx, query, queryParams...)
 	var like int64
 	err := row.Scan(&like)
 	return like, err
@@ -179,8 +299,16 @@ const getLikelihood = `-- name: GetLikelihood :one
 SELECT likelihood('12345', 0.5)
 `
 
-func (q *Queries) GetLikelihood(ctx context.Context) (interface{}, error) {
-	row := q.db.QueryRowContext(ctx, getLikelihood)
+func (q *Queries) GetLikelihood(ctx context.Context, aq ...AdditionalQuery) (interface{}, error) {
+	query := getLikelihood
+	queryParams := []interface{}{}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	row := q.db.QueryRowContext(ctx, query, queryParams...)
 	var likelihood interface{}
 	err := row.Scan(&likelihood)
 	return likelihood, err
@@ -190,8 +318,16 @@ const getLikely = `-- name: GetLikely :one
 SELECT likely('12345')
 `
 
-func (q *Queries) GetLikely(ctx context.Context) (interface{}, error) {
-	row := q.db.QueryRowContext(ctx, getLikely)
+func (q *Queries) GetLikely(ctx context.Context, aq ...AdditionalQuery) (interface{}, error) {
+	query := getLikely
+	queryParams := []interface{}{}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	row := q.db.QueryRowContext(ctx, query, queryParams...)
 	var likely interface{}
 	err := row.Scan(&likely)
 	return likely, err
@@ -201,8 +337,16 @@ const getLower = `-- name: GetLower :one
 SELECT lower('ABCDE')
 `
 
-func (q *Queries) GetLower(ctx context.Context) (string, error) {
-	row := q.db.QueryRowContext(ctx, getLower)
+func (q *Queries) GetLower(ctx context.Context, aq ...AdditionalQuery) (string, error) {
+	query := getLower
+	queryParams := []interface{}{}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	row := q.db.QueryRowContext(ctx, query, queryParams...)
 	var lower string
 	err := row.Scan(&lower)
 	return lower, err
@@ -212,8 +356,16 @@ const getLtrim = `-- name: GetLtrim :one
 SELECT ltrim(' ABCDE')
 `
 
-func (q *Queries) GetLtrim(ctx context.Context) (string, error) {
-	row := q.db.QueryRowContext(ctx, getLtrim)
+func (q *Queries) GetLtrim(ctx context.Context, aq ...AdditionalQuery) (string, error) {
+	query := getLtrim
+	queryParams := []interface{}{}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	row := q.db.QueryRowContext(ctx, query, queryParams...)
 	var ltrim string
 	err := row.Scan(&ltrim)
 	return ltrim, err
@@ -223,8 +375,16 @@ const getLtrim2 = `-- name: GetLtrim2 :one
 SELECT ltrim(':ABCDE', ':')
 `
 
-func (q *Queries) GetLtrim2(ctx context.Context) (string, error) {
-	row := q.db.QueryRowContext(ctx, getLtrim2)
+func (q *Queries) GetLtrim2(ctx context.Context, aq ...AdditionalQuery) (string, error) {
+	query := getLtrim2
+	queryParams := []interface{}{}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	row := q.db.QueryRowContext(ctx, query, queryParams...)
 	var ltrim string
 	err := row.Scan(&ltrim)
 	return ltrim, err
@@ -234,8 +394,16 @@ const getMax3 = `-- name: GetMax3 :one
 SELECT max(1, 3, 2)
 `
 
-func (q *Queries) GetMax3(ctx context.Context) (interface{}, error) {
-	row := q.db.QueryRowContext(ctx, getMax3)
+func (q *Queries) GetMax3(ctx context.Context, aq ...AdditionalQuery) (interface{}, error) {
+	query := getMax3
+	queryParams := []interface{}{}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	row := q.db.QueryRowContext(ctx, query, queryParams...)
 	var max interface{}
 	err := row.Scan(&max)
 	return max, err
@@ -245,8 +413,16 @@ const getMin3 = `-- name: GetMin3 :one
 SELECT min(1, 3, 2)
 `
 
-func (q *Queries) GetMin3(ctx context.Context) (interface{}, error) {
-	row := q.db.QueryRowContext(ctx, getMin3)
+func (q *Queries) GetMin3(ctx context.Context, aq ...AdditionalQuery) (interface{}, error) {
+	query := getMin3
+	queryParams := []interface{}{}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	row := q.db.QueryRowContext(ctx, query, queryParams...)
 	var min interface{}
 	err := row.Scan(&min)
 	return min, err
@@ -256,8 +432,16 @@ const getNullif = `-- name: GetNullif :one
 SELECT nullif(1, 2)
 `
 
-func (q *Queries) GetNullif(ctx context.Context) (interface{}, error) {
-	row := q.db.QueryRowContext(ctx, getNullif)
+func (q *Queries) GetNullif(ctx context.Context, aq ...AdditionalQuery) (interface{}, error) {
+	query := getNullif
+	queryParams := []interface{}{}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	row := q.db.QueryRowContext(ctx, query, queryParams...)
 	var nullif interface{}
 	err := row.Scan(&nullif)
 	return nullif, err
@@ -267,8 +451,16 @@ const getPrintf = `-- name: GetPrintf :one
 SELECT printf('Hello %s', 'world')
 `
 
-func (q *Queries) GetPrintf(ctx context.Context) (sql.NullString, error) {
-	row := q.db.QueryRowContext(ctx, getPrintf)
+func (q *Queries) GetPrintf(ctx context.Context, aq ...AdditionalQuery) (sql.NullString, error) {
+	query := getPrintf
+	queryParams := []interface{}{}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	row := q.db.QueryRowContext(ctx, query, queryParams...)
 	var printf sql.NullString
 	err := row.Scan(&printf)
 	return printf, err
@@ -278,8 +470,16 @@ const getQuote = `-- name: GetQuote :one
 SELECT quote(1)
 `
 
-func (q *Queries) GetQuote(ctx context.Context) (string, error) {
-	row := q.db.QueryRowContext(ctx, getQuote)
+func (q *Queries) GetQuote(ctx context.Context, aq ...AdditionalQuery) (string, error) {
+	query := getQuote
+	queryParams := []interface{}{}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	row := q.db.QueryRowContext(ctx, query, queryParams...)
 	var quote string
 	err := row.Scan(&quote)
 	return quote, err
@@ -289,8 +489,16 @@ const getRandom = `-- name: GetRandom :one
 SELECT random()
 `
 
-func (q *Queries) GetRandom(ctx context.Context) (interface{}, error) {
-	row := q.db.QueryRowContext(ctx, getRandom)
+func (q *Queries) GetRandom(ctx context.Context, aq ...AdditionalQuery) (interface{}, error) {
+	query := getRandom
+	queryParams := []interface{}{}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	row := q.db.QueryRowContext(ctx, query, queryParams...)
 	var random interface{}
 	err := row.Scan(&random)
 	return random, err
@@ -300,8 +508,16 @@ const getRandomBlob = `-- name: GetRandomBlob :one
 SELECT randomblob(16)
 `
 
-func (q *Queries) GetRandomBlob(ctx context.Context) (interface{}, error) {
-	row := q.db.QueryRowContext(ctx, getRandomBlob)
+func (q *Queries) GetRandomBlob(ctx context.Context, aq ...AdditionalQuery) (interface{}, error) {
+	query := getRandomBlob
+	queryParams := []interface{}{}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	row := q.db.QueryRowContext(ctx, query, queryParams...)
 	var randomblob interface{}
 	err := row.Scan(&randomblob)
 	return randomblob, err
@@ -311,8 +527,16 @@ const getReplace = `-- name: GetReplace :one
 SELECT replace('abc', 'bc', 'df')
 `
 
-func (q *Queries) GetReplace(ctx context.Context) (string, error) {
-	row := q.db.QueryRowContext(ctx, getReplace)
+func (q *Queries) GetReplace(ctx context.Context, aq ...AdditionalQuery) (string, error) {
+	query := getReplace
+	queryParams := []interface{}{}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	row := q.db.QueryRowContext(ctx, query, queryParams...)
 	var replace string
 	err := row.Scan(&replace)
 	return replace, err
@@ -322,8 +546,16 @@ const getRound = `-- name: GetRound :one
 SELECT round(1.1)
 `
 
-func (q *Queries) GetRound(ctx context.Context) (float64, error) {
-	row := q.db.QueryRowContext(ctx, getRound)
+func (q *Queries) GetRound(ctx context.Context, aq ...AdditionalQuery) (float64, error) {
+	query := getRound
+	queryParams := []interface{}{}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	row := q.db.QueryRowContext(ctx, query, queryParams...)
 	var round float64
 	err := row.Scan(&round)
 	return round, err
@@ -333,8 +565,16 @@ const getRound2 = `-- name: GetRound2 :one
 SELECT round(1.1, 2)
 `
 
-func (q *Queries) GetRound2(ctx context.Context) (float64, error) {
-	row := q.db.QueryRowContext(ctx, getRound2)
+func (q *Queries) GetRound2(ctx context.Context, aq ...AdditionalQuery) (float64, error) {
+	query := getRound2
+	queryParams := []interface{}{}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	row := q.db.QueryRowContext(ctx, query, queryParams...)
 	var round float64
 	err := row.Scan(&round)
 	return round, err
@@ -344,8 +584,16 @@ const getRtrim = `-- name: GetRtrim :one
 SELECT rtrim('ABCDE ')
 `
 
-func (q *Queries) GetRtrim(ctx context.Context) (string, error) {
-	row := q.db.QueryRowContext(ctx, getRtrim)
+func (q *Queries) GetRtrim(ctx context.Context, aq ...AdditionalQuery) (string, error) {
+	query := getRtrim
+	queryParams := []interface{}{}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	row := q.db.QueryRowContext(ctx, query, queryParams...)
 	var rtrim string
 	err := row.Scan(&rtrim)
 	return rtrim, err
@@ -355,8 +603,16 @@ const getRtrim2 = `-- name: GetRtrim2 :one
 SELECT rtrim('ABCDE:', ':')
 `
 
-func (q *Queries) GetRtrim2(ctx context.Context) (string, error) {
-	row := q.db.QueryRowContext(ctx, getRtrim2)
+func (q *Queries) GetRtrim2(ctx context.Context, aq ...AdditionalQuery) (string, error) {
+	query := getRtrim2
+	queryParams := []interface{}{}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	row := q.db.QueryRowContext(ctx, query, queryParams...)
 	var rtrim string
 	err := row.Scan(&rtrim)
 	return rtrim, err
@@ -366,8 +622,16 @@ const getSQLiteCompileOptionGet = `-- name: GetSQLiteCompileOptionGet :one
 SELECT sqlite_compileoption_get(1)
 `
 
-func (q *Queries) GetSQLiteCompileOptionGet(ctx context.Context) (sql.NullString, error) {
-	row := q.db.QueryRowContext(ctx, getSQLiteCompileOptionGet)
+func (q *Queries) GetSQLiteCompileOptionGet(ctx context.Context, aq ...AdditionalQuery) (sql.NullString, error) {
+	query := getSQLiteCompileOptionGet
+	queryParams := []interface{}{}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	row := q.db.QueryRowContext(ctx, query, queryParams...)
 	var sqlite_compileoption_get sql.NullString
 	err := row.Scan(&sqlite_compileoption_get)
 	return sqlite_compileoption_get, err
@@ -377,8 +641,16 @@ const getSQLiteCompileOptionUsed = `-- name: GetSQLiteCompileOptionUsed :one
 SELECT sqlite_compileoption_used(1)
 `
 
-func (q *Queries) GetSQLiteCompileOptionUsed(ctx context.Context) (int64, error) {
-	row := q.db.QueryRowContext(ctx, getSQLiteCompileOptionUsed)
+func (q *Queries) GetSQLiteCompileOptionUsed(ctx context.Context, aq ...AdditionalQuery) (int64, error) {
+	query := getSQLiteCompileOptionUsed
+	queryParams := []interface{}{}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	row := q.db.QueryRowContext(ctx, query, queryParams...)
 	var sqlite_compileoption_used int64
 	err := row.Scan(&sqlite_compileoption_used)
 	return sqlite_compileoption_used, err
@@ -388,8 +660,16 @@ const getSQLiteOffset = `-- name: GetSQLiteOffset :one
 SELECT sqlite_offset(1)
 `
 
-func (q *Queries) GetSQLiteOffset(ctx context.Context) (sql.NullInt64, error) {
-	row := q.db.QueryRowContext(ctx, getSQLiteOffset)
+func (q *Queries) GetSQLiteOffset(ctx context.Context, aq ...AdditionalQuery) (sql.NullInt64, error) {
+	query := getSQLiteOffset
+	queryParams := []interface{}{}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	row := q.db.QueryRowContext(ctx, query, queryParams...)
 	var sqlite_offset sql.NullInt64
 	err := row.Scan(&sqlite_offset)
 	return sqlite_offset, err
@@ -399,8 +679,16 @@ const getSQLiteSourceID = `-- name: GetSQLiteSourceID :one
 SELECT sqlite_source_id()
 `
 
-func (q *Queries) GetSQLiteSourceID(ctx context.Context) (string, error) {
-	row := q.db.QueryRowContext(ctx, getSQLiteSourceID)
+func (q *Queries) GetSQLiteSourceID(ctx context.Context, aq ...AdditionalQuery) (string, error) {
+	query := getSQLiteSourceID
+	queryParams := []interface{}{}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	row := q.db.QueryRowContext(ctx, query, queryParams...)
 	var sqlite_source_id string
 	err := row.Scan(&sqlite_source_id)
 	return sqlite_source_id, err
@@ -410,8 +698,16 @@ const getSQLiteVersion = `-- name: GetSQLiteVersion :one
 SELECT sqlite_version()
 `
 
-func (q *Queries) GetSQLiteVersion(ctx context.Context) (string, error) {
-	row := q.db.QueryRowContext(ctx, getSQLiteVersion)
+func (q *Queries) GetSQLiteVersion(ctx context.Context, aq ...AdditionalQuery) (string, error) {
+	query := getSQLiteVersion
+	queryParams := []interface{}{}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	row := q.db.QueryRowContext(ctx, query, queryParams...)
 	var sqlite_version string
 	err := row.Scan(&sqlite_version)
 	return sqlite_version, err
@@ -421,8 +717,16 @@ const getSign = `-- name: GetSign :one
 SELECT sign(1)
 `
 
-func (q *Queries) GetSign(ctx context.Context) (sql.NullInt64, error) {
-	row := q.db.QueryRowContext(ctx, getSign)
+func (q *Queries) GetSign(ctx context.Context, aq ...AdditionalQuery) (sql.NullInt64, error) {
+	query := getSign
+	queryParams := []interface{}{}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	row := q.db.QueryRowContext(ctx, query, queryParams...)
 	var sign sql.NullInt64
 	err := row.Scan(&sign)
 	return sign, err
@@ -432,8 +736,16 @@ const getSoundex = `-- name: GetSoundex :one
 SELECT soundex('abc')
 `
 
-func (q *Queries) GetSoundex(ctx context.Context) (string, error) {
-	row := q.db.QueryRowContext(ctx, getSoundex)
+func (q *Queries) GetSoundex(ctx context.Context, aq ...AdditionalQuery) (string, error) {
+	query := getSoundex
+	queryParams := []interface{}{}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	row := q.db.QueryRowContext(ctx, query, queryParams...)
 	var soundex string
 	err := row.Scan(&soundex)
 	return soundex, err
@@ -443,8 +755,16 @@ const getSubstr2 = `-- name: GetSubstr2 :one
 SELECT substr('abcdef', 2)
 `
 
-func (q *Queries) GetSubstr2(ctx context.Context) (string, error) {
-	row := q.db.QueryRowContext(ctx, getSubstr2)
+func (q *Queries) GetSubstr2(ctx context.Context, aq ...AdditionalQuery) (string, error) {
+	query := getSubstr2
+	queryParams := []interface{}{}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	row := q.db.QueryRowContext(ctx, query, queryParams...)
 	var substr string
 	err := row.Scan(&substr)
 	return substr, err
@@ -454,8 +774,16 @@ const getSubstr3 = `-- name: GetSubstr3 :one
 SELECT substr('abcdef', 1, 2)
 `
 
-func (q *Queries) GetSubstr3(ctx context.Context) (string, error) {
-	row := q.db.QueryRowContext(ctx, getSubstr3)
+func (q *Queries) GetSubstr3(ctx context.Context, aq ...AdditionalQuery) (string, error) {
+	query := getSubstr3
+	queryParams := []interface{}{}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	row := q.db.QueryRowContext(ctx, query, queryParams...)
 	var substr string
 	err := row.Scan(&substr)
 	return substr, err
@@ -465,8 +793,16 @@ const getSubstring2 = `-- name: GetSubstring2 :one
 SELECT substring('abcdef', 1)
 `
 
-func (q *Queries) GetSubstring2(ctx context.Context) (string, error) {
-	row := q.db.QueryRowContext(ctx, getSubstring2)
+func (q *Queries) GetSubstring2(ctx context.Context, aq ...AdditionalQuery) (string, error) {
+	query := getSubstring2
+	queryParams := []interface{}{}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	row := q.db.QueryRowContext(ctx, query, queryParams...)
 	var substring string
 	err := row.Scan(&substring)
 	return substring, err
@@ -476,8 +812,16 @@ const getSusbstring3 = `-- name: GetSusbstring3 :one
 SELECT substring('abcdef', 1, 2)
 `
 
-func (q *Queries) GetSusbstring3(ctx context.Context) (string, error) {
-	row := q.db.QueryRowContext(ctx, getSusbstring3)
+func (q *Queries) GetSusbstring3(ctx context.Context, aq ...AdditionalQuery) (string, error) {
+	query := getSusbstring3
+	queryParams := []interface{}{}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	row := q.db.QueryRowContext(ctx, query, queryParams...)
 	var substring string
 	err := row.Scan(&substring)
 	return substring, err
@@ -487,8 +831,16 @@ const getTotalChanges = `-- name: GetTotalChanges :one
 SELECT total_changes()
 `
 
-func (q *Queries) GetTotalChanges(ctx context.Context) (int64, error) {
-	row := q.db.QueryRowContext(ctx, getTotalChanges)
+func (q *Queries) GetTotalChanges(ctx context.Context, aq ...AdditionalQuery) (int64, error) {
+	query := getTotalChanges
+	queryParams := []interface{}{}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	row := q.db.QueryRowContext(ctx, query, queryParams...)
 	var total_changes int64
 	err := row.Scan(&total_changes)
 	return total_changes, err
@@ -498,8 +850,16 @@ const getTrim = `-- name: GetTrim :one
 SELECT trim(' ABCDE ')
 `
 
-func (q *Queries) GetTrim(ctx context.Context) (string, error) {
-	row := q.db.QueryRowContext(ctx, getTrim)
+func (q *Queries) GetTrim(ctx context.Context, aq ...AdditionalQuery) (string, error) {
+	query := getTrim
+	queryParams := []interface{}{}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	row := q.db.QueryRowContext(ctx, query, queryParams...)
 	var trim string
 	err := row.Scan(&trim)
 	return trim, err
@@ -509,8 +869,16 @@ const getTrim2 = `-- name: GetTrim2 :one
 SELECT trim(':ABCDE:', ':')
 `
 
-func (q *Queries) GetTrim2(ctx context.Context) (string, error) {
-	row := q.db.QueryRowContext(ctx, getTrim2)
+func (q *Queries) GetTrim2(ctx context.Context, aq ...AdditionalQuery) (string, error) {
+	query := getTrim2
+	queryParams := []interface{}{}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	row := q.db.QueryRowContext(ctx, query, queryParams...)
 	var trim string
 	err := row.Scan(&trim)
 	return trim, err
@@ -520,8 +888,16 @@ const getTypeof = `-- name: GetTypeof :one
 SELECT typeof('ABCDE')
 `
 
-func (q *Queries) GetTypeof(ctx context.Context) (string, error) {
-	row := q.db.QueryRowContext(ctx, getTypeof)
+func (q *Queries) GetTypeof(ctx context.Context, aq ...AdditionalQuery) (string, error) {
+	query := getTypeof
+	queryParams := []interface{}{}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	row := q.db.QueryRowContext(ctx, query, queryParams...)
 	var typeof string
 	err := row.Scan(&typeof)
 	return typeof, err
@@ -531,8 +907,16 @@ const getUnicode = `-- name: GetUnicode :one
 SELECT unicode('A')
 `
 
-func (q *Queries) GetUnicode(ctx context.Context) (int64, error) {
-	row := q.db.QueryRowContext(ctx, getUnicode)
+func (q *Queries) GetUnicode(ctx context.Context, aq ...AdditionalQuery) (int64, error) {
+	query := getUnicode
+	queryParams := []interface{}{}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	row := q.db.QueryRowContext(ctx, query, queryParams...)
 	var unicode int64
 	err := row.Scan(&unicode)
 	return unicode, err
@@ -542,8 +926,16 @@ const getUnlikely = `-- name: GetUnlikely :one
 SELECT unlikely('12345')
 `
 
-func (q *Queries) GetUnlikely(ctx context.Context) (interface{}, error) {
-	row := q.db.QueryRowContext(ctx, getUnlikely)
+func (q *Queries) GetUnlikely(ctx context.Context, aq ...AdditionalQuery) (interface{}, error) {
+	query := getUnlikely
+	queryParams := []interface{}{}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	row := q.db.QueryRowContext(ctx, query, queryParams...)
 	var unlikely interface{}
 	err := row.Scan(&unlikely)
 	return unlikely, err
@@ -553,8 +945,16 @@ const getUpper = `-- name: GetUpper :one
 SELECT upper('abcde')
 `
 
-func (q *Queries) GetUpper(ctx context.Context) (string, error) {
-	row := q.db.QueryRowContext(ctx, getUpper)
+func (q *Queries) GetUpper(ctx context.Context, aq ...AdditionalQuery) (string, error) {
+	query := getUpper
+	queryParams := []interface{}{}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	row := q.db.QueryRowContext(ctx, query, queryParams...)
 	var upper string
 	err := row.Scan(&upper)
 	return upper, err
@@ -564,8 +964,16 @@ const getZeroblob = `-- name: GetZeroblob :one
 SELECT zeroblob(16)
 `
 
-func (q *Queries) GetZeroblob(ctx context.Context) ([]byte, error) {
-	row := q.db.QueryRowContext(ctx, getZeroblob)
+func (q *Queries) GetZeroblob(ctx context.Context, aq ...AdditionalQuery) ([]byte, error) {
+	query := getZeroblob
+	queryParams := []interface{}{}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	row := q.db.QueryRowContext(ctx, query, queryParams...)
 	var zeroblob []byte
 	err := row.Scan(&zeroblob)
 	return zeroblob, err

--- a/internal/endtoend/testdata/case_named_params/mysql/go/db.go
+++ b/internal/endtoend/testdata/case_named_params/mysql/go/db.go
@@ -29,3 +29,8 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/case_named_params/mysql/go/db.go
+++ b/internal/endtoend/testdata/case_named_params/mysql/go/db.go
@@ -32,5 +32,5 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/case_named_params/mysql/go/query.sql.go
+++ b/internal/endtoend/testdata/case_named_params/mysql/go/query.sql.go
@@ -23,13 +23,21 @@ type ListAuthorsParams struct {
 	Username sql.NullString
 }
 
-func (q *Queries) ListAuthors(ctx context.Context, arg ListAuthorsParams) (Author, error) {
-	row := q.db.QueryRowContext(ctx, listAuthors,
+func (q *Queries) ListAuthors(ctx context.Context, arg ListAuthorsParams, aq ...AdditionalQuery) (Author, error) {
+	query := listAuthors
+	queryParams := []interface{}{
 		arg.Email,
 		arg.Email,
 		arg.Username,
 		arg.Username,
-	)
+	}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	row := q.db.QueryRowContext(ctx, query, queryParams...)
 	var i Author
 	err := row.Scan(
 		&i.ID,

--- a/internal/endtoend/testdata/case_named_params/postgresql/go/db.go
+++ b/internal/endtoend/testdata/case_named_params/postgresql/go/db.go
@@ -29,3 +29,8 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/case_named_params/postgresql/go/db.go
+++ b/internal/endtoend/testdata/case_named_params/postgresql/go/db.go
@@ -32,5 +32,5 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/case_named_params/postgresql/go/query.sql.go
+++ b/internal/endtoend/testdata/case_named_params/postgresql/go/query.sql.go
@@ -22,8 +22,16 @@ type ListAuthorsParams struct {
 	Username string
 }
 
-func (q *Queries) ListAuthors(ctx context.Context, arg ListAuthorsParams) (Author, error) {
-	row := q.db.QueryRowContext(ctx, listAuthors, arg.Email, arg.Username)
+func (q *Queries) ListAuthors(ctx context.Context, arg ListAuthorsParams, aq ...AdditionalQuery) (Author, error) {
+	query := listAuthors
+	queryParams := []interface{}{arg.Email, arg.Username}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	row := q.db.QueryRowContext(ctx, query, queryParams...)
 	var i Author
 	err := row.Scan(
 		&i.ID,

--- a/internal/endtoend/testdata/case_sensitive/sqlite/go/db.go
+++ b/internal/endtoend/testdata/case_sensitive/sqlite/go/db.go
@@ -29,3 +29,8 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/case_sensitive/sqlite/go/db.go
+++ b/internal/endtoend/testdata/case_sensitive/sqlite/go/db.go
@@ -32,5 +32,5 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/case_sensitive/sqlite/go/query.sql.go
+++ b/internal/endtoend/testdata/case_sensitive/sqlite/go/query.sql.go
@@ -24,6 +24,9 @@ type InsertContactParams struct {
 }
 
 func (q *Queries) InsertContact(ctx context.Context, arg InsertContactParams) error {
-	_, err := q.db.ExecContext(ctx, insertContact, arg.Pid, arg.Customername)
+	query := insertContact
+	queryParams := []interface{}{arg.Pid, arg.Customername}
+
+	_, err := q.db.ExecContext(ctx, query, queryParams...)
 	return err
 }

--- a/internal/endtoend/testdata/case_stmt_bool/pgx/v4/go/db.go
+++ b/internal/endtoend/testdata/case_stmt_bool/pgx/v4/go/db.go
@@ -33,5 +33,5 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/case_stmt_bool/pgx/v4/go/db.go
+++ b/internal/endtoend/testdata/case_stmt_bool/pgx/v4/go/db.go
@@ -30,3 +30,8 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/case_stmt_bool/pgx/v4/go/query.sql.go
+++ b/internal/endtoend/testdata/case_stmt_bool/pgx/v4/go/query.sql.go
@@ -17,8 +17,16 @@ END is_one
 FROM foo
 `
 
-func (q *Queries) CaseStatementBoolean(ctx context.Context, id string) ([]bool, error) {
-	rows, err := q.db.Query(ctx, caseStatementBoolean, id)
+func (q *Queries) CaseStatementBoolean(ctx context.Context, id string, aq ...AdditionalQuery) ([]bool, error) {
+	query := caseStatementBoolean
+	queryParams := []interface{}{id}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.Query(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/endtoend/testdata/case_stmt_bool/pgx/v5/go/db.go
+++ b/internal/endtoend/testdata/case_stmt_bool/pgx/v5/go/db.go
@@ -33,5 +33,5 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/case_stmt_bool/pgx/v5/go/db.go
+++ b/internal/endtoend/testdata/case_stmt_bool/pgx/v5/go/db.go
@@ -30,3 +30,8 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/case_stmt_bool/pgx/v5/go/query.sql.go
+++ b/internal/endtoend/testdata/case_stmt_bool/pgx/v5/go/query.sql.go
@@ -17,8 +17,16 @@ END is_one
 FROM foo
 `
 
-func (q *Queries) CaseStatementBoolean(ctx context.Context, id string) ([]bool, error) {
-	rows, err := q.db.Query(ctx, caseStatementBoolean, id)
+func (q *Queries) CaseStatementBoolean(ctx context.Context, id string, aq ...AdditionalQuery) ([]bool, error) {
+	query := caseStatementBoolean
+	queryParams := []interface{}{id}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.Query(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/endtoend/testdata/case_stmt_bool/stdlib/go/db.go
+++ b/internal/endtoend/testdata/case_stmt_bool/stdlib/go/db.go
@@ -29,3 +29,8 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/case_stmt_bool/stdlib/go/db.go
+++ b/internal/endtoend/testdata/case_stmt_bool/stdlib/go/db.go
@@ -32,5 +32,5 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/case_stmt_bool/stdlib/go/query.sql.go
+++ b/internal/endtoend/testdata/case_stmt_bool/stdlib/go/query.sql.go
@@ -17,8 +17,16 @@ END is_one
 FROM foo
 `
 
-func (q *Queries) CaseStatementBoolean(ctx context.Context, id string) ([]bool, error) {
-	rows, err := q.db.QueryContext(ctx, caseStatementBoolean, id)
+func (q *Queries) CaseStatementBoolean(ctx context.Context, id string, aq ...AdditionalQuery) ([]bool, error) {
+	query := caseStatementBoolean
+	queryParams := []interface{}{id}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.QueryContext(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/endtoend/testdata/case_text/pgx/v4/go/db.go
+++ b/internal/endtoend/testdata/case_text/pgx/v4/go/db.go
@@ -33,5 +33,5 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/case_text/pgx/v4/go/db.go
+++ b/internal/endtoend/testdata/case_text/pgx/v4/go/db.go
@@ -30,3 +30,8 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/case_text/pgx/v4/go/query.sql.go
+++ b/internal/endtoend/testdata/case_text/pgx/v4/go/query.sql.go
@@ -17,8 +17,16 @@ END is_one
 FROM foo
 `
 
-func (q *Queries) CaseStatementText(ctx context.Context, id string) ([]string, error) {
-	rows, err := q.db.Query(ctx, caseStatementText, id)
+func (q *Queries) CaseStatementText(ctx context.Context, id string, aq ...AdditionalQuery) ([]string, error) {
+	query := caseStatementText
+	queryParams := []interface{}{id}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.Query(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/endtoend/testdata/case_text/pgx/v5/go/db.go
+++ b/internal/endtoend/testdata/case_text/pgx/v5/go/db.go
@@ -33,5 +33,5 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/case_text/pgx/v5/go/db.go
+++ b/internal/endtoend/testdata/case_text/pgx/v5/go/db.go
@@ -30,3 +30,8 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/case_text/pgx/v5/go/query.sql.go
+++ b/internal/endtoend/testdata/case_text/pgx/v5/go/query.sql.go
@@ -17,8 +17,16 @@ END is_one
 FROM foo
 `
 
-func (q *Queries) CaseStatementText(ctx context.Context, id string) ([]string, error) {
-	rows, err := q.db.Query(ctx, caseStatementText, id)
+func (q *Queries) CaseStatementText(ctx context.Context, id string, aq ...AdditionalQuery) ([]string, error) {
+	query := caseStatementText
+	queryParams := []interface{}{id}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.Query(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/endtoend/testdata/case_text/stdlib/go/db.go
+++ b/internal/endtoend/testdata/case_text/stdlib/go/db.go
@@ -29,3 +29,8 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/case_text/stdlib/go/db.go
+++ b/internal/endtoend/testdata/case_text/stdlib/go/db.go
@@ -32,5 +32,5 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/case_text/stdlib/go/query.sql.go
+++ b/internal/endtoend/testdata/case_text/stdlib/go/query.sql.go
@@ -17,8 +17,16 @@ END is_one
 FROM foo
 `
 
-func (q *Queries) CaseStatementText(ctx context.Context, id string) ([]string, error) {
-	rows, err := q.db.QueryContext(ctx, caseStatementText, id)
+func (q *Queries) CaseStatementText(ctx context.Context, id string, aq ...AdditionalQuery) ([]string, error) {
+	query := caseStatementText
+	queryParams := []interface{}{id}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.QueryContext(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/endtoend/testdata/cast_coalesce/pgx/v4/go/db.go
+++ b/internal/endtoend/testdata/cast_coalesce/pgx/v4/go/db.go
@@ -33,5 +33,5 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/cast_coalesce/pgx/v4/go/db.go
+++ b/internal/endtoend/testdata/cast_coalesce/pgx/v4/go/db.go
@@ -30,3 +30,8 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/cast_coalesce/pgx/v4/go/query.sql.go
+++ b/internal/endtoend/testdata/cast_coalesce/pgx/v4/go/query.sql.go
@@ -14,8 +14,16 @@ SELECT coalesce(bar, '')::text as login
 FROM foo
 `
 
-func (q *Queries) CastCoalesce(ctx context.Context) ([]string, error) {
-	rows, err := q.db.Query(ctx, castCoalesce)
+func (q *Queries) CastCoalesce(ctx context.Context, aq ...AdditionalQuery) ([]string, error) {
+	query := castCoalesce
+	queryParams := []interface{}{}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.Query(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/endtoend/testdata/cast_coalesce/pgx/v5/go/db.go
+++ b/internal/endtoend/testdata/cast_coalesce/pgx/v5/go/db.go
@@ -33,5 +33,5 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/cast_coalesce/pgx/v5/go/db.go
+++ b/internal/endtoend/testdata/cast_coalesce/pgx/v5/go/db.go
@@ -30,3 +30,8 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/cast_coalesce/pgx/v5/go/query.sql.go
+++ b/internal/endtoend/testdata/cast_coalesce/pgx/v5/go/query.sql.go
@@ -14,8 +14,16 @@ SELECT coalesce(bar, '')::text as login
 FROM foo
 `
 
-func (q *Queries) CastCoalesce(ctx context.Context) ([]string, error) {
-	rows, err := q.db.Query(ctx, castCoalesce)
+func (q *Queries) CastCoalesce(ctx context.Context, aq ...AdditionalQuery) ([]string, error) {
+	query := castCoalesce
+	queryParams := []interface{}{}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.Query(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/endtoend/testdata/cast_coalesce/stdlib/go/db.go
+++ b/internal/endtoend/testdata/cast_coalesce/stdlib/go/db.go
@@ -29,3 +29,8 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/cast_coalesce/stdlib/go/db.go
+++ b/internal/endtoend/testdata/cast_coalesce/stdlib/go/db.go
@@ -32,5 +32,5 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/cast_coalesce/stdlib/go/query.sql.go
+++ b/internal/endtoend/testdata/cast_coalesce/stdlib/go/query.sql.go
@@ -14,8 +14,16 @@ SELECT coalesce(bar, '')::text as login
 FROM foo
 `
 
-func (q *Queries) CastCoalesce(ctx context.Context) ([]string, error) {
-	rows, err := q.db.QueryContext(ctx, castCoalesce)
+func (q *Queries) CastCoalesce(ctx context.Context, aq ...AdditionalQuery) ([]string, error) {
+	query := castCoalesce
+	queryParams := []interface{}{}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.QueryContext(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/endtoend/testdata/cast_null/pgx/v4/go/db.go
+++ b/internal/endtoend/testdata/cast_null/pgx/v4/go/db.go
@@ -33,5 +33,5 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/cast_null/pgx/v4/go/db.go
+++ b/internal/endtoend/testdata/cast_null/pgx/v4/go/db.go
@@ -30,3 +30,8 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/cast_null/pgx/v4/go/query.sql.go
+++ b/internal/endtoend/testdata/cast_null/pgx/v4/go/query.sql.go
@@ -26,8 +26,16 @@ type ListNullableRow struct {
 	D sql.NullTime
 }
 
-func (q *Queries) ListNullable(ctx context.Context) ([]ListNullableRow, error) {
-	rows, err := q.db.Query(ctx, listNullable)
+func (q *Queries) ListNullable(ctx context.Context, aq ...AdditionalQuery) ([]ListNullableRow, error) {
+	query := listNullable
+	queryParams := []interface{}{}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.Query(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/endtoend/testdata/cast_null/pgx/v5/go/db.go
+++ b/internal/endtoend/testdata/cast_null/pgx/v5/go/db.go
@@ -33,5 +33,5 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/cast_null/pgx/v5/go/db.go
+++ b/internal/endtoend/testdata/cast_null/pgx/v5/go/db.go
@@ -30,3 +30,8 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/cast_null/pgx/v5/go/query.sql.go
+++ b/internal/endtoend/testdata/cast_null/pgx/v5/go/query.sql.go
@@ -27,8 +27,16 @@ type ListNullableRow struct {
 	D pgtype.Time
 }
 
-func (q *Queries) ListNullable(ctx context.Context) ([]ListNullableRow, error) {
-	rows, err := q.db.Query(ctx, listNullable)
+func (q *Queries) ListNullable(ctx context.Context, aq ...AdditionalQuery) ([]ListNullableRow, error) {
+	query := listNullable
+	queryParams := []interface{}{}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.Query(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/endtoend/testdata/cast_null/stdlib/go/db.go
+++ b/internal/endtoend/testdata/cast_null/stdlib/go/db.go
@@ -29,3 +29,8 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/cast_null/stdlib/go/db.go
+++ b/internal/endtoend/testdata/cast_null/stdlib/go/db.go
@@ -32,5 +32,5 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/cast_null/stdlib/go/query.sql.go
+++ b/internal/endtoend/testdata/cast_null/stdlib/go/query.sql.go
@@ -26,8 +26,16 @@ type ListNullableRow struct {
 	D sql.NullTime
 }
 
-func (q *Queries) ListNullable(ctx context.Context) ([]ListNullableRow, error) {
-	rows, err := q.db.QueryContext(ctx, listNullable)
+func (q *Queries) ListNullable(ctx context.Context, aq ...AdditionalQuery) ([]ListNullableRow, error) {
+	query := listNullable
+	queryParams := []interface{}{}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.QueryContext(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/endtoend/testdata/cast_param/sqlite/go/db.go
+++ b/internal/endtoend/testdata/cast_param/sqlite/go/db.go
@@ -29,3 +29,8 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/cast_param/sqlite/go/db.go
+++ b/internal/endtoend/testdata/cast_param/sqlite/go/db.go
@@ -32,5 +32,5 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/cast_param/sqlite/go/query.sql.go
+++ b/internal/endtoend/testdata/cast_param/sqlite/go/query.sql.go
@@ -15,8 +15,16 @@ from my_table
 where (cast(?1 as boolean) or not invalid)
 `
 
-func (q *Queries) GetData(ctx context.Context, allowInvalid bool) ([]MyTable, error) {
-	rows, err := q.db.QueryContext(ctx, getData, allowInvalid)
+func (q *Queries) GetData(ctx context.Context, allowInvalid bool, aq ...AdditionalQuery) ([]MyTable, error) {
+	query := getData
+	queryParams := []interface{}{allowInvalid}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.QueryContext(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/endtoend/testdata/citext/pgx/go/db.go
+++ b/internal/endtoend/testdata/citext/pgx/go/db.go
@@ -33,5 +33,5 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/citext/pgx/go/db.go
+++ b/internal/endtoend/testdata/citext/pgx/go/db.go
@@ -30,3 +30,8 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/citext/pgx/go/query.sql.go
+++ b/internal/endtoend/testdata/citext/pgx/go/query.sql.go
@@ -14,8 +14,16 @@ SELECT bar, bat
 FROM foo
 `
 
-func (q *Queries) GetCitexts(ctx context.Context) ([]Foo, error) {
-	rows, err := q.db.Query(ctx, getCitexts)
+func (q *Queries) GetCitexts(ctx context.Context, aq ...AdditionalQuery) ([]Foo, error) {
+	query := getCitexts
+	queryParams := []interface{}{}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.Query(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/endtoend/testdata/citext/stdlib/go/db.go
+++ b/internal/endtoend/testdata/citext/stdlib/go/db.go
@@ -29,3 +29,8 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/citext/stdlib/go/db.go
+++ b/internal/endtoend/testdata/citext/stdlib/go/db.go
@@ -32,5 +32,5 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/citext/stdlib/go/query.sql.go
+++ b/internal/endtoend/testdata/citext/stdlib/go/query.sql.go
@@ -14,8 +14,16 @@ SELECT bar, bat
 FROM foo
 `
 
-func (q *Queries) GetCitexts(ctx context.Context) ([]Foo, error) {
-	rows, err := q.db.QueryContext(ctx, getCitexts)
+func (q *Queries) GetCitexts(ctx context.Context, aq ...AdditionalQuery) ([]Foo, error) {
+	query := getCitexts
+	queryParams := []interface{}{}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.QueryContext(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/endtoend/testdata/coalesce/mysql/go/db.go
+++ b/internal/endtoend/testdata/coalesce/mysql/go/db.go
@@ -29,3 +29,8 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/coalesce/mysql/go/db.go
+++ b/internal/endtoend/testdata/coalesce/mysql/go/db.go
@@ -32,5 +32,5 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/coalesce/mysql/go/query.sql.go
+++ b/internal/endtoend/testdata/coalesce/mysql/go/query.sql.go
@@ -15,8 +15,16 @@ SELECT coalesce(bar, '') as login
 FROM foo
 `
 
-func (q *Queries) Coalesce(ctx context.Context) ([]string, error) {
-	rows, err := q.db.QueryContext(ctx, coalesce)
+func (q *Queries) Coalesce(ctx context.Context, aq ...AdditionalQuery) ([]string, error) {
+	query := coalesce
+	queryParams := []interface{}{}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.QueryContext(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}
@@ -49,8 +57,16 @@ type CoalesceColumnsRow struct {
 	Bar_2 string
 }
 
-func (q *Queries) CoalesceColumns(ctx context.Context) ([]CoalesceColumnsRow, error) {
-	rows, err := q.db.QueryContext(ctx, coalesceColumns)
+func (q *Queries) CoalesceColumns(ctx context.Context, aq ...AdditionalQuery) ([]CoalesceColumnsRow, error) {
+	query := coalesceColumns
+	queryParams := []interface{}{}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.QueryContext(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/endtoend/testdata/coalesce/postgresql/pgx/v4/go/db.go
+++ b/internal/endtoend/testdata/coalesce/postgresql/pgx/v4/go/db.go
@@ -33,5 +33,5 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/coalesce/postgresql/pgx/v4/go/db.go
+++ b/internal/endtoend/testdata/coalesce/postgresql/pgx/v4/go/db.go
@@ -30,3 +30,8 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/coalesce/postgresql/pgx/v4/go/query.sql.go
+++ b/internal/endtoend/testdata/coalesce/postgresql/pgx/v4/go/query.sql.go
@@ -15,8 +15,16 @@ SELECT coalesce(baz, 0) as login
 FROM foo
 `
 
-func (q *Queries) CoalesceNumeric(ctx context.Context) ([]int64, error) {
-	rows, err := q.db.Query(ctx, coalesceNumeric)
+func (q *Queries) CoalesceNumeric(ctx context.Context, aq ...AdditionalQuery) ([]int64, error) {
+	query := coalesceNumeric
+	queryParams := []interface{}{}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.Query(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}
@@ -46,8 +54,16 @@ type CoalesceNumericColumnsRow struct {
 	Baz_2 int64
 }
 
-func (q *Queries) CoalesceNumericColumns(ctx context.Context) ([]CoalesceNumericColumnsRow, error) {
-	rows, err := q.db.Query(ctx, coalesceNumericColumns)
+func (q *Queries) CoalesceNumericColumns(ctx context.Context, aq ...AdditionalQuery) ([]CoalesceNumericColumnsRow, error) {
+	query := coalesceNumericColumns
+	queryParams := []interface{}{}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.Query(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}
@@ -76,8 +92,16 @@ type CoalesceNumericNullRow struct {
 	Baz_2 sql.NullInt64
 }
 
-func (q *Queries) CoalesceNumericNull(ctx context.Context) ([]CoalesceNumericNullRow, error) {
-	rows, err := q.db.Query(ctx, coalesceNumericNull)
+func (q *Queries) CoalesceNumericNull(ctx context.Context, aq ...AdditionalQuery) ([]CoalesceNumericNullRow, error) {
+	query := coalesceNumericNull
+	queryParams := []interface{}{}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.Query(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}
@@ -101,8 +125,16 @@ SELECT coalesce(bar, '') as login
 FROM foo
 `
 
-func (q *Queries) CoalesceString(ctx context.Context) ([]string, error) {
-	rows, err := q.db.Query(ctx, coalesceString)
+func (q *Queries) CoalesceString(ctx context.Context, aq ...AdditionalQuery) ([]string, error) {
+	query := coalesceString
+	queryParams := []interface{}{}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.Query(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}
@@ -132,8 +164,16 @@ type CoalesceStringColumnsRow struct {
 	Bar_2 string
 }
 
-func (q *Queries) CoalesceStringColumns(ctx context.Context) ([]CoalesceStringColumnsRow, error) {
-	rows, err := q.db.Query(ctx, coalesceStringColumns)
+func (q *Queries) CoalesceStringColumns(ctx context.Context, aq ...AdditionalQuery) ([]CoalesceStringColumnsRow, error) {
+	query := coalesceStringColumns
+	queryParams := []interface{}{}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.Query(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}
@@ -162,8 +202,16 @@ type CoalesceStringNullRow struct {
 	Bar_2 sql.NullString
 }
 
-func (q *Queries) CoalesceStringNull(ctx context.Context) ([]CoalesceStringNullRow, error) {
-	rows, err := q.db.Query(ctx, coalesceStringNull)
+func (q *Queries) CoalesceStringNull(ctx context.Context, aq ...AdditionalQuery) ([]CoalesceStringNullRow, error) {
+	query := coalesceStringNull
+	queryParams := []interface{}{}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.Query(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/endtoend/testdata/coalesce/postgresql/pgx/v5/go/db.go
+++ b/internal/endtoend/testdata/coalesce/postgresql/pgx/v5/go/db.go
@@ -33,5 +33,5 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/coalesce/postgresql/pgx/v5/go/db.go
+++ b/internal/endtoend/testdata/coalesce/postgresql/pgx/v5/go/db.go
@@ -30,3 +30,8 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/coalesce/postgresql/pgx/v5/go/query.sql.go
+++ b/internal/endtoend/testdata/coalesce/postgresql/pgx/v5/go/query.sql.go
@@ -16,8 +16,16 @@ SELECT coalesce(baz, 0) as login
 FROM foo
 `
 
-func (q *Queries) CoalesceNumeric(ctx context.Context) ([]int64, error) {
-	rows, err := q.db.Query(ctx, coalesceNumeric)
+func (q *Queries) CoalesceNumeric(ctx context.Context, aq ...AdditionalQuery) ([]int64, error) {
+	query := coalesceNumeric
+	queryParams := []interface{}{}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.Query(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}
@@ -47,8 +55,16 @@ type CoalesceNumericColumnsRow struct {
 	Baz_2 int64
 }
 
-func (q *Queries) CoalesceNumericColumns(ctx context.Context) ([]CoalesceNumericColumnsRow, error) {
-	rows, err := q.db.Query(ctx, coalesceNumericColumns)
+func (q *Queries) CoalesceNumericColumns(ctx context.Context, aq ...AdditionalQuery) ([]CoalesceNumericColumnsRow, error) {
+	query := coalesceNumericColumns
+	queryParams := []interface{}{}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.Query(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}
@@ -77,8 +93,16 @@ type CoalesceNumericNullRow struct {
 	Baz_2 pgtype.Int8
 }
 
-func (q *Queries) CoalesceNumericNull(ctx context.Context) ([]CoalesceNumericNullRow, error) {
-	rows, err := q.db.Query(ctx, coalesceNumericNull)
+func (q *Queries) CoalesceNumericNull(ctx context.Context, aq ...AdditionalQuery) ([]CoalesceNumericNullRow, error) {
+	query := coalesceNumericNull
+	queryParams := []interface{}{}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.Query(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}
@@ -102,8 +126,16 @@ SELECT coalesce(bar, '') as login
 FROM foo
 `
 
-func (q *Queries) CoalesceString(ctx context.Context) ([]string, error) {
-	rows, err := q.db.Query(ctx, coalesceString)
+func (q *Queries) CoalesceString(ctx context.Context, aq ...AdditionalQuery) ([]string, error) {
+	query := coalesceString
+	queryParams := []interface{}{}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.Query(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}
@@ -133,8 +165,16 @@ type CoalesceStringColumnsRow struct {
 	Bar_2 string
 }
 
-func (q *Queries) CoalesceStringColumns(ctx context.Context) ([]CoalesceStringColumnsRow, error) {
-	rows, err := q.db.Query(ctx, coalesceStringColumns)
+func (q *Queries) CoalesceStringColumns(ctx context.Context, aq ...AdditionalQuery) ([]CoalesceStringColumnsRow, error) {
+	query := coalesceStringColumns
+	queryParams := []interface{}{}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.Query(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}
@@ -163,8 +203,16 @@ type CoalesceStringNullRow struct {
 	Bar_2 pgtype.Text
 }
 
-func (q *Queries) CoalesceStringNull(ctx context.Context) ([]CoalesceStringNullRow, error) {
-	rows, err := q.db.Query(ctx, coalesceStringNull)
+func (q *Queries) CoalesceStringNull(ctx context.Context, aq ...AdditionalQuery) ([]CoalesceStringNullRow, error) {
+	query := coalesceStringNull
+	queryParams := []interface{}{}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.Query(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/endtoend/testdata/coalesce/postgresql/stdlib/go/db.go
+++ b/internal/endtoend/testdata/coalesce/postgresql/stdlib/go/db.go
@@ -29,3 +29,8 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/coalesce/postgresql/stdlib/go/db.go
+++ b/internal/endtoend/testdata/coalesce/postgresql/stdlib/go/db.go
@@ -32,5 +32,5 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/coalesce/postgresql/stdlib/go/query.sql.go
+++ b/internal/endtoend/testdata/coalesce/postgresql/stdlib/go/query.sql.go
@@ -15,8 +15,16 @@ SELECT coalesce(baz, 0) as login
 FROM foo
 `
 
-func (q *Queries) CoalesceNumeric(ctx context.Context) ([]int64, error) {
-	rows, err := q.db.QueryContext(ctx, coalesceNumeric)
+func (q *Queries) CoalesceNumeric(ctx context.Context, aq ...AdditionalQuery) ([]int64, error) {
+	query := coalesceNumeric
+	queryParams := []interface{}{}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.QueryContext(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}
@@ -49,8 +57,16 @@ type CoalesceNumericColumnsRow struct {
 	Baz_2 int64
 }
 
-func (q *Queries) CoalesceNumericColumns(ctx context.Context) ([]CoalesceNumericColumnsRow, error) {
-	rows, err := q.db.QueryContext(ctx, coalesceNumericColumns)
+func (q *Queries) CoalesceNumericColumns(ctx context.Context, aq ...AdditionalQuery) ([]CoalesceNumericColumnsRow, error) {
+	query := coalesceNumericColumns
+	queryParams := []interface{}{}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.QueryContext(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}
@@ -82,8 +98,16 @@ type CoalesceNumericNullRow struct {
 	Baz_2 sql.NullInt64
 }
 
-func (q *Queries) CoalesceNumericNull(ctx context.Context) ([]CoalesceNumericNullRow, error) {
-	rows, err := q.db.QueryContext(ctx, coalesceNumericNull)
+func (q *Queries) CoalesceNumericNull(ctx context.Context, aq ...AdditionalQuery) ([]CoalesceNumericNullRow, error) {
+	query := coalesceNumericNull
+	queryParams := []interface{}{}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.QueryContext(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}
@@ -110,8 +134,16 @@ SELECT coalesce(bar, '') as login
 FROM foo
 `
 
-func (q *Queries) CoalesceString(ctx context.Context) ([]string, error) {
-	rows, err := q.db.QueryContext(ctx, coalesceString)
+func (q *Queries) CoalesceString(ctx context.Context, aq ...AdditionalQuery) ([]string, error) {
+	query := coalesceString
+	queryParams := []interface{}{}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.QueryContext(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}
@@ -144,8 +176,16 @@ type CoalesceStringColumnsRow struct {
 	Bar_2 string
 }
 
-func (q *Queries) CoalesceStringColumns(ctx context.Context) ([]CoalesceStringColumnsRow, error) {
-	rows, err := q.db.QueryContext(ctx, coalesceStringColumns)
+func (q *Queries) CoalesceStringColumns(ctx context.Context, aq ...AdditionalQuery) ([]CoalesceStringColumnsRow, error) {
+	query := coalesceStringColumns
+	queryParams := []interface{}{}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.QueryContext(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}
@@ -177,8 +217,16 @@ type CoalesceStringNullRow struct {
 	Bar_2 sql.NullString
 }
 
-func (q *Queries) CoalesceStringNull(ctx context.Context) ([]CoalesceStringNullRow, error) {
-	rows, err := q.db.QueryContext(ctx, coalesceStringNull)
+func (q *Queries) CoalesceStringNull(ctx context.Context, aq ...AdditionalQuery) ([]CoalesceStringNullRow, error) {
+	query := coalesceStringNull
+	queryParams := []interface{}{}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.QueryContext(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/endtoend/testdata/coalesce/sqlite/go/db.go
+++ b/internal/endtoend/testdata/coalesce/sqlite/go/db.go
@@ -29,3 +29,8 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/coalesce/sqlite/go/db.go
+++ b/internal/endtoend/testdata/coalesce/sqlite/go/db.go
@@ -32,5 +32,5 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/coalesce/sqlite/go/query.sql.go
+++ b/internal/endtoend/testdata/coalesce/sqlite/go/query.sql.go
@@ -15,8 +15,16 @@ SELECT coalesce(bar, '') as login
 FROM foo
 `
 
-func (q *Queries) Coalesce(ctx context.Context) ([]string, error) {
-	rows, err := q.db.QueryContext(ctx, coalesce)
+func (q *Queries) Coalesce(ctx context.Context, aq ...AdditionalQuery) ([]string, error) {
+	query := coalesce
+	queryParams := []interface{}{}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.QueryContext(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}
@@ -49,8 +57,16 @@ type CoalesceColumnsRow struct {
 	Bar_2 string
 }
 
-func (q *Queries) CoalesceColumns(ctx context.Context) ([]CoalesceColumnsRow, error) {
-	rows, err := q.db.QueryContext(ctx, coalesceColumns)
+func (q *Queries) CoalesceColumns(ctx context.Context, aq ...AdditionalQuery) ([]CoalesceColumnsRow, error) {
+	query := coalesceColumns
+	queryParams := []interface{}{}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.QueryContext(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/endtoend/testdata/coalesce_as/mysql/go/db.go
+++ b/internal/endtoend/testdata/coalesce_as/mysql/go/db.go
@@ -29,3 +29,8 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/coalesce_as/mysql/go/db.go
+++ b/internal/endtoend/testdata/coalesce_as/mysql/go/db.go
@@ -32,5 +32,5 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/coalesce_as/mysql/go/query.sql.go
+++ b/internal/endtoend/testdata/coalesce_as/mysql/go/query.sql.go
@@ -21,8 +21,16 @@ type SumBazRow struct {
 	Quantity interface{}
 }
 
-func (q *Queries) SumBaz(ctx context.Context) ([]SumBazRow, error) {
-	rows, err := q.db.QueryContext(ctx, sumBaz)
+func (q *Queries) SumBaz(ctx context.Context, aq ...AdditionalQuery) ([]SumBazRow, error) {
+	query := sumBaz
+	queryParams := []interface{}{}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.QueryContext(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/endtoend/testdata/coalesce_as/postgresql/pgx/v4/go/db.go
+++ b/internal/endtoend/testdata/coalesce_as/postgresql/pgx/v4/go/db.go
@@ -33,5 +33,5 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/coalesce_as/postgresql/pgx/v4/go/db.go
+++ b/internal/endtoend/testdata/coalesce_as/postgresql/pgx/v4/go/db.go
@@ -30,3 +30,8 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/coalesce_as/postgresql/pgx/v4/go/query.sql.go
+++ b/internal/endtoend/testdata/coalesce_as/postgresql/pgx/v4/go/query.sql.go
@@ -21,8 +21,16 @@ type SumBazRow struct {
 	Quantity interface{}
 }
 
-func (q *Queries) SumBaz(ctx context.Context) ([]SumBazRow, error) {
-	rows, err := q.db.Query(ctx, sumBaz)
+func (q *Queries) SumBaz(ctx context.Context, aq ...AdditionalQuery) ([]SumBazRow, error) {
+	query := sumBaz
+	queryParams := []interface{}{}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.Query(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/endtoend/testdata/coalesce_as/postgresql/pgx/v5/go/db.go
+++ b/internal/endtoend/testdata/coalesce_as/postgresql/pgx/v5/go/db.go
@@ -33,5 +33,5 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/coalesce_as/postgresql/pgx/v5/go/db.go
+++ b/internal/endtoend/testdata/coalesce_as/postgresql/pgx/v5/go/db.go
@@ -30,3 +30,8 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/coalesce_as/postgresql/pgx/v5/go/query.sql.go
+++ b/internal/endtoend/testdata/coalesce_as/postgresql/pgx/v5/go/query.sql.go
@@ -22,8 +22,16 @@ type SumBazRow struct {
 	Quantity interface{}
 }
 
-func (q *Queries) SumBaz(ctx context.Context) ([]SumBazRow, error) {
-	rows, err := q.db.Query(ctx, sumBaz)
+func (q *Queries) SumBaz(ctx context.Context, aq ...AdditionalQuery) ([]SumBazRow, error) {
+	query := sumBaz
+	queryParams := []interface{}{}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.Query(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/endtoend/testdata/coalesce_as/postgresql/stdlib/go/db.go
+++ b/internal/endtoend/testdata/coalesce_as/postgresql/stdlib/go/db.go
@@ -29,3 +29,8 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/coalesce_as/postgresql/stdlib/go/db.go
+++ b/internal/endtoend/testdata/coalesce_as/postgresql/stdlib/go/db.go
@@ -32,5 +32,5 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/coalesce_as/postgresql/stdlib/go/query.sql.go
+++ b/internal/endtoend/testdata/coalesce_as/postgresql/stdlib/go/query.sql.go
@@ -21,8 +21,16 @@ type SumBazRow struct {
 	Quantity interface{}
 }
 
-func (q *Queries) SumBaz(ctx context.Context) ([]SumBazRow, error) {
-	rows, err := q.db.QueryContext(ctx, sumBaz)
+func (q *Queries) SumBaz(ctx context.Context, aq ...AdditionalQuery) ([]SumBazRow, error) {
+	query := sumBaz
+	queryParams := []interface{}{}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.QueryContext(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/endtoend/testdata/coalesce_as/sqlite/go/db.go
+++ b/internal/endtoend/testdata/coalesce_as/sqlite/go/db.go
@@ -29,3 +29,8 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/coalesce_as/sqlite/go/db.go
+++ b/internal/endtoend/testdata/coalesce_as/sqlite/go/db.go
@@ -32,5 +32,5 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/coalesce_as/sqlite/go/query.sql.go
+++ b/internal/endtoend/testdata/coalesce_as/sqlite/go/query.sql.go
@@ -21,8 +21,16 @@ type SumBazRow struct {
 	Quantity interface{}
 }
 
-func (q *Queries) SumBaz(ctx context.Context) ([]SumBazRow, error) {
-	rows, err := q.db.QueryContext(ctx, sumBaz)
+func (q *Queries) SumBaz(ctx context.Context, aq ...AdditionalQuery) ([]SumBazRow, error) {
+	query := sumBaz
+	queryParams := []interface{}{}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.QueryContext(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/endtoend/testdata/coalesce_join/postgresql/go/db.go
+++ b/internal/endtoend/testdata/coalesce_join/postgresql/go/db.go
@@ -29,3 +29,8 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/coalesce_join/postgresql/go/db.go
+++ b/internal/endtoend/testdata/coalesce_join/postgresql/go/db.go
@@ -32,5 +32,5 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/coalesce_join/postgresql/go/query.sql.go
+++ b/internal/endtoend/testdata/coalesce_join/postgresql/go/query.sql.go
@@ -20,8 +20,16 @@ type GetBarRow struct {
 	BarID int64
 }
 
-func (q *Queries) GetBar(ctx context.Context) ([]GetBarRow, error) {
-	rows, err := q.db.QueryContext(ctx, getBar)
+func (q *Queries) GetBar(ctx context.Context, aq ...AdditionalQuery) ([]GetBarRow, error) {
+	query := getBar
+	queryParams := []interface{}{}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.QueryContext(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/endtoend/testdata/codegen_struct_field_names/stdlib/go/db.go
+++ b/internal/endtoend/testdata/codegen_struct_field_names/stdlib/go/db.go
@@ -29,3 +29,8 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/codegen_struct_field_names/stdlib/go/db.go
+++ b/internal/endtoend/testdata/codegen_struct_field_names/stdlib/go/db.go
@@ -32,5 +32,5 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/codegen_struct_field_names/stdlib/go/query.sql.go
+++ b/internal/endtoend/testdata/codegen_struct_field_names/stdlib/go/query.sql.go
@@ -13,8 +13,16 @@ const test = `-- name: test :one
 SELECT id, !!!nobody,_,-would-believe---this-...?!, parent        id from bar limit 1
 `
 
-func (q *Queries) test(ctx context.Context) (Bar, error) {
-	row := q.db.QueryRowContext(ctx, test)
+func (q *Queries) test(ctx context.Context, aq ...AdditionalQuery) (Bar, error) {
+	query := test
+	queryParams := []interface{}{}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	row := q.db.QueryRowContext(ctx, query, queryParams...)
 	var i Bar
 	err := row.Scan(&i.ID, &i.NobodyWouldBelieveThis, &i.ParentID)
 	return i, err

--- a/internal/endtoend/testdata/column_as/mysql/go/db.go
+++ b/internal/endtoend/testdata/column_as/mysql/go/db.go
@@ -29,3 +29,8 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/column_as/mysql/go/db.go
+++ b/internal/endtoend/testdata/column_as/mysql/go/db.go
@@ -32,5 +32,5 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/column_as/mysql/go/query.sql.go
+++ b/internal/endtoend/testdata/column_as/mysql/go/query.sql.go
@@ -18,8 +18,16 @@ type WithAsRow struct {
 	Y int32
 }
 
-func (q *Queries) WithAs(ctx context.Context) (WithAsRow, error) {
-	row := q.db.QueryRowContext(ctx, withAs)
+func (q *Queries) WithAs(ctx context.Context, aq ...AdditionalQuery) (WithAsRow, error) {
+	query := withAs
+	queryParams := []interface{}{}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	row := q.db.QueryRowContext(ctx, query, queryParams...)
 	var i WithAsRow
 	err := row.Scan(&i.X, &i.Y)
 	return i, err
@@ -34,8 +42,16 @@ type WithoutAsRow struct {
 	Y int32
 }
 
-func (q *Queries) WithoutAs(ctx context.Context) (WithoutAsRow, error) {
-	row := q.db.QueryRowContext(ctx, withoutAs)
+func (q *Queries) WithoutAs(ctx context.Context, aq ...AdditionalQuery) (WithoutAsRow, error) {
+	query := withoutAs
+	queryParams := []interface{}{}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	row := q.db.QueryRowContext(ctx, query, queryParams...)
 	var i WithoutAsRow
 	err := row.Scan(&i.X, &i.Y)
 	return i, err

--- a/internal/endtoend/testdata/column_as/postgresql/pgx/v4/go/db.go
+++ b/internal/endtoend/testdata/column_as/postgresql/pgx/v4/go/db.go
@@ -33,5 +33,5 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/column_as/postgresql/pgx/v4/go/db.go
+++ b/internal/endtoend/testdata/column_as/postgresql/pgx/v4/go/db.go
@@ -30,3 +30,8 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/column_as/postgresql/pgx/v4/go/query.sql.go
+++ b/internal/endtoend/testdata/column_as/postgresql/pgx/v4/go/query.sql.go
@@ -18,8 +18,10 @@ type WithAsRow struct {
 	Y int32
 }
 
-func (q *Queries) WithAs(ctx context.Context) (WithAsRow, error) {
-	row := q.db.QueryRow(ctx, withAs)
+func (q *Queries) WithAs(ctx context.Context, aq ...AdditionalQuery) (WithAsRow, error) {
+	query := withAs
+	queryParams := []interface{}{}
+	row := q.db.QueryRow(ctx, query, queryParams...)
 	var i WithAsRow
 	err := row.Scan(&i.X, &i.Y)
 	return i, err
@@ -34,8 +36,10 @@ type WithoutAsRow struct {
 	Y int32
 }
 
-func (q *Queries) WithoutAs(ctx context.Context) (WithoutAsRow, error) {
-	row := q.db.QueryRow(ctx, withoutAs)
+func (q *Queries) WithoutAs(ctx context.Context, aq ...AdditionalQuery) (WithoutAsRow, error) {
+	query := withoutAs
+	queryParams := []interface{}{}
+	row := q.db.QueryRow(ctx, query, queryParams...)
 	var i WithoutAsRow
 	err := row.Scan(&i.X, &i.Y)
 	return i, err

--- a/internal/endtoend/testdata/column_as/postgresql/pgx/v5/go/db.go
+++ b/internal/endtoend/testdata/column_as/postgresql/pgx/v5/go/db.go
@@ -33,5 +33,5 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/column_as/postgresql/pgx/v5/go/db.go
+++ b/internal/endtoend/testdata/column_as/postgresql/pgx/v5/go/db.go
@@ -30,3 +30,8 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/column_as/postgresql/pgx/v5/go/query.sql.go
+++ b/internal/endtoend/testdata/column_as/postgresql/pgx/v5/go/query.sql.go
@@ -18,8 +18,10 @@ type WithAsRow struct {
 	Y int32
 }
 
-func (q *Queries) WithAs(ctx context.Context) (WithAsRow, error) {
-	row := q.db.QueryRow(ctx, withAs)
+func (q *Queries) WithAs(ctx context.Context, aq ...AdditionalQuery) (WithAsRow, error) {
+	query := withAs
+	queryParams := []interface{}{}
+	row := q.db.QueryRow(ctx, query, queryParams...)
 	var i WithAsRow
 	err := row.Scan(&i.X, &i.Y)
 	return i, err
@@ -34,8 +36,10 @@ type WithoutAsRow struct {
 	Y int32
 }
 
-func (q *Queries) WithoutAs(ctx context.Context) (WithoutAsRow, error) {
-	row := q.db.QueryRow(ctx, withoutAs)
+func (q *Queries) WithoutAs(ctx context.Context, aq ...AdditionalQuery) (WithoutAsRow, error) {
+	query := withoutAs
+	queryParams := []interface{}{}
+	row := q.db.QueryRow(ctx, query, queryParams...)
 	var i WithoutAsRow
 	err := row.Scan(&i.X, &i.Y)
 	return i, err

--- a/internal/endtoend/testdata/column_as/postgresql/stdlib/go/db.go
+++ b/internal/endtoend/testdata/column_as/postgresql/stdlib/go/db.go
@@ -29,3 +29,8 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/column_as/postgresql/stdlib/go/db.go
+++ b/internal/endtoend/testdata/column_as/postgresql/stdlib/go/db.go
@@ -32,5 +32,5 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/column_as/postgresql/stdlib/go/query.sql.go
+++ b/internal/endtoend/testdata/column_as/postgresql/stdlib/go/query.sql.go
@@ -18,8 +18,16 @@ type WithAsRow struct {
 	Y int32
 }
 
-func (q *Queries) WithAs(ctx context.Context) (WithAsRow, error) {
-	row := q.db.QueryRowContext(ctx, withAs)
+func (q *Queries) WithAs(ctx context.Context, aq ...AdditionalQuery) (WithAsRow, error) {
+	query := withAs
+	queryParams := []interface{}{}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	row := q.db.QueryRowContext(ctx, query, queryParams...)
 	var i WithAsRow
 	err := row.Scan(&i.X, &i.Y)
 	return i, err
@@ -34,8 +42,16 @@ type WithoutAsRow struct {
 	Y int32
 }
 
-func (q *Queries) WithoutAs(ctx context.Context) (WithoutAsRow, error) {
-	row := q.db.QueryRowContext(ctx, withoutAs)
+func (q *Queries) WithoutAs(ctx context.Context, aq ...AdditionalQuery) (WithoutAsRow, error) {
+	query := withoutAs
+	queryParams := []interface{}{}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	row := q.db.QueryRowContext(ctx, query, queryParams...)
 	var i WithoutAsRow
 	err := row.Scan(&i.X, &i.Y)
 	return i, err

--- a/internal/endtoend/testdata/column_as/sqlite/go/db.go
+++ b/internal/endtoend/testdata/column_as/sqlite/go/db.go
@@ -29,3 +29,8 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/column_as/sqlite/go/db.go
+++ b/internal/endtoend/testdata/column_as/sqlite/go/db.go
@@ -32,5 +32,5 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/column_as/sqlite/go/query.sql.go
+++ b/internal/endtoend/testdata/column_as/sqlite/go/query.sql.go
@@ -18,8 +18,16 @@ type WithAsRow struct {
 	Y int64
 }
 
-func (q *Queries) WithAs(ctx context.Context) (WithAsRow, error) {
-	row := q.db.QueryRowContext(ctx, withAs)
+func (q *Queries) WithAs(ctx context.Context, aq ...AdditionalQuery) (WithAsRow, error) {
+	query := withAs
+	queryParams := []interface{}{}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	row := q.db.QueryRowContext(ctx, query, queryParams...)
 	var i WithAsRow
 	err := row.Scan(&i.X, &i.Y)
 	return i, err
@@ -34,8 +42,16 @@ type WithoutAsRow struct {
 	Y int64
 }
 
-func (q *Queries) WithoutAs(ctx context.Context) (WithoutAsRow, error) {
-	row := q.db.QueryRowContext(ctx, withoutAs)
+func (q *Queries) WithoutAs(ctx context.Context, aq ...AdditionalQuery) (WithoutAsRow, error) {
+	query := withoutAs
+	queryParams := []interface{}{}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	row := q.db.QueryRowContext(ctx, query, queryParams...)
 	var i WithoutAsRow
 	err := row.Scan(&i.X, &i.Y)
 	return i, err

--- a/internal/endtoend/testdata/comment_godoc/postgresql/pgx/v4/go/db.go
+++ b/internal/endtoend/testdata/comment_godoc/postgresql/pgx/v4/go/db.go
@@ -33,5 +33,5 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/comment_godoc/postgresql/pgx/v4/go/db.go
+++ b/internal/endtoend/testdata/comment_godoc/postgresql/pgx/v4/go/db.go
@@ -30,3 +30,8 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/comment_godoc/postgresql/pgx/v4/go/query.sql.go
+++ b/internal/endtoend/testdata/comment_godoc/postgresql/pgx/v4/go/query.sql.go
@@ -49,8 +49,16 @@ SELECT bar FROM foo
 `
 
 // This function returns a list of Foos
-func (q *Queries) ManyFoo(ctx context.Context) ([]sql.NullString, error) {
-	rows, err := q.db.Query(ctx, manyFoo)
+func (q *Queries) ManyFoo(ctx context.Context, aq ...AdditionalQuery) ([]sql.NullString, error) {
+	query := manyFoo
+	queryParams := []interface{}{}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.Query(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}
@@ -74,8 +82,10 @@ SELECT bar FROM foo
 `
 
 // This function returns one Foo
-func (q *Queries) OneFoo(ctx context.Context) (sql.NullString, error) {
-	row := q.db.QueryRow(ctx, oneFoo)
+func (q *Queries) OneFoo(ctx context.Context, aq ...AdditionalQuery) (sql.NullString, error) {
+	query := oneFoo
+	queryParams := []interface{}{}
+	row := q.db.QueryRow(ctx, query, queryParams...)
 	var bar sql.NullString
 	err := row.Scan(&bar)
 	return bar, err

--- a/internal/endtoend/testdata/comment_godoc/postgresql/pgx/v5/go/db.go
+++ b/internal/endtoend/testdata/comment_godoc/postgresql/pgx/v5/go/db.go
@@ -33,5 +33,5 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/comment_godoc/postgresql/pgx/v5/go/db.go
+++ b/internal/endtoend/testdata/comment_godoc/postgresql/pgx/v5/go/db.go
@@ -30,3 +30,8 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/comment_godoc/postgresql/pgx/v5/go/query.sql.go
+++ b/internal/endtoend/testdata/comment_godoc/postgresql/pgx/v5/go/query.sql.go
@@ -49,8 +49,16 @@ SELECT bar FROM foo
 `
 
 // This function returns a list of Foos
-func (q *Queries) ManyFoo(ctx context.Context) ([]pgtype.Text, error) {
-	rows, err := q.db.Query(ctx, manyFoo)
+func (q *Queries) ManyFoo(ctx context.Context, aq ...AdditionalQuery) ([]pgtype.Text, error) {
+	query := manyFoo
+	queryParams := []interface{}{}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.Query(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}
@@ -74,8 +82,10 @@ SELECT bar FROM foo
 `
 
 // This function returns one Foo
-func (q *Queries) OneFoo(ctx context.Context) (pgtype.Text, error) {
-	row := q.db.QueryRow(ctx, oneFoo)
+func (q *Queries) OneFoo(ctx context.Context, aq ...AdditionalQuery) (pgtype.Text, error) {
+	query := oneFoo
+	queryParams := []interface{}{}
+	row := q.db.QueryRow(ctx, query, queryParams...)
 	var bar pgtype.Text
 	err := row.Scan(&bar)
 	return bar, err

--- a/internal/endtoend/testdata/comment_godoc_db_argument/postgresql/pgx/v4/go/db.go
+++ b/internal/endtoend/testdata/comment_godoc_db_argument/postgresql/pgx/v4/go/db.go
@@ -23,3 +23,8 @@ func New() *Queries {
 
 type Queries struct {
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/comment_godoc_db_argument/postgresql/pgx/v4/go/db.go
+++ b/internal/endtoend/testdata/comment_godoc_db_argument/postgresql/pgx/v4/go/db.go
@@ -26,5 +26,5 @@ type Queries struct {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/comment_godoc_db_argument/postgresql/pgx/v4/go/query.sql.go
+++ b/internal/endtoend/testdata/comment_godoc_db_argument/postgresql/pgx/v4/go/query.sql.go
@@ -49,8 +49,16 @@ SELECT bar FROM foo
 `
 
 // This function returns a list of Foos
-func (q *Queries) ManyFoo(ctx context.Context, db DBTX) ([]sql.NullString, error) {
-	rows, err := db.Query(ctx, manyFoo)
+func (q *Queries) ManyFoo(ctx context.Context, db DBTX, aq ...AdditionalQuery) ([]sql.NullString, error) {
+	query := manyFoo
+	queryParams := []interface{}{}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := db.Query(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}
@@ -74,8 +82,10 @@ SELECT bar FROM foo
 `
 
 // This function returns one Foo
-func (q *Queries) OneFoo(ctx context.Context, db DBTX) (sql.NullString, error) {
-	row := db.QueryRow(ctx, oneFoo)
+func (q *Queries) OneFoo(ctx context.Context, db DBTX, aq ...AdditionalQuery) (sql.NullString, error) {
+	query := oneFoo
+	queryParams := []interface{}{}
+	row := db.QueryRow(ctx, query, queryParams...)
 	var bar sql.NullString
 	err := row.Scan(&bar)
 	return bar, err

--- a/internal/endtoend/testdata/comment_godoc_db_argument/postgresql/pgx/v5/go/db.go
+++ b/internal/endtoend/testdata/comment_godoc_db_argument/postgresql/pgx/v5/go/db.go
@@ -23,3 +23,8 @@ func New() *Queries {
 
 type Queries struct {
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/comment_godoc_db_argument/postgresql/pgx/v5/go/db.go
+++ b/internal/endtoend/testdata/comment_godoc_db_argument/postgresql/pgx/v5/go/db.go
@@ -26,5 +26,5 @@ type Queries struct {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/comment_godoc_db_argument/postgresql/pgx/v5/go/query.sql.go
+++ b/internal/endtoend/testdata/comment_godoc_db_argument/postgresql/pgx/v5/go/query.sql.go
@@ -49,8 +49,16 @@ SELECT bar FROM foo
 `
 
 // This function returns a list of Foos
-func (q *Queries) ManyFoo(ctx context.Context, db DBTX) ([]pgtype.Text, error) {
-	rows, err := db.Query(ctx, manyFoo)
+func (q *Queries) ManyFoo(ctx context.Context, db DBTX, aq ...AdditionalQuery) ([]pgtype.Text, error) {
+	query := manyFoo
+	queryParams := []interface{}{}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := db.Query(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}
@@ -74,8 +82,10 @@ SELECT bar FROM foo
 `
 
 // This function returns one Foo
-func (q *Queries) OneFoo(ctx context.Context, db DBTX) (pgtype.Text, error) {
-	row := db.QueryRow(ctx, oneFoo)
+func (q *Queries) OneFoo(ctx context.Context, db DBTX, aq ...AdditionalQuery) (pgtype.Text, error) {
+	query := oneFoo
+	queryParams := []interface{}{}
+	row := db.QueryRow(ctx, query, queryParams...)
 	var bar pgtype.Text
 	err := row.Scan(&bar)
 	return bar, err

--- a/internal/endtoend/testdata/comment_on/postgresql/pgx/v4/go/db.go
+++ b/internal/endtoend/testdata/comment_on/postgresql/pgx/v4/go/db.go
@@ -33,5 +33,5 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/comment_on/postgresql/pgx/v4/go/db.go
+++ b/internal/endtoend/testdata/comment_on/postgresql/pgx/v4/go/db.go
@@ -30,3 +30,8 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/comment_on/postgresql/pgx/v4/go/query.sql.go
+++ b/internal/endtoend/testdata/comment_on/postgresql/pgx/v4/go/query.sql.go
@@ -13,8 +13,16 @@ const listBar = `-- name: ListBar :many
 SELECT baz FROM foo.bar
 `
 
-func (q *Queries) ListBar(ctx context.Context) ([]string, error) {
-	rows, err := q.db.Query(ctx, listBar)
+func (q *Queries) ListBar(ctx context.Context, aq ...AdditionalQuery) ([]string, error) {
+	query := listBar
+	queryParams := []interface{}{}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.Query(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}
@@ -37,8 +45,16 @@ const listBat = `-- name: ListBat :many
 SELECT baz FROM foo.bat
 `
 
-func (q *Queries) ListBat(ctx context.Context) ([]string, error) {
-	rows, err := q.db.Query(ctx, listBat)
+func (q *Queries) ListBat(ctx context.Context, aq ...AdditionalQuery) ([]string, error) {
+	query := listBat
+	queryParams := []interface{}{}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.Query(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/endtoend/testdata/comment_on/postgresql/pgx/v5/go/db.go
+++ b/internal/endtoend/testdata/comment_on/postgresql/pgx/v5/go/db.go
@@ -33,5 +33,5 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/comment_on/postgresql/pgx/v5/go/db.go
+++ b/internal/endtoend/testdata/comment_on/postgresql/pgx/v5/go/db.go
@@ -30,3 +30,8 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/comment_on/postgresql/pgx/v5/go/query.sql.go
+++ b/internal/endtoend/testdata/comment_on/postgresql/pgx/v5/go/query.sql.go
@@ -13,8 +13,16 @@ const listBar = `-- name: ListBar :many
 SELECT baz FROM foo.bar
 `
 
-func (q *Queries) ListBar(ctx context.Context) ([]string, error) {
-	rows, err := q.db.Query(ctx, listBar)
+func (q *Queries) ListBar(ctx context.Context, aq ...AdditionalQuery) ([]string, error) {
+	query := listBar
+	queryParams := []interface{}{}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.Query(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}
@@ -37,8 +45,16 @@ const listBat = `-- name: ListBat :many
 SELECT baz FROM foo.bat
 `
 
-func (q *Queries) ListBat(ctx context.Context) ([]string, error) {
-	rows, err := q.db.Query(ctx, listBat)
+func (q *Queries) ListBat(ctx context.Context, aq ...AdditionalQuery) ([]string, error) {
+	query := listBat
+	queryParams := []interface{}{}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.Query(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/endtoend/testdata/comment_on/postgresql/stdlib/go/db.go
+++ b/internal/endtoend/testdata/comment_on/postgresql/stdlib/go/db.go
@@ -29,3 +29,8 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/comment_on/postgresql/stdlib/go/db.go
+++ b/internal/endtoend/testdata/comment_on/postgresql/stdlib/go/db.go
@@ -32,5 +32,5 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/comment_on/postgresql/stdlib/go/query.sql.go
+++ b/internal/endtoend/testdata/comment_on/postgresql/stdlib/go/query.sql.go
@@ -13,8 +13,16 @@ const listBar = `-- name: ListBar :many
 SELECT baz FROM foo.bar
 `
 
-func (q *Queries) ListBar(ctx context.Context) ([]string, error) {
-	rows, err := q.db.QueryContext(ctx, listBar)
+func (q *Queries) ListBar(ctx context.Context, aq ...AdditionalQuery) ([]string, error) {
+	query := listBar
+	queryParams := []interface{}{}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.QueryContext(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}
@@ -40,8 +48,16 @@ const listBat = `-- name: ListBat :many
 SELECT baz FROM foo.bat
 `
 
-func (q *Queries) ListBat(ctx context.Context) ([]string, error) {
-	rows, err := q.db.QueryContext(ctx, listBat)
+func (q *Queries) ListBat(ctx context.Context, aq ...AdditionalQuery) ([]string, error) {
+	query := listBat
+	queryParams := []interface{}{}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.QueryContext(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/endtoend/testdata/comment_syntax/mysql/go/db.go
+++ b/internal/endtoend/testdata/comment_syntax/mysql/go/db.go
@@ -29,3 +29,8 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/comment_syntax/mysql/go/db.go
+++ b/internal/endtoend/testdata/comment_syntax/mysql/go/db.go
@@ -32,5 +32,5 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/comment_syntax/mysql/go/query.sql.go
+++ b/internal/endtoend/testdata/comment_syntax/mysql/go/query.sql.go
@@ -14,8 +14,16 @@ const doubleDash = `-- name: DoubleDash :one
 SELECT bar FROM foo LIMIT 1
 `
 
-func (q *Queries) DoubleDash(ctx context.Context) (sql.NullString, error) {
-	row := q.db.QueryRowContext(ctx, doubleDash)
+func (q *Queries) DoubleDash(ctx context.Context, aq ...AdditionalQuery) (sql.NullString, error) {
+	query := doubleDash
+	queryParams := []interface{}{}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	row := q.db.QueryRowContext(ctx, query, queryParams...)
 	var bar sql.NullString
 	err := row.Scan(&bar)
 	return bar, err
@@ -26,8 +34,16 @@ const hash = `-- name: Hash :one
 SELECT bar FROM foo LIMIT 1
 `
 
-func (q *Queries) Hash(ctx context.Context) (sql.NullString, error) {
-	row := q.db.QueryRowContext(ctx, hash)
+func (q *Queries) Hash(ctx context.Context, aq ...AdditionalQuery) (sql.NullString, error) {
+	query := hash
+	queryParams := []interface{}{}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	row := q.db.QueryRowContext(ctx, query, queryParams...)
 	var bar sql.NullString
 	err := row.Scan(&bar)
 	return bar, err
@@ -37,8 +53,16 @@ const slashStar = `-- name: SlashStar :one
 SELECT bar FROM foo LIMIT 1
 `
 
-func (q *Queries) SlashStar(ctx context.Context) (sql.NullString, error) {
-	row := q.db.QueryRowContext(ctx, slashStar)
+func (q *Queries) SlashStar(ctx context.Context, aq ...AdditionalQuery) (sql.NullString, error) {
+	query := slashStar
+	queryParams := []interface{}{}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	row := q.db.QueryRowContext(ctx, query, queryParams...)
 	var bar sql.NullString
 	err := row.Scan(&bar)
 	return bar, err

--- a/internal/endtoend/testdata/comment_syntax/postgresql/pgx/v4/go/db.go
+++ b/internal/endtoend/testdata/comment_syntax/postgresql/pgx/v4/go/db.go
@@ -33,5 +33,5 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/comment_syntax/postgresql/pgx/v4/go/db.go
+++ b/internal/endtoend/testdata/comment_syntax/postgresql/pgx/v4/go/db.go
@@ -30,3 +30,8 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/comment_syntax/postgresql/pgx/v4/go/query.sql.go
+++ b/internal/endtoend/testdata/comment_syntax/postgresql/pgx/v4/go/query.sql.go
@@ -14,8 +14,10 @@ const doubleDash = `-- name: DoubleDash :one
 SELECT bar FROM foo LIMIT 1
 `
 
-func (q *Queries) DoubleDash(ctx context.Context) (sql.NullString, error) {
-	row := q.db.QueryRow(ctx, doubleDash)
+func (q *Queries) DoubleDash(ctx context.Context, aq ...AdditionalQuery) (sql.NullString, error) {
+	query := doubleDash
+	queryParams := []interface{}{}
+	row := q.db.QueryRow(ctx, query, queryParams...)
 	var bar sql.NullString
 	err := row.Scan(&bar)
 	return bar, err
@@ -25,8 +27,10 @@ const slashStar = `-- name: SlashStar :one
 SELECT bar FROM foo LIMIT 1
 `
 
-func (q *Queries) SlashStar(ctx context.Context) (sql.NullString, error) {
-	row := q.db.QueryRow(ctx, slashStar)
+func (q *Queries) SlashStar(ctx context.Context, aq ...AdditionalQuery) (sql.NullString, error) {
+	query := slashStar
+	queryParams := []interface{}{}
+	row := q.db.QueryRow(ctx, query, queryParams...)
 	var bar sql.NullString
 	err := row.Scan(&bar)
 	return bar, err

--- a/internal/endtoend/testdata/comment_syntax/postgresql/pgx/v5/go/db.go
+++ b/internal/endtoend/testdata/comment_syntax/postgresql/pgx/v5/go/db.go
@@ -33,5 +33,5 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/comment_syntax/postgresql/pgx/v5/go/db.go
+++ b/internal/endtoend/testdata/comment_syntax/postgresql/pgx/v5/go/db.go
@@ -30,3 +30,8 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/comment_syntax/postgresql/pgx/v5/go/query.sql.go
+++ b/internal/endtoend/testdata/comment_syntax/postgresql/pgx/v5/go/query.sql.go
@@ -15,8 +15,10 @@ const doubleDash = `-- name: DoubleDash :one
 SELECT bar FROM foo LIMIT 1
 `
 
-func (q *Queries) DoubleDash(ctx context.Context) (pgtype.Text, error) {
-	row := q.db.QueryRow(ctx, doubleDash)
+func (q *Queries) DoubleDash(ctx context.Context, aq ...AdditionalQuery) (pgtype.Text, error) {
+	query := doubleDash
+	queryParams := []interface{}{}
+	row := q.db.QueryRow(ctx, query, queryParams...)
 	var bar pgtype.Text
 	err := row.Scan(&bar)
 	return bar, err
@@ -26,8 +28,10 @@ const slashStar = `-- name: SlashStar :one
 SELECT bar FROM foo LIMIT 1
 `
 
-func (q *Queries) SlashStar(ctx context.Context) (pgtype.Text, error) {
-	row := q.db.QueryRow(ctx, slashStar)
+func (q *Queries) SlashStar(ctx context.Context, aq ...AdditionalQuery) (pgtype.Text, error) {
+	query := slashStar
+	queryParams := []interface{}{}
+	row := q.db.QueryRow(ctx, query, queryParams...)
 	var bar pgtype.Text
 	err := row.Scan(&bar)
 	return bar, err

--- a/internal/endtoend/testdata/comment_syntax/postgresql/stdlib/go/db.go
+++ b/internal/endtoend/testdata/comment_syntax/postgresql/stdlib/go/db.go
@@ -29,3 +29,8 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/comment_syntax/postgresql/stdlib/go/db.go
+++ b/internal/endtoend/testdata/comment_syntax/postgresql/stdlib/go/db.go
@@ -32,5 +32,5 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/comment_syntax/postgresql/stdlib/go/query.sql.go
+++ b/internal/endtoend/testdata/comment_syntax/postgresql/stdlib/go/query.sql.go
@@ -14,8 +14,16 @@ const doubleDash = `-- name: DoubleDash :one
 SELECT bar FROM foo LIMIT 1
 `
 
-func (q *Queries) DoubleDash(ctx context.Context) (sql.NullString, error) {
-	row := q.db.QueryRowContext(ctx, doubleDash)
+func (q *Queries) DoubleDash(ctx context.Context, aq ...AdditionalQuery) (sql.NullString, error) {
+	query := doubleDash
+	queryParams := []interface{}{}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	row := q.db.QueryRowContext(ctx, query, queryParams...)
 	var bar sql.NullString
 	err := row.Scan(&bar)
 	return bar, err
@@ -25,8 +33,16 @@ const slashStar = `-- name: SlashStar :one
 SELECT bar FROM foo LIMIT 1
 `
 
-func (q *Queries) SlashStar(ctx context.Context) (sql.NullString, error) {
-	row := q.db.QueryRowContext(ctx, slashStar)
+func (q *Queries) SlashStar(ctx context.Context, aq ...AdditionalQuery) (sql.NullString, error) {
+	query := slashStar
+	queryParams := []interface{}{}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	row := q.db.QueryRowContext(ctx, query, queryParams...)
 	var bar sql.NullString
 	err := row.Scan(&bar)
 	return bar, err

--- a/internal/endtoend/testdata/comment_syntax/sqlite/go/db.go
+++ b/internal/endtoend/testdata/comment_syntax/sqlite/go/db.go
@@ -29,3 +29,8 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/comment_syntax/sqlite/go/db.go
+++ b/internal/endtoend/testdata/comment_syntax/sqlite/go/db.go
@@ -32,5 +32,5 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/comment_syntax/sqlite/go/query.sql.go
+++ b/internal/endtoend/testdata/comment_syntax/sqlite/go/query.sql.go
@@ -14,8 +14,16 @@ const doubleDash = `-- name: DoubleDash :one
 SELECT bar FROM foo LIMIT 1
 `
 
-func (q *Queries) DoubleDash(ctx context.Context) (sql.NullString, error) {
-	row := q.db.QueryRowContext(ctx, doubleDash)
+func (q *Queries) DoubleDash(ctx context.Context, aq ...AdditionalQuery) (sql.NullString, error) {
+	query := doubleDash
+	queryParams := []interface{}{}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	row := q.db.QueryRowContext(ctx, query, queryParams...)
 	var bar sql.NullString
 	err := row.Scan(&bar)
 	return bar, err
@@ -25,8 +33,16 @@ const slashStar = `-- name: SlashStar :one
 SELECT bar FROM foo LIMIT 1
 `
 
-func (q *Queries) SlashStar(ctx context.Context) (sql.NullString, error) {
-	row := q.db.QueryRowContext(ctx, slashStar)
+func (q *Queries) SlashStar(ctx context.Context, aq ...AdditionalQuery) (sql.NullString, error) {
+	query := slashStar
+	queryParams := []interface{}{}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	row := q.db.QueryRowContext(ctx, query, queryParams...)
 	var bar sql.NullString
 	err := row.Scan(&bar)
 	return bar, err

--- a/internal/endtoend/testdata/comparisons/mysql/go/db.go
+++ b/internal/endtoend/testdata/comparisons/mysql/go/db.go
@@ -29,3 +29,8 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/comparisons/mysql/go/db.go
+++ b/internal/endtoend/testdata/comparisons/mysql/go/db.go
@@ -32,5 +32,5 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/comparisons/mysql/go/query.sql.go
+++ b/internal/endtoend/testdata/comparisons/mysql/go/query.sql.go
@@ -13,8 +13,16 @@ const alsoNotEqual = `-- name: AlsoNotEqual :many
 SELECT count(*) <> 0 FROM bar
 `
 
-func (q *Queries) AlsoNotEqual(ctx context.Context) ([]bool, error) {
-	rows, err := q.db.QueryContext(ctx, alsoNotEqual)
+func (q *Queries) AlsoNotEqual(ctx context.Context, aq ...AdditionalQuery) ([]bool, error) {
+	query := alsoNotEqual
+	queryParams := []interface{}{}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.QueryContext(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}
@@ -40,8 +48,16 @@ const equal = `-- name: Equal :many
 SELECT count(*) = 0 FROM bar
 `
 
-func (q *Queries) Equal(ctx context.Context) ([]bool, error) {
-	rows, err := q.db.QueryContext(ctx, equal)
+func (q *Queries) Equal(ctx context.Context, aq ...AdditionalQuery) ([]bool, error) {
+	query := equal
+	queryParams := []interface{}{}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.QueryContext(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}
@@ -67,8 +83,16 @@ const greaterThan = `-- name: GreaterThan :many
 SELECT count(*) > 0 FROM bar
 `
 
-func (q *Queries) GreaterThan(ctx context.Context) ([]bool, error) {
-	rows, err := q.db.QueryContext(ctx, greaterThan)
+func (q *Queries) GreaterThan(ctx context.Context, aq ...AdditionalQuery) ([]bool, error) {
+	query := greaterThan
+	queryParams := []interface{}{}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.QueryContext(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}
@@ -94,8 +118,16 @@ const greaterThanOrEqual = `-- name: GreaterThanOrEqual :many
 SELECT count(*) >= 0 FROM bar
 `
 
-func (q *Queries) GreaterThanOrEqual(ctx context.Context) ([]bool, error) {
-	rows, err := q.db.QueryContext(ctx, greaterThanOrEqual)
+func (q *Queries) GreaterThanOrEqual(ctx context.Context, aq ...AdditionalQuery) ([]bool, error) {
+	query := greaterThanOrEqual
+	queryParams := []interface{}{}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.QueryContext(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}
@@ -121,8 +153,16 @@ const lessThan = `-- name: LessThan :many
 SELECT count(*) < 0 FROM bar
 `
 
-func (q *Queries) LessThan(ctx context.Context) ([]bool, error) {
-	rows, err := q.db.QueryContext(ctx, lessThan)
+func (q *Queries) LessThan(ctx context.Context, aq ...AdditionalQuery) ([]bool, error) {
+	query := lessThan
+	queryParams := []interface{}{}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.QueryContext(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}
@@ -148,8 +188,16 @@ const lessThanOrEqual = `-- name: LessThanOrEqual :many
 SELECT count(*) <= 0 FROM bar
 `
 
-func (q *Queries) LessThanOrEqual(ctx context.Context) ([]bool, error) {
-	rows, err := q.db.QueryContext(ctx, lessThanOrEqual)
+func (q *Queries) LessThanOrEqual(ctx context.Context, aq ...AdditionalQuery) ([]bool, error) {
+	query := lessThanOrEqual
+	queryParams := []interface{}{}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.QueryContext(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}
@@ -175,8 +223,16 @@ const notEqual = `-- name: NotEqual :many
 SELECT count(*) != 0 FROM bar
 `
 
-func (q *Queries) NotEqual(ctx context.Context) ([]bool, error) {
-	rows, err := q.db.QueryContext(ctx, notEqual)
+func (q *Queries) NotEqual(ctx context.Context, aq ...AdditionalQuery) ([]bool, error) {
+	query := notEqual
+	queryParams := []interface{}{}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.QueryContext(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/endtoend/testdata/comparisons/postgresql/pgx/v4/go/db.go
+++ b/internal/endtoend/testdata/comparisons/postgresql/pgx/v4/go/db.go
@@ -33,5 +33,5 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/comparisons/postgresql/pgx/v4/go/db.go
+++ b/internal/endtoend/testdata/comparisons/postgresql/pgx/v4/go/db.go
@@ -30,3 +30,8 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/comparisons/postgresql/pgx/v4/go/query.sql.go
+++ b/internal/endtoend/testdata/comparisons/postgresql/pgx/v4/go/query.sql.go
@@ -13,8 +13,16 @@ const alsoNotEqual = `-- name: AlsoNotEqual :many
 SELECT count(*) <> 0 FROM bar
 `
 
-func (q *Queries) AlsoNotEqual(ctx context.Context) ([]bool, error) {
-	rows, err := q.db.Query(ctx, alsoNotEqual)
+func (q *Queries) AlsoNotEqual(ctx context.Context, aq ...AdditionalQuery) ([]bool, error) {
+	query := alsoNotEqual
+	queryParams := []interface{}{}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.Query(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}
@@ -37,8 +45,16 @@ const equal = `-- name: Equal :many
 SELECT count(*) = 0 FROM bar
 `
 
-func (q *Queries) Equal(ctx context.Context) ([]bool, error) {
-	rows, err := q.db.Query(ctx, equal)
+func (q *Queries) Equal(ctx context.Context, aq ...AdditionalQuery) ([]bool, error) {
+	query := equal
+	queryParams := []interface{}{}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.Query(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}
@@ -61,8 +77,16 @@ const greaterThan = `-- name: GreaterThan :many
 SELECT count(*) > 0 FROM bar
 `
 
-func (q *Queries) GreaterThan(ctx context.Context) ([]bool, error) {
-	rows, err := q.db.Query(ctx, greaterThan)
+func (q *Queries) GreaterThan(ctx context.Context, aq ...AdditionalQuery) ([]bool, error) {
+	query := greaterThan
+	queryParams := []interface{}{}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.Query(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}
@@ -85,8 +109,16 @@ const greaterThanOrEqual = `-- name: GreaterThanOrEqual :many
 SELECT count(*) >= 0 FROM bar
 `
 
-func (q *Queries) GreaterThanOrEqual(ctx context.Context) ([]bool, error) {
-	rows, err := q.db.Query(ctx, greaterThanOrEqual)
+func (q *Queries) GreaterThanOrEqual(ctx context.Context, aq ...AdditionalQuery) ([]bool, error) {
+	query := greaterThanOrEqual
+	queryParams := []interface{}{}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.Query(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}
@@ -109,8 +141,16 @@ const lessThan = `-- name: LessThan :many
 SELECT count(*) < 0 FROM bar
 `
 
-func (q *Queries) LessThan(ctx context.Context) ([]bool, error) {
-	rows, err := q.db.Query(ctx, lessThan)
+func (q *Queries) LessThan(ctx context.Context, aq ...AdditionalQuery) ([]bool, error) {
+	query := lessThan
+	queryParams := []interface{}{}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.Query(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}
@@ -133,8 +173,16 @@ const lessThanOrEqual = `-- name: LessThanOrEqual :many
 SELECT count(*) <= 0 FROM bar
 `
 
-func (q *Queries) LessThanOrEqual(ctx context.Context) ([]bool, error) {
-	rows, err := q.db.Query(ctx, lessThanOrEqual)
+func (q *Queries) LessThanOrEqual(ctx context.Context, aq ...AdditionalQuery) ([]bool, error) {
+	query := lessThanOrEqual
+	queryParams := []interface{}{}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.Query(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}
@@ -157,8 +205,16 @@ const notEqual = `-- name: NotEqual :many
 SELECT count(*) != 0 FROM bar
 `
 
-func (q *Queries) NotEqual(ctx context.Context) ([]bool, error) {
-	rows, err := q.db.Query(ctx, notEqual)
+func (q *Queries) NotEqual(ctx context.Context, aq ...AdditionalQuery) ([]bool, error) {
+	query := notEqual
+	queryParams := []interface{}{}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.Query(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/endtoend/testdata/comparisons/postgresql/pgx/v5/go/db.go
+++ b/internal/endtoend/testdata/comparisons/postgresql/pgx/v5/go/db.go
@@ -33,5 +33,5 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/comparisons/postgresql/pgx/v5/go/db.go
+++ b/internal/endtoend/testdata/comparisons/postgresql/pgx/v5/go/db.go
@@ -30,3 +30,8 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/comparisons/postgresql/pgx/v5/go/query.sql.go
+++ b/internal/endtoend/testdata/comparisons/postgresql/pgx/v5/go/query.sql.go
@@ -13,8 +13,16 @@ const alsoNotEqual = `-- name: AlsoNotEqual :many
 SELECT count(*) <> 0 FROM bar
 `
 
-func (q *Queries) AlsoNotEqual(ctx context.Context) ([]bool, error) {
-	rows, err := q.db.Query(ctx, alsoNotEqual)
+func (q *Queries) AlsoNotEqual(ctx context.Context, aq ...AdditionalQuery) ([]bool, error) {
+	query := alsoNotEqual
+	queryParams := []interface{}{}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.Query(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}
@@ -37,8 +45,16 @@ const equal = `-- name: Equal :many
 SELECT count(*) = 0 FROM bar
 `
 
-func (q *Queries) Equal(ctx context.Context) ([]bool, error) {
-	rows, err := q.db.Query(ctx, equal)
+func (q *Queries) Equal(ctx context.Context, aq ...AdditionalQuery) ([]bool, error) {
+	query := equal
+	queryParams := []interface{}{}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.Query(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}
@@ -61,8 +77,16 @@ const greaterThan = `-- name: GreaterThan :many
 SELECT count(*) > 0 FROM bar
 `
 
-func (q *Queries) GreaterThan(ctx context.Context) ([]bool, error) {
-	rows, err := q.db.Query(ctx, greaterThan)
+func (q *Queries) GreaterThan(ctx context.Context, aq ...AdditionalQuery) ([]bool, error) {
+	query := greaterThan
+	queryParams := []interface{}{}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.Query(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}
@@ -85,8 +109,16 @@ const greaterThanOrEqual = `-- name: GreaterThanOrEqual :many
 SELECT count(*) >= 0 FROM bar
 `
 
-func (q *Queries) GreaterThanOrEqual(ctx context.Context) ([]bool, error) {
-	rows, err := q.db.Query(ctx, greaterThanOrEqual)
+func (q *Queries) GreaterThanOrEqual(ctx context.Context, aq ...AdditionalQuery) ([]bool, error) {
+	query := greaterThanOrEqual
+	queryParams := []interface{}{}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.Query(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}
@@ -109,8 +141,16 @@ const lessThan = `-- name: LessThan :many
 SELECT count(*) < 0 FROM bar
 `
 
-func (q *Queries) LessThan(ctx context.Context) ([]bool, error) {
-	rows, err := q.db.Query(ctx, lessThan)
+func (q *Queries) LessThan(ctx context.Context, aq ...AdditionalQuery) ([]bool, error) {
+	query := lessThan
+	queryParams := []interface{}{}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.Query(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}
@@ -133,8 +173,16 @@ const lessThanOrEqual = `-- name: LessThanOrEqual :many
 SELECT count(*) <= 0 FROM bar
 `
 
-func (q *Queries) LessThanOrEqual(ctx context.Context) ([]bool, error) {
-	rows, err := q.db.Query(ctx, lessThanOrEqual)
+func (q *Queries) LessThanOrEqual(ctx context.Context, aq ...AdditionalQuery) ([]bool, error) {
+	query := lessThanOrEqual
+	queryParams := []interface{}{}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.Query(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}
@@ -157,8 +205,16 @@ const notEqual = `-- name: NotEqual :many
 SELECT count(*) != 0 FROM bar
 `
 
-func (q *Queries) NotEqual(ctx context.Context) ([]bool, error) {
-	rows, err := q.db.Query(ctx, notEqual)
+func (q *Queries) NotEqual(ctx context.Context, aq ...AdditionalQuery) ([]bool, error) {
+	query := notEqual
+	queryParams := []interface{}{}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.Query(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/endtoend/testdata/comparisons/postgresql/stdlib/go/db.go
+++ b/internal/endtoend/testdata/comparisons/postgresql/stdlib/go/db.go
@@ -29,3 +29,8 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/comparisons/postgresql/stdlib/go/db.go
+++ b/internal/endtoend/testdata/comparisons/postgresql/stdlib/go/db.go
@@ -32,5 +32,5 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/comparisons/postgresql/stdlib/go/query.sql.go
+++ b/internal/endtoend/testdata/comparisons/postgresql/stdlib/go/query.sql.go
@@ -13,8 +13,16 @@ const alsoNotEqual = `-- name: AlsoNotEqual :many
 SELECT count(*) <> 0 FROM bar
 `
 
-func (q *Queries) AlsoNotEqual(ctx context.Context) ([]bool, error) {
-	rows, err := q.db.QueryContext(ctx, alsoNotEqual)
+func (q *Queries) AlsoNotEqual(ctx context.Context, aq ...AdditionalQuery) ([]bool, error) {
+	query := alsoNotEqual
+	queryParams := []interface{}{}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.QueryContext(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}
@@ -40,8 +48,16 @@ const equal = `-- name: Equal :many
 SELECT count(*) = 0 FROM bar
 `
 
-func (q *Queries) Equal(ctx context.Context) ([]bool, error) {
-	rows, err := q.db.QueryContext(ctx, equal)
+func (q *Queries) Equal(ctx context.Context, aq ...AdditionalQuery) ([]bool, error) {
+	query := equal
+	queryParams := []interface{}{}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.QueryContext(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}
@@ -67,8 +83,16 @@ const greaterThan = `-- name: GreaterThan :many
 SELECT count(*) > 0 FROM bar
 `
 
-func (q *Queries) GreaterThan(ctx context.Context) ([]bool, error) {
-	rows, err := q.db.QueryContext(ctx, greaterThan)
+func (q *Queries) GreaterThan(ctx context.Context, aq ...AdditionalQuery) ([]bool, error) {
+	query := greaterThan
+	queryParams := []interface{}{}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.QueryContext(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}
@@ -94,8 +118,16 @@ const greaterThanOrEqual = `-- name: GreaterThanOrEqual :many
 SELECT count(*) >= 0 FROM bar
 `
 
-func (q *Queries) GreaterThanOrEqual(ctx context.Context) ([]bool, error) {
-	rows, err := q.db.QueryContext(ctx, greaterThanOrEqual)
+func (q *Queries) GreaterThanOrEqual(ctx context.Context, aq ...AdditionalQuery) ([]bool, error) {
+	query := greaterThanOrEqual
+	queryParams := []interface{}{}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.QueryContext(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}
@@ -121,8 +153,16 @@ const lessThan = `-- name: LessThan :many
 SELECT count(*) < 0 FROM bar
 `
 
-func (q *Queries) LessThan(ctx context.Context) ([]bool, error) {
-	rows, err := q.db.QueryContext(ctx, lessThan)
+func (q *Queries) LessThan(ctx context.Context, aq ...AdditionalQuery) ([]bool, error) {
+	query := lessThan
+	queryParams := []interface{}{}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.QueryContext(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}
@@ -148,8 +188,16 @@ const lessThanOrEqual = `-- name: LessThanOrEqual :many
 SELECT count(*) <= 0 FROM bar
 `
 
-func (q *Queries) LessThanOrEqual(ctx context.Context) ([]bool, error) {
-	rows, err := q.db.QueryContext(ctx, lessThanOrEqual)
+func (q *Queries) LessThanOrEqual(ctx context.Context, aq ...AdditionalQuery) ([]bool, error) {
+	query := lessThanOrEqual
+	queryParams := []interface{}{}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.QueryContext(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}
@@ -175,8 +223,16 @@ const notEqual = `-- name: NotEqual :many
 SELECT count(*) != 0 FROM bar
 `
 
-func (q *Queries) NotEqual(ctx context.Context) ([]bool, error) {
-	rows, err := q.db.QueryContext(ctx, notEqual)
+func (q *Queries) NotEqual(ctx context.Context, aq ...AdditionalQuery) ([]bool, error) {
+	query := notEqual
+	queryParams := []interface{}{}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.QueryContext(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/endtoend/testdata/comparisons/sqlite/go/db.go
+++ b/internal/endtoend/testdata/comparisons/sqlite/go/db.go
@@ -29,3 +29,8 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/comparisons/sqlite/go/db.go
+++ b/internal/endtoend/testdata/comparisons/sqlite/go/db.go
@@ -32,5 +32,5 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/comparisons/sqlite/go/query.sql.go
+++ b/internal/endtoend/testdata/comparisons/sqlite/go/query.sql.go
@@ -13,8 +13,16 @@ const alsoNotEqual = `-- name: AlsoNotEqual :many
 SELECT count(*) <> 0 FROM bar
 `
 
-func (q *Queries) AlsoNotEqual(ctx context.Context) ([]bool, error) {
-	rows, err := q.db.QueryContext(ctx, alsoNotEqual)
+func (q *Queries) AlsoNotEqual(ctx context.Context, aq ...AdditionalQuery) ([]bool, error) {
+	query := alsoNotEqual
+	queryParams := []interface{}{}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.QueryContext(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}
@@ -40,8 +48,16 @@ const equal = `-- name: Equal :many
 SELECT count(*) = 0 FROM bar
 `
 
-func (q *Queries) Equal(ctx context.Context) ([]bool, error) {
-	rows, err := q.db.QueryContext(ctx, equal)
+func (q *Queries) Equal(ctx context.Context, aq ...AdditionalQuery) ([]bool, error) {
+	query := equal
+	queryParams := []interface{}{}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.QueryContext(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}
@@ -67,8 +83,16 @@ const greaterThan = `-- name: GreaterThan :many
 SELECT count(*) > 0 FROM bar
 `
 
-func (q *Queries) GreaterThan(ctx context.Context) ([]bool, error) {
-	rows, err := q.db.QueryContext(ctx, greaterThan)
+func (q *Queries) GreaterThan(ctx context.Context, aq ...AdditionalQuery) ([]bool, error) {
+	query := greaterThan
+	queryParams := []interface{}{}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.QueryContext(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}
@@ -94,8 +118,16 @@ const greaterThanOrEqual = `-- name: GreaterThanOrEqual :many
 SELECT count(*) >= 0 FROM bar
 `
 
-func (q *Queries) GreaterThanOrEqual(ctx context.Context) ([]bool, error) {
-	rows, err := q.db.QueryContext(ctx, greaterThanOrEqual)
+func (q *Queries) GreaterThanOrEqual(ctx context.Context, aq ...AdditionalQuery) ([]bool, error) {
+	query := greaterThanOrEqual
+	queryParams := []interface{}{}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.QueryContext(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}
@@ -121,8 +153,16 @@ const lessThan = `-- name: LessThan :many
 SELECT count(*) < 0 FROM bar
 `
 
-func (q *Queries) LessThan(ctx context.Context) ([]bool, error) {
-	rows, err := q.db.QueryContext(ctx, lessThan)
+func (q *Queries) LessThan(ctx context.Context, aq ...AdditionalQuery) ([]bool, error) {
+	query := lessThan
+	queryParams := []interface{}{}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.QueryContext(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}
@@ -148,8 +188,16 @@ const lessThanOrEqual = `-- name: LessThanOrEqual :many
 SELECT count(*) <= 0 FROM bar
 `
 
-func (q *Queries) LessThanOrEqual(ctx context.Context) ([]bool, error) {
-	rows, err := q.db.QueryContext(ctx, lessThanOrEqual)
+func (q *Queries) LessThanOrEqual(ctx context.Context, aq ...AdditionalQuery) ([]bool, error) {
+	query := lessThanOrEqual
+	queryParams := []interface{}{}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.QueryContext(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}
@@ -175,8 +223,16 @@ const notEqual = `-- name: NotEqual :many
 SELECT count(*) != 0 FROM bar
 `
 
-func (q *Queries) NotEqual(ctx context.Context) ([]bool, error) {
-	rows, err := q.db.QueryContext(ctx, notEqual)
+func (q *Queries) NotEqual(ctx context.Context, aq ...AdditionalQuery) ([]bool, error) {
+	query := notEqual
+	queryParams := []interface{}{}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.QueryContext(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/endtoend/testdata/composite_type/pgx/v4/go/db.go
+++ b/internal/endtoend/testdata/composite_type/pgx/v4/go/db.go
@@ -33,5 +33,5 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/composite_type/pgx/v4/go/db.go
+++ b/internal/endtoend/testdata/composite_type/pgx/v4/go/db.go
@@ -30,3 +30,8 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/composite_type/pgx/v4/go/query.sql.go
+++ b/internal/endtoend/testdata/composite_type/pgx/v4/go/query.sql.go
@@ -13,8 +13,16 @@ const listPaths = `-- name: ListPaths :many
 SELECT point_one, point_two FROM foo.paths
 `
 
-func (q *Queries) ListPaths(ctx context.Context) ([]FooPath, error) {
-	rows, err := q.db.Query(ctx, listPaths)
+func (q *Queries) ListPaths(ctx context.Context, aq ...AdditionalQuery) ([]FooPath, error) {
+	query := listPaths
+	queryParams := []interface{}{}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.Query(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/endtoend/testdata/composite_type/pgx/v5/go/db.go
+++ b/internal/endtoend/testdata/composite_type/pgx/v5/go/db.go
@@ -33,5 +33,5 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/composite_type/pgx/v5/go/db.go
+++ b/internal/endtoend/testdata/composite_type/pgx/v5/go/db.go
@@ -30,3 +30,8 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/composite_type/pgx/v5/go/query.sql.go
+++ b/internal/endtoend/testdata/composite_type/pgx/v5/go/query.sql.go
@@ -13,8 +13,16 @@ const listPaths = `-- name: ListPaths :many
 SELECT point_one, point_two FROM foo.paths
 `
 
-func (q *Queries) ListPaths(ctx context.Context) ([]FooPath, error) {
-	rows, err := q.db.Query(ctx, listPaths)
+func (q *Queries) ListPaths(ctx context.Context, aq ...AdditionalQuery) ([]FooPath, error) {
+	query := listPaths
+	queryParams := []interface{}{}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.Query(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/endtoend/testdata/composite_type/stdlib/go/db.go
+++ b/internal/endtoend/testdata/composite_type/stdlib/go/db.go
@@ -29,3 +29,8 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/composite_type/stdlib/go/db.go
+++ b/internal/endtoend/testdata/composite_type/stdlib/go/db.go
@@ -32,5 +32,5 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/composite_type/stdlib/go/query.sql.go
+++ b/internal/endtoend/testdata/composite_type/stdlib/go/query.sql.go
@@ -13,8 +13,16 @@ const listPaths = `-- name: ListPaths :many
 SELECT point_one, point_two FROM foo.paths
 `
 
-func (q *Queries) ListPaths(ctx context.Context) ([]FooPath, error) {
-	rows, err := q.db.QueryContext(ctx, listPaths)
+func (q *Queries) ListPaths(ctx context.Context, aq ...AdditionalQuery) ([]FooPath, error) {
+	query := listPaths
+	queryParams := []interface{}{}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.QueryContext(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/endtoend/testdata/conflicted_arg_name/postgresql/db/db.go
+++ b/internal/endtoend/testdata/conflicted_arg_name/postgresql/db/db.go
@@ -29,3 +29,8 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/conflicted_arg_name/postgresql/db/db.go
+++ b/internal/endtoend/testdata/conflicted_arg_name/postgresql/db/db.go
@@ -32,5 +32,5 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/conflicted_arg_name/postgresql/db/query.sql.go
+++ b/internal/endtoend/testdata/conflicted_arg_name/postgresql/db/query.sql.go
@@ -16,8 +16,16 @@ const time2ByTime = `-- name: Time2ByTime :one
 SELECT time2 FROM foo WHERE time=$1
 `
 
-func (q *Queries) Time2ByTime(ctx context.Context, argTime time.Time) (time.Time, error) {
-	row := q.db.QueryRowContext(ctx, time2ByTime, argTime)
+func (q *Queries) Time2ByTime(ctx context.Context, argTime time.Time, aq ...AdditionalQuery) (time.Time, error) {
+	query := time2ByTime
+	queryParams := []interface{}{argTime}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	row := q.db.QueryRowContext(ctx, query, queryParams...)
 	var time2 time.Time
 	err := row.Scan(&time2)
 	return time2, err
@@ -27,8 +35,16 @@ const uuid2ByUuid = `-- name: Uuid2ByUuid :one
 SELECT uuid2 FROM foo WHERE uuid=$1
 `
 
-func (q *Queries) Uuid2ByUuid(ctx context.Context, argUuid uuid.UUID) (uuid.UUID, error) {
-	row := q.db.QueryRowContext(ctx, uuid2ByUuid, argUuid)
+func (q *Queries) Uuid2ByUuid(ctx context.Context, argUuid uuid.UUID, aq ...AdditionalQuery) (uuid.UUID, error) {
+	query := uuid2ByUuid
+	queryParams := []interface{}{argUuid}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	row := q.db.QueryRowContext(ctx, query, queryParams...)
 	var uuid2 uuid.UUID
 	err := row.Scan(&uuid2)
 	return uuid2, err

--- a/internal/endtoend/testdata/copyfrom/mysql/go/db.go
+++ b/internal/endtoend/testdata/copyfrom/mysql/go/db.go
@@ -29,3 +29,8 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/copyfrom/mysql/go/db.go
+++ b/internal/endtoend/testdata/copyfrom/mysql/go/db.go
@@ -32,5 +32,5 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/copyfrom/postgresql/pgx/v4/go/db.go
+++ b/internal/endtoend/testdata/copyfrom/postgresql/pgx/v4/go/db.go
@@ -31,3 +31,8 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/copyfrom/postgresql/pgx/v4/go/db.go
+++ b/internal/endtoend/testdata/copyfrom/postgresql/pgx/v4/go/db.go
@@ -34,5 +34,5 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/copyfrom/postgresql/pgx/v5/go/db.go
+++ b/internal/endtoend/testdata/copyfrom/postgresql/pgx/v5/go/db.go
@@ -31,3 +31,8 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/copyfrom/postgresql/pgx/v5/go/db.go
+++ b/internal/endtoend/testdata/copyfrom/postgresql/pgx/v5/go/db.go
@@ -34,5 +34,5 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/copyfrom_imports/postgresql/pgx/v4/go/db.go
+++ b/internal/endtoend/testdata/copyfrom_imports/postgresql/pgx/v4/go/db.go
@@ -31,3 +31,8 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/copyfrom_imports/postgresql/pgx/v4/go/db.go
+++ b/internal/endtoend/testdata/copyfrom_imports/postgresql/pgx/v4/go/db.go
@@ -34,5 +34,5 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/copyfrom_imports/postgresql/pgx/v5/go/db.go
+++ b/internal/endtoend/testdata/copyfrom_imports/postgresql/pgx/v5/go/db.go
@@ -31,3 +31,8 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/copyfrom_imports/postgresql/pgx/v5/go/db.go
+++ b/internal/endtoend/testdata/copyfrom_imports/postgresql/pgx/v5/go/db.go
@@ -34,5 +34,5 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/copyfrom_singlecolumn/postgresql/pgx/v4/go/db.go
+++ b/internal/endtoend/testdata/copyfrom_singlecolumn/postgresql/pgx/v4/go/db.go
@@ -31,3 +31,8 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/copyfrom_singlecolumn/postgresql/pgx/v4/go/db.go
+++ b/internal/endtoend/testdata/copyfrom_singlecolumn/postgresql/pgx/v4/go/db.go
@@ -34,5 +34,5 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/copyfrom_singlecolumn/postgresql/pgx/v5/go/db.go
+++ b/internal/endtoend/testdata/copyfrom_singlecolumn/postgresql/pgx/v5/go/db.go
@@ -31,3 +31,8 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/copyfrom_singlecolumn/postgresql/pgx/v5/go/db.go
+++ b/internal/endtoend/testdata/copyfrom_singlecolumn/postgresql/pgx/v5/go/db.go
@@ -34,5 +34,5 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/count_star/mysql/go/db.go
+++ b/internal/endtoend/testdata/count_star/mysql/go/db.go
@@ -29,3 +29,8 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/count_star/mysql/go/db.go
+++ b/internal/endtoend/testdata/count_star/mysql/go/db.go
@@ -32,5 +32,5 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/count_star/mysql/go/query.sql.go
+++ b/internal/endtoend/testdata/count_star/mysql/go/query.sql.go
@@ -13,8 +13,16 @@ const countStarLower = `-- name: CountStarLower :one
 SELECT count(*) FROM bar
 `
 
-func (q *Queries) CountStarLower(ctx context.Context) (int64, error) {
-	row := q.db.QueryRowContext(ctx, countStarLower)
+func (q *Queries) CountStarLower(ctx context.Context, aq ...AdditionalQuery) (int64, error) {
+	query := countStarLower
+	queryParams := []interface{}{}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	row := q.db.QueryRowContext(ctx, query, queryParams...)
 	var count int64
 	err := row.Scan(&count)
 	return count, err
@@ -24,8 +32,16 @@ const countStarUpper = `-- name: CountStarUpper :one
 SELECT COUNT(*) FROM bar
 `
 
-func (q *Queries) CountStarUpper(ctx context.Context) (int64, error) {
-	row := q.db.QueryRowContext(ctx, countStarUpper)
+func (q *Queries) CountStarUpper(ctx context.Context, aq ...AdditionalQuery) (int64, error) {
+	query := countStarUpper
+	queryParams := []interface{}{}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	row := q.db.QueryRowContext(ctx, query, queryParams...)
 	var count int64
 	err := row.Scan(&count)
 	return count, err

--- a/internal/endtoend/testdata/count_star/postgresql/pgx/v4/go/db.go
+++ b/internal/endtoend/testdata/count_star/postgresql/pgx/v4/go/db.go
@@ -33,5 +33,5 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/count_star/postgresql/pgx/v4/go/db.go
+++ b/internal/endtoend/testdata/count_star/postgresql/pgx/v4/go/db.go
@@ -30,3 +30,8 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/count_star/postgresql/pgx/v4/go/query.sql.go
+++ b/internal/endtoend/testdata/count_star/postgresql/pgx/v4/go/query.sql.go
@@ -13,8 +13,10 @@ const countStarLower = `-- name: CountStarLower :one
 SELECT count(*) FROM bar
 `
 
-func (q *Queries) CountStarLower(ctx context.Context) (int64, error) {
-	row := q.db.QueryRow(ctx, countStarLower)
+func (q *Queries) CountStarLower(ctx context.Context, aq ...AdditionalQuery) (int64, error) {
+	query := countStarLower
+	queryParams := []interface{}{}
+	row := q.db.QueryRow(ctx, query, queryParams...)
 	var count int64
 	err := row.Scan(&count)
 	return count, err
@@ -24,8 +26,10 @@ const countStarUpper = `-- name: CountStarUpper :one
 SELECT COUNT(*) FROM bar
 `
 
-func (q *Queries) CountStarUpper(ctx context.Context) (int64, error) {
-	row := q.db.QueryRow(ctx, countStarUpper)
+func (q *Queries) CountStarUpper(ctx context.Context, aq ...AdditionalQuery) (int64, error) {
+	query := countStarUpper
+	queryParams := []interface{}{}
+	row := q.db.QueryRow(ctx, query, queryParams...)
 	var count int64
 	err := row.Scan(&count)
 	return count, err

--- a/internal/endtoend/testdata/count_star/postgresql/pgx/v5/go/db.go
+++ b/internal/endtoend/testdata/count_star/postgresql/pgx/v5/go/db.go
@@ -33,5 +33,5 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/count_star/postgresql/pgx/v5/go/db.go
+++ b/internal/endtoend/testdata/count_star/postgresql/pgx/v5/go/db.go
@@ -30,3 +30,8 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/count_star/postgresql/pgx/v5/go/query.sql.go
+++ b/internal/endtoend/testdata/count_star/postgresql/pgx/v5/go/query.sql.go
@@ -13,8 +13,10 @@ const countStarLower = `-- name: CountStarLower :one
 SELECT count(*) FROM bar
 `
 
-func (q *Queries) CountStarLower(ctx context.Context) (int64, error) {
-	row := q.db.QueryRow(ctx, countStarLower)
+func (q *Queries) CountStarLower(ctx context.Context, aq ...AdditionalQuery) (int64, error) {
+	query := countStarLower
+	queryParams := []interface{}{}
+	row := q.db.QueryRow(ctx, query, queryParams...)
 	var count int64
 	err := row.Scan(&count)
 	return count, err
@@ -24,8 +26,10 @@ const countStarUpper = `-- name: CountStarUpper :one
 SELECT COUNT(*) FROM bar
 `
 
-func (q *Queries) CountStarUpper(ctx context.Context) (int64, error) {
-	row := q.db.QueryRow(ctx, countStarUpper)
+func (q *Queries) CountStarUpper(ctx context.Context, aq ...AdditionalQuery) (int64, error) {
+	query := countStarUpper
+	queryParams := []interface{}{}
+	row := q.db.QueryRow(ctx, query, queryParams...)
 	var count int64
 	err := row.Scan(&count)
 	return count, err

--- a/internal/endtoend/testdata/count_star/postgresql/stdlib/go/db.go
+++ b/internal/endtoend/testdata/count_star/postgresql/stdlib/go/db.go
@@ -29,3 +29,8 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/count_star/postgresql/stdlib/go/db.go
+++ b/internal/endtoend/testdata/count_star/postgresql/stdlib/go/db.go
@@ -32,5 +32,5 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/count_star/postgresql/stdlib/go/query.sql.go
+++ b/internal/endtoend/testdata/count_star/postgresql/stdlib/go/query.sql.go
@@ -13,8 +13,16 @@ const countStarLower = `-- name: CountStarLower :one
 SELECT count(*) FROM bar
 `
 
-func (q *Queries) CountStarLower(ctx context.Context) (int64, error) {
-	row := q.db.QueryRowContext(ctx, countStarLower)
+func (q *Queries) CountStarLower(ctx context.Context, aq ...AdditionalQuery) (int64, error) {
+	query := countStarLower
+	queryParams := []interface{}{}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	row := q.db.QueryRowContext(ctx, query, queryParams...)
 	var count int64
 	err := row.Scan(&count)
 	return count, err
@@ -24,8 +32,16 @@ const countStarUpper = `-- name: CountStarUpper :one
 SELECT COUNT(*) FROM bar
 `
 
-func (q *Queries) CountStarUpper(ctx context.Context) (int64, error) {
-	row := q.db.QueryRowContext(ctx, countStarUpper)
+func (q *Queries) CountStarUpper(ctx context.Context, aq ...AdditionalQuery) (int64, error) {
+	query := countStarUpper
+	queryParams := []interface{}{}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	row := q.db.QueryRowContext(ctx, query, queryParams...)
 	var count int64
 	err := row.Scan(&count)
 	return count, err

--- a/internal/endtoend/testdata/count_star/sqlite/go/db.go
+++ b/internal/endtoend/testdata/count_star/sqlite/go/db.go
@@ -29,3 +29,8 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/count_star/sqlite/go/db.go
+++ b/internal/endtoend/testdata/count_star/sqlite/go/db.go
@@ -32,5 +32,5 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/count_star/sqlite/go/query.sql.go
+++ b/internal/endtoend/testdata/count_star/sqlite/go/query.sql.go
@@ -13,8 +13,16 @@ const countStarLower = `-- name: CountStarLower :one
 SELECT count(*) FROM bar
 `
 
-func (q *Queries) CountStarLower(ctx context.Context) (int64, error) {
-	row := q.db.QueryRowContext(ctx, countStarLower)
+func (q *Queries) CountStarLower(ctx context.Context, aq ...AdditionalQuery) (int64, error) {
+	query := countStarLower
+	queryParams := []interface{}{}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	row := q.db.QueryRowContext(ctx, query, queryParams...)
 	var count int64
 	err := row.Scan(&count)
 	return count, err
@@ -24,8 +32,16 @@ const countStarUpper = `-- name: CountStarUpper :one
 SELECT COUNT(*) FROM bar
 `
 
-func (q *Queries) CountStarUpper(ctx context.Context) (int64, error) {
-	row := q.db.QueryRowContext(ctx, countStarUpper)
+func (q *Queries) CountStarUpper(ctx context.Context, aq ...AdditionalQuery) (int64, error) {
+	query := countStarUpper
+	queryParams := []interface{}{}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	row := q.db.QueryRowContext(ctx, query, queryParams...)
 	var count int64
 	err := row.Scan(&count)
 	return count, err

--- a/internal/endtoend/testdata/create_materialized_view/postgresql/go/db.go
+++ b/internal/endtoend/testdata/create_materialized_view/postgresql/go/db.go
@@ -29,3 +29,8 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/create_materialized_view/postgresql/go/db.go
+++ b/internal/endtoend/testdata/create_materialized_view/postgresql/go/db.go
@@ -32,5 +32,5 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/create_materialized_view/postgresql/go/query.sql.go
+++ b/internal/endtoend/testdata/create_materialized_view/postgresql/go/query.sql.go
@@ -13,8 +13,16 @@ const getFirst = `-- name: GetFirst :many
 SELECT val FROM mat_first_view
 `
 
-func (q *Queries) GetFirst(ctx context.Context) ([]string, error) {
-	rows, err := q.db.QueryContext(ctx, getFirst)
+func (q *Queries) GetFirst(ctx context.Context, aq ...AdditionalQuery) ([]string, error) {
+	query := getFirst
+	queryParams := []interface{}{}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.QueryContext(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/endtoend/testdata/create_table_as/postgresql/go/db.go
+++ b/internal/endtoend/testdata/create_table_as/postgresql/go/db.go
@@ -29,3 +29,8 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/create_table_as/postgresql/go/db.go
+++ b/internal/endtoend/testdata/create_table_as/postgresql/go/db.go
@@ -32,5 +32,5 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/create_table_as/postgresql/go/query.sql.go
+++ b/internal/endtoend/testdata/create_table_as/postgresql/go/query.sql.go
@@ -13,8 +13,16 @@ const getFirst = `-- name: GetFirst :many
 SELECT val FROM second_table
 `
 
-func (q *Queries) GetFirst(ctx context.Context) ([]string, error) {
-	rows, err := q.db.QueryContext(ctx, getFirst)
+func (q *Queries) GetFirst(ctx context.Context, aq ...AdditionalQuery) ([]string, error) {
+	query := getFirst
+	queryParams := []interface{}{}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.QueryContext(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/endtoend/testdata/create_table_like/mysql/go/db.go
+++ b/internal/endtoend/testdata/create_table_like/mysql/go/db.go
@@ -29,3 +29,8 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/create_table_like/mysql/go/db.go
+++ b/internal/endtoend/testdata/create_table_like/mysql/go/db.go
@@ -32,5 +32,5 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/create_table_like/mysql/go/query.sql.go
+++ b/internal/endtoend/testdata/create_table_like/mysql/go/query.sql.go
@@ -13,8 +13,16 @@ const getAll = `-- name: GetAll :many
 SELECT id, first_name, last_name, date_of_birth FROM super_users
 `
 
-func (q *Queries) GetAll(ctx context.Context) ([]SuperUser, error) {
-	rows, err := q.db.QueryContext(ctx, getAll)
+func (q *Queries) GetAll(ctx context.Context, aq ...AdditionalQuery) ([]SuperUser, error) {
+	query := getAll
+	queryParams := []interface{}{}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.QueryContext(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/endtoend/testdata/create_table_like/postgresql/go/db.go
+++ b/internal/endtoend/testdata/create_table_like/postgresql/go/db.go
@@ -29,3 +29,8 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/create_table_like/postgresql/go/db.go
+++ b/internal/endtoend/testdata/create_table_like/postgresql/go/db.go
@@ -32,5 +32,5 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/create_table_like/postgresql/go/query.sql.go
+++ b/internal/endtoend/testdata/create_table_like/postgresql/go/query.sql.go
@@ -13,8 +13,16 @@ const getAll = `-- name: GetAll :many
 SELECT id, first_name, last_name, date_of_birth FROM super_users
 `
 
-func (q *Queries) GetAll(ctx context.Context) ([]SuperUser, error) {
-	rows, err := q.db.QueryContext(ctx, getAll)
+func (q *Queries) GetAll(ctx context.Context, aq ...AdditionalQuery) ([]SuperUser, error) {
+	query := getAll
+	queryParams := []interface{}{}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.QueryContext(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/endtoend/testdata/create_view/mysql/go/db.go
+++ b/internal/endtoend/testdata/create_view/mysql/go/db.go
@@ -29,3 +29,8 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/create_view/mysql/go/db.go
+++ b/internal/endtoend/testdata/create_view/mysql/go/db.go
@@ -32,5 +32,5 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/create_view/mysql/go/query.sql.go
+++ b/internal/endtoend/testdata/create_view/mysql/go/query.sql.go
@@ -13,8 +13,16 @@ const getFirst = `-- name: GetFirst :many
 SELECT val FROM first_view
 `
 
-func (q *Queries) GetFirst(ctx context.Context) ([]string, error) {
-	rows, err := q.db.QueryContext(ctx, getFirst)
+func (q *Queries) GetFirst(ctx context.Context, aq ...AdditionalQuery) ([]string, error) {
+	query := getFirst
+	queryParams := []interface{}{}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.QueryContext(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}
@@ -40,8 +48,16 @@ const getSecond = `-- name: GetSecond :many
 SELECT val, val2 FROM second_view WHERE val2 = $1
 `
 
-func (q *Queries) GetSecond(ctx context.Context) ([]SecondView, error) {
-	rows, err := q.db.QueryContext(ctx, getSecond)
+func (q *Queries) GetSecond(ctx context.Context, aq ...AdditionalQuery) ([]SecondView, error) {
+	query := getSecond
+	queryParams := []interface{}{}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.QueryContext(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/endtoend/testdata/create_view/postgresql/go/db.go
+++ b/internal/endtoend/testdata/create_view/postgresql/go/db.go
@@ -29,3 +29,8 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/create_view/postgresql/go/db.go
+++ b/internal/endtoend/testdata/create_view/postgresql/go/db.go
@@ -32,5 +32,5 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/create_view/postgresql/go/query.sql.go
+++ b/internal/endtoend/testdata/create_view/postgresql/go/query.sql.go
@@ -14,8 +14,16 @@ const getFirst = `-- name: GetFirst :many
 SELECT val FROM first_view
 `
 
-func (q *Queries) GetFirst(ctx context.Context) ([]string, error) {
-	rows, err := q.db.QueryContext(ctx, getFirst)
+func (q *Queries) GetFirst(ctx context.Context, aq ...AdditionalQuery) ([]string, error) {
+	query := getFirst
+	queryParams := []interface{}{}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.QueryContext(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}
@@ -41,8 +49,16 @@ const getSecond = `-- name: GetSecond :many
 SELECT val, val2 FROM second_view WHERE val2 = $1
 `
 
-func (q *Queries) GetSecond(ctx context.Context, val2 sql.NullInt32) ([]SecondView, error) {
-	rows, err := q.db.QueryContext(ctx, getSecond, val2)
+func (q *Queries) GetSecond(ctx context.Context, val2 sql.NullInt32, aq ...AdditionalQuery) ([]SecondView, error) {
+	query := getSecond
+	queryParams := []interface{}{val2}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.QueryContext(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/endtoend/testdata/create_view/sqlite/go/db.go
+++ b/internal/endtoend/testdata/create_view/sqlite/go/db.go
@@ -29,3 +29,8 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/create_view/sqlite/go/db.go
+++ b/internal/endtoend/testdata/create_view/sqlite/go/db.go
@@ -32,5 +32,5 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/create_view/sqlite/go/query.sql.go
+++ b/internal/endtoend/testdata/create_view/sqlite/go/query.sql.go
@@ -14,8 +14,16 @@ const getFirst = `-- name: GetFirst :many
 SELECT val FROM first_view
 `
 
-func (q *Queries) GetFirst(ctx context.Context) ([]string, error) {
-	rows, err := q.db.QueryContext(ctx, getFirst)
+func (q *Queries) GetFirst(ctx context.Context, aq ...AdditionalQuery) ([]string, error) {
+	query := getFirst
+	queryParams := []interface{}{}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.QueryContext(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}
@@ -41,8 +49,16 @@ const getSecond = `-- name: GetSecond :many
 SELECT val, val2 FROM second_view WHERE val2 = ?
 `
 
-func (q *Queries) GetSecond(ctx context.Context, val2 sql.NullInt64) ([]SecondView, error) {
-	rows, err := q.db.QueryContext(ctx, getSecond, val2)
+func (q *Queries) GetSecond(ctx context.Context, val2 sql.NullInt64, aq ...AdditionalQuery) ([]SecondView, error) {
+	query := getSecond
+	queryParams := []interface{}{val2}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.QueryContext(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/endtoend/testdata/cte_count/mysql/go/db.go
+++ b/internal/endtoend/testdata/cte_count/mysql/go/db.go
@@ -29,3 +29,8 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/cte_count/mysql/go/db.go
+++ b/internal/endtoend/testdata/cte_count/mysql/go/db.go
@@ -32,5 +32,5 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/cte_count/mysql/go/query.sql.go
+++ b/internal/endtoend/testdata/cte_count/mysql/go/query.sql.go
@@ -24,8 +24,16 @@ type CTECountRow struct {
 	Count_2 int64
 }
 
-func (q *Queries) CTECount(ctx context.Context) ([]CTECountRow, error) {
-	rows, err := q.db.QueryContext(ctx, cTECount)
+func (q *Queries) CTECount(ctx context.Context, aq ...AdditionalQuery) ([]CTECountRow, error) {
+	query := cTECount
+	queryParams := []interface{}{}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.QueryContext(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/endtoend/testdata/cte_count/pgx/v4/go/db.go
+++ b/internal/endtoend/testdata/cte_count/pgx/v4/go/db.go
@@ -33,5 +33,5 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/cte_count/pgx/v4/go/db.go
+++ b/internal/endtoend/testdata/cte_count/pgx/v4/go/db.go
@@ -30,3 +30,8 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/cte_count/pgx/v4/go/query.sql.go
+++ b/internal/endtoend/testdata/cte_count/pgx/v4/go/query.sql.go
@@ -24,8 +24,16 @@ type CTECountRow struct {
 	Count_2 int64
 }
 
-func (q *Queries) CTECount(ctx context.Context) ([]CTECountRow, error) {
-	rows, err := q.db.Query(ctx, cTECount)
+func (q *Queries) CTECount(ctx context.Context, aq ...AdditionalQuery) ([]CTECountRow, error) {
+	query := cTECount
+	queryParams := []interface{}{}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.Query(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/endtoend/testdata/cte_count/pgx/v5/go/db.go
+++ b/internal/endtoend/testdata/cte_count/pgx/v5/go/db.go
@@ -33,5 +33,5 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/cte_count/pgx/v5/go/db.go
+++ b/internal/endtoend/testdata/cte_count/pgx/v5/go/db.go
@@ -30,3 +30,8 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/cte_count/pgx/v5/go/query.sql.go
+++ b/internal/endtoend/testdata/cte_count/pgx/v5/go/query.sql.go
@@ -24,8 +24,16 @@ type CTECountRow struct {
 	Count_2 int64
 }
 
-func (q *Queries) CTECount(ctx context.Context) ([]CTECountRow, error) {
-	rows, err := q.db.Query(ctx, cTECount)
+func (q *Queries) CTECount(ctx context.Context, aq ...AdditionalQuery) ([]CTECountRow, error) {
+	query := cTECount
+	queryParams := []interface{}{}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.Query(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/endtoend/testdata/cte_count/stdlib/go/db.go
+++ b/internal/endtoend/testdata/cte_count/stdlib/go/db.go
@@ -29,3 +29,8 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/cte_count/stdlib/go/db.go
+++ b/internal/endtoend/testdata/cte_count/stdlib/go/db.go
@@ -32,5 +32,5 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/cte_count/stdlib/go/query.sql.go
+++ b/internal/endtoend/testdata/cte_count/stdlib/go/query.sql.go
@@ -24,8 +24,16 @@ type CTECountRow struct {
 	Count_2 int64
 }
 
-func (q *Queries) CTECount(ctx context.Context) ([]CTECountRow, error) {
-	rows, err := q.db.QueryContext(ctx, cTECount)
+func (q *Queries) CTECount(ctx context.Context, aq ...AdditionalQuery) ([]CTECountRow, error) {
+	query := cTECount
+	queryParams := []interface{}{}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.QueryContext(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/endtoend/testdata/cte_filter/mysql/go/db.go
+++ b/internal/endtoend/testdata/cte_filter/mysql/go/db.go
@@ -29,3 +29,8 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/cte_filter/mysql/go/db.go
+++ b/internal/endtoend/testdata/cte_filter/mysql/go/db.go
@@ -32,5 +32,5 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/cte_filter/mysql/go/query.sql.go
+++ b/internal/endtoend/testdata/cte_filter/mysql/go/query.sql.go
@@ -17,8 +17,16 @@ SELECT filter_count.count
 FROM filter_count
 `
 
-func (q *Queries) CTEFilter(ctx context.Context, ready bool) ([]int64, error) {
-	rows, err := q.db.QueryContext(ctx, cTEFilter, ready)
+func (q *Queries) CTEFilter(ctx context.Context, ready bool, aq ...AdditionalQuery) ([]int64, error) {
+	query := cTEFilter
+	queryParams := []interface{}{ready}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.QueryContext(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/endtoend/testdata/cte_filter/pgx/v4/go/db.go
+++ b/internal/endtoend/testdata/cte_filter/pgx/v4/go/db.go
@@ -33,5 +33,5 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/cte_filter/pgx/v4/go/db.go
+++ b/internal/endtoend/testdata/cte_filter/pgx/v4/go/db.go
@@ -30,3 +30,8 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/cte_filter/pgx/v4/go/query.sql.go
+++ b/internal/endtoend/testdata/cte_filter/pgx/v4/go/query.sql.go
@@ -17,8 +17,16 @@ SELECT filter_count.count
 FROM filter_count
 `
 
-func (q *Queries) CTEFilter(ctx context.Context, ready bool) ([]int64, error) {
-	rows, err := q.db.Query(ctx, cTEFilter, ready)
+func (q *Queries) CTEFilter(ctx context.Context, ready bool, aq ...AdditionalQuery) ([]int64, error) {
+	query := cTEFilter
+	queryParams := []interface{}{ready}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.Query(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/endtoend/testdata/cte_filter/pgx/v5/go/db.go
+++ b/internal/endtoend/testdata/cte_filter/pgx/v5/go/db.go
@@ -33,5 +33,5 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/cte_filter/pgx/v5/go/db.go
+++ b/internal/endtoend/testdata/cte_filter/pgx/v5/go/db.go
@@ -30,3 +30,8 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/cte_filter/pgx/v5/go/query.sql.go
+++ b/internal/endtoend/testdata/cte_filter/pgx/v5/go/query.sql.go
@@ -17,8 +17,16 @@ SELECT filter_count.count
 FROM filter_count
 `
 
-func (q *Queries) CTEFilter(ctx context.Context, ready bool) ([]int64, error) {
-	rows, err := q.db.Query(ctx, cTEFilter, ready)
+func (q *Queries) CTEFilter(ctx context.Context, ready bool, aq ...AdditionalQuery) ([]int64, error) {
+	query := cTEFilter
+	queryParams := []interface{}{ready}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.Query(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/endtoend/testdata/cte_filter/stdlib/go/db.go
+++ b/internal/endtoend/testdata/cte_filter/stdlib/go/db.go
@@ -29,3 +29,8 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/cte_filter/stdlib/go/db.go
+++ b/internal/endtoend/testdata/cte_filter/stdlib/go/db.go
@@ -32,5 +32,5 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/cte_filter/stdlib/go/query.sql.go
+++ b/internal/endtoend/testdata/cte_filter/stdlib/go/query.sql.go
@@ -17,8 +17,16 @@ SELECT filter_count.count
 FROM filter_count
 `
 
-func (q *Queries) CTEFilter(ctx context.Context, ready bool) ([]int64, error) {
-	rows, err := q.db.QueryContext(ctx, cTEFilter, ready)
+func (q *Queries) CTEFilter(ctx context.Context, ready bool, aq ...AdditionalQuery) ([]int64, error) {
+	query := cTEFilter
+	queryParams := []interface{}{ready}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.QueryContext(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/endtoend/testdata/cte_in_delete/mysql/go/db.go
+++ b/internal/endtoend/testdata/cte_in_delete/mysql/go/db.go
@@ -29,3 +29,8 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/cte_in_delete/mysql/go/db.go
+++ b/internal/endtoend/testdata/cte_in_delete/mysql/go/db.go
@@ -32,5 +32,5 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/cte_in_delete/mysql/go/query.sql.go
+++ b/internal/endtoend/testdata/cte_in_delete/mysql/go/query.sql.go
@@ -17,6 +17,9 @@ DELETE FROM bar WHERE id IN (SELECT id FROM ready_ids)
 `
 
 func (q *Queries) DeleteReadyWithCTE(ctx context.Context) error {
-	_, err := q.db.ExecContext(ctx, deleteReadyWithCTE)
+	query := deleteReadyWithCTE
+	queryParams := []interface{}{}
+
+	_, err := q.db.ExecContext(ctx, query, queryParams...)
 	return err
 }

--- a/internal/endtoend/testdata/cte_in_delete/pgx/v4/go/db.go
+++ b/internal/endtoend/testdata/cte_in_delete/pgx/v4/go/db.go
@@ -33,5 +33,5 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/cte_in_delete/pgx/v4/go/db.go
+++ b/internal/endtoend/testdata/cte_in_delete/pgx/v4/go/db.go
@@ -30,3 +30,8 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/cte_in_delete/pgx/v4/go/query.sql.go
+++ b/internal/endtoend/testdata/cte_in_delete/pgx/v4/go/query.sql.go
@@ -17,8 +17,16 @@ DELETE FROM bar WHERE id IN (SELECT id FROM ready_ids)
 RETURNING id
 `
 
-func (q *Queries) DeleteReadyWithCTE(ctx context.Context) ([]int32, error) {
-	rows, err := q.db.Query(ctx, deleteReadyWithCTE)
+func (q *Queries) DeleteReadyWithCTE(ctx context.Context, aq ...AdditionalQuery) ([]int32, error) {
+	query := deleteReadyWithCTE
+	queryParams := []interface{}{}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.Query(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/endtoend/testdata/cte_in_delete/pgx/v5/go/db.go
+++ b/internal/endtoend/testdata/cte_in_delete/pgx/v5/go/db.go
@@ -33,5 +33,5 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/cte_in_delete/pgx/v5/go/db.go
+++ b/internal/endtoend/testdata/cte_in_delete/pgx/v5/go/db.go
@@ -30,3 +30,8 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/cte_in_delete/pgx/v5/go/query.sql.go
+++ b/internal/endtoend/testdata/cte_in_delete/pgx/v5/go/query.sql.go
@@ -17,8 +17,16 @@ DELETE FROM bar WHERE id IN (SELECT id FROM ready_ids)
 RETURNING id
 `
 
-func (q *Queries) DeleteReadyWithCTE(ctx context.Context) ([]int32, error) {
-	rows, err := q.db.Query(ctx, deleteReadyWithCTE)
+func (q *Queries) DeleteReadyWithCTE(ctx context.Context, aq ...AdditionalQuery) ([]int32, error) {
+	query := deleteReadyWithCTE
+	queryParams := []interface{}{}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.Query(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/endtoend/testdata/cte_in_delete/stdlib/go/db.go
+++ b/internal/endtoend/testdata/cte_in_delete/stdlib/go/db.go
@@ -29,3 +29,8 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/cte_in_delete/stdlib/go/db.go
+++ b/internal/endtoend/testdata/cte_in_delete/stdlib/go/db.go
@@ -32,5 +32,5 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/cte_in_delete/stdlib/go/query.sql.go
+++ b/internal/endtoend/testdata/cte_in_delete/stdlib/go/query.sql.go
@@ -17,8 +17,16 @@ DELETE FROM bar WHERE id IN (SELECT id FROM ready_ids)
 RETURNING id
 `
 
-func (q *Queries) DeleteReadyWithCTE(ctx context.Context) ([]int32, error) {
-	rows, err := q.db.QueryContext(ctx, deleteReadyWithCTE)
+func (q *Queries) DeleteReadyWithCTE(ctx context.Context, aq ...AdditionalQuery) ([]int32, error) {
+	query := deleteReadyWithCTE
+	queryParams := []interface{}{}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.QueryContext(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/endtoend/testdata/cte_recursive/mysql/go/db.go
+++ b/internal/endtoend/testdata/cte_recursive/mysql/go/db.go
@@ -29,3 +29,8 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/cte_recursive/mysql/go/db.go
+++ b/internal/endtoend/testdata/cte_recursive/mysql/go/db.go
@@ -32,5 +32,5 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/cte_recursive/mysql/go/query.sql.go
+++ b/internal/endtoend/testdata/cte_recursive/mysql/go/query.sql.go
@@ -26,8 +26,16 @@ type CTERecursiveRow struct {
 	ParentID sql.NullInt32
 }
 
-func (q *Queries) CTERecursive(ctx context.Context, id int32) ([]CTERecursiveRow, error) {
-	rows, err := q.db.QueryContext(ctx, cTERecursive, id)
+func (q *Queries) CTERecursive(ctx context.Context, id int32, aq ...AdditionalQuery) ([]CTERecursiveRow, error) {
+	query := cTERecursive
+	queryParams := []interface{}{id}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.QueryContext(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/endtoend/testdata/cte_recursive/pgx/v4/go/db.go
+++ b/internal/endtoend/testdata/cte_recursive/pgx/v4/go/db.go
@@ -33,5 +33,5 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/cte_recursive/pgx/v4/go/db.go
+++ b/internal/endtoend/testdata/cte_recursive/pgx/v4/go/db.go
@@ -30,3 +30,8 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/cte_recursive/pgx/v4/go/query.sql.go
+++ b/internal/endtoend/testdata/cte_recursive/pgx/v4/go/query.sql.go
@@ -26,8 +26,16 @@ type CTERecursiveRow struct {
 	ParentID sql.NullInt32
 }
 
-func (q *Queries) CTERecursive(ctx context.Context, id int32) ([]CTERecursiveRow, error) {
-	rows, err := q.db.Query(ctx, cTERecursive, id)
+func (q *Queries) CTERecursive(ctx context.Context, id int32, aq ...AdditionalQuery) ([]CTERecursiveRow, error) {
+	query := cTERecursive
+	queryParams := []interface{}{id}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.Query(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/endtoend/testdata/cte_recursive/pgx/v5/go/db.go
+++ b/internal/endtoend/testdata/cte_recursive/pgx/v5/go/db.go
@@ -33,5 +33,5 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/cte_recursive/pgx/v5/go/db.go
+++ b/internal/endtoend/testdata/cte_recursive/pgx/v5/go/db.go
@@ -30,3 +30,8 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/cte_recursive/pgx/v5/go/query.sql.go
+++ b/internal/endtoend/testdata/cte_recursive/pgx/v5/go/query.sql.go
@@ -27,8 +27,16 @@ type CTERecursiveRow struct {
 	ParentID pgtype.Int4
 }
 
-func (q *Queries) CTERecursive(ctx context.Context, id int32) ([]CTERecursiveRow, error) {
-	rows, err := q.db.Query(ctx, cTERecursive, id)
+func (q *Queries) CTERecursive(ctx context.Context, id int32, aq ...AdditionalQuery) ([]CTERecursiveRow, error) {
+	query := cTERecursive
+	queryParams := []interface{}{id}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.Query(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/endtoend/testdata/cte_recursive/stdlib/go/db.go
+++ b/internal/endtoend/testdata/cte_recursive/stdlib/go/db.go
@@ -29,3 +29,8 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/cte_recursive/stdlib/go/db.go
+++ b/internal/endtoend/testdata/cte_recursive/stdlib/go/db.go
@@ -32,5 +32,5 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/cte_recursive/stdlib/go/query.sql.go
+++ b/internal/endtoend/testdata/cte_recursive/stdlib/go/query.sql.go
@@ -26,8 +26,16 @@ type CTERecursiveRow struct {
 	ParentID sql.NullInt32
 }
 
-func (q *Queries) CTERecursive(ctx context.Context, id int32) ([]CTERecursiveRow, error) {
-	rows, err := q.db.QueryContext(ctx, cTERecursive, id)
+func (q *Queries) CTERecursive(ctx context.Context, id int32, aq ...AdditionalQuery) ([]CTERecursiveRow, error) {
+	query := cTERecursive
+	queryParams := []interface{}{id}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.QueryContext(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/endtoend/testdata/data_type_boolean/mysql/db/db.go
+++ b/internal/endtoend/testdata/data_type_boolean/mysql/db/db.go
@@ -29,3 +29,8 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/data_type_boolean/mysql/db/db.go
+++ b/internal/endtoend/testdata/data_type_boolean/mysql/db/db.go
@@ -32,5 +32,5 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/data_type_boolean/mysql/db/query.sql.go
+++ b/internal/endtoend/testdata/data_type_boolean/mysql/db/query.sql.go
@@ -13,8 +13,16 @@ const listBar = `-- name: ListBar :many
 SELECT col_a, col_b, col_c FROM bar
 `
 
-func (q *Queries) ListBar(ctx context.Context) ([]Bar, error) {
-	rows, err := q.db.QueryContext(ctx, listBar)
+func (q *Queries) ListBar(ctx context.Context, aq ...AdditionalQuery) ([]Bar, error) {
+	query := listBar
+	queryParams := []interface{}{}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.QueryContext(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}
@@ -40,8 +48,16 @@ const listFoo = `-- name: ListFoo :many
 SELECT col_a, col_b, col_c FROM foo
 `
 
-func (q *Queries) ListFoo(ctx context.Context) ([]Foo, error) {
-	rows, err := q.db.QueryContext(ctx, listFoo)
+func (q *Queries) ListFoo(ctx context.Context, aq ...AdditionalQuery) ([]Foo, error) {
+	query := listFoo
+	queryParams := []interface{}{}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.QueryContext(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/endtoend/testdata/data_type_boolean/postgresql/pgx/v4/go/db.go
+++ b/internal/endtoend/testdata/data_type_boolean/postgresql/pgx/v4/go/db.go
@@ -33,5 +33,5 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/data_type_boolean/postgresql/pgx/v4/go/db.go
+++ b/internal/endtoend/testdata/data_type_boolean/postgresql/pgx/v4/go/db.go
@@ -30,3 +30,8 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/data_type_boolean/postgresql/pgx/v4/go/query.sql.go
+++ b/internal/endtoend/testdata/data_type_boolean/postgresql/pgx/v4/go/query.sql.go
@@ -13,8 +13,16 @@ const listBar = `-- name: ListBar :many
 SELECT col_a, col_b FROM bar
 `
 
-func (q *Queries) ListBar(ctx context.Context) ([]Bar, error) {
-	rows, err := q.db.Query(ctx, listBar)
+func (q *Queries) ListBar(ctx context.Context, aq ...AdditionalQuery) ([]Bar, error) {
+	query := listBar
+	queryParams := []interface{}{}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.Query(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}
@@ -37,8 +45,16 @@ const listFoo = `-- name: ListFoo :many
 SELECT col_a, col_b FROM foo
 `
 
-func (q *Queries) ListFoo(ctx context.Context) ([]Foo, error) {
-	rows, err := q.db.Query(ctx, listFoo)
+func (q *Queries) ListFoo(ctx context.Context, aq ...AdditionalQuery) ([]Foo, error) {
+	query := listFoo
+	queryParams := []interface{}{}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.Query(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/endtoend/testdata/data_type_boolean/postgresql/pgx/v5/go/db.go
+++ b/internal/endtoend/testdata/data_type_boolean/postgresql/pgx/v5/go/db.go
@@ -33,5 +33,5 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/data_type_boolean/postgresql/pgx/v5/go/db.go
+++ b/internal/endtoend/testdata/data_type_boolean/postgresql/pgx/v5/go/db.go
@@ -30,3 +30,8 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/data_type_boolean/postgresql/pgx/v5/go/query.sql.go
+++ b/internal/endtoend/testdata/data_type_boolean/postgresql/pgx/v5/go/query.sql.go
@@ -13,8 +13,16 @@ const listBar = `-- name: ListBar :many
 SELECT col_a, col_b FROM bar
 `
 
-func (q *Queries) ListBar(ctx context.Context) ([]Bar, error) {
-	rows, err := q.db.Query(ctx, listBar)
+func (q *Queries) ListBar(ctx context.Context, aq ...AdditionalQuery) ([]Bar, error) {
+	query := listBar
+	queryParams := []interface{}{}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.Query(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}
@@ -37,8 +45,16 @@ const listFoo = `-- name: ListFoo :many
 SELECT col_a, col_b FROM foo
 `
 
-func (q *Queries) ListFoo(ctx context.Context) ([]Foo, error) {
-	rows, err := q.db.Query(ctx, listFoo)
+func (q *Queries) ListFoo(ctx context.Context, aq ...AdditionalQuery) ([]Foo, error) {
+	query := listFoo
+	queryParams := []interface{}{}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.Query(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/endtoend/testdata/data_type_boolean/postgresql/stdlib/go/db.go
+++ b/internal/endtoend/testdata/data_type_boolean/postgresql/stdlib/go/db.go
@@ -29,3 +29,8 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/data_type_boolean/postgresql/stdlib/go/db.go
+++ b/internal/endtoend/testdata/data_type_boolean/postgresql/stdlib/go/db.go
@@ -32,5 +32,5 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/data_type_boolean/postgresql/stdlib/go/query.sql.go
+++ b/internal/endtoend/testdata/data_type_boolean/postgresql/stdlib/go/query.sql.go
@@ -13,8 +13,16 @@ const listBar = `-- name: ListBar :many
 SELECT col_a, col_b FROM bar
 `
 
-func (q *Queries) ListBar(ctx context.Context) ([]Bar, error) {
-	rows, err := q.db.QueryContext(ctx, listBar)
+func (q *Queries) ListBar(ctx context.Context, aq ...AdditionalQuery) ([]Bar, error) {
+	query := listBar
+	queryParams := []interface{}{}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.QueryContext(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}
@@ -40,8 +48,16 @@ const listFoo = `-- name: ListFoo :many
 SELECT col_a, col_b FROM foo
 `
 
-func (q *Queries) ListFoo(ctx context.Context) ([]Foo, error) {
-	rows, err := q.db.QueryContext(ctx, listFoo)
+func (q *Queries) ListFoo(ctx context.Context, aq ...AdditionalQuery) ([]Foo, error) {
+	query := listFoo
+	queryParams := []interface{}{}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.QueryContext(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/endtoend/testdata/data_type_boolean/sqlite/db/db.go
+++ b/internal/endtoend/testdata/data_type_boolean/sqlite/db/db.go
@@ -29,3 +29,8 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/data_type_boolean/sqlite/db/db.go
+++ b/internal/endtoend/testdata/data_type_boolean/sqlite/db/db.go
@@ -32,5 +32,5 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/data_type_boolean/sqlite/db/query.sql.go
+++ b/internal/endtoend/testdata/data_type_boolean/sqlite/db/query.sql.go
@@ -13,8 +13,16 @@ const listBar = `-- name: ListBar :many
 SELECT col_a, col_b FROM bar
 `
 
-func (q *Queries) ListBar(ctx context.Context) ([]Bar, error) {
-	rows, err := q.db.QueryContext(ctx, listBar)
+func (q *Queries) ListBar(ctx context.Context, aq ...AdditionalQuery) ([]Bar, error) {
+	query := listBar
+	queryParams := []interface{}{}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.QueryContext(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}
@@ -40,8 +48,16 @@ const listFoo = `-- name: ListFoo :many
 SELECT col_a, col_b FROM foo
 `
 
-func (q *Queries) ListFoo(ctx context.Context) ([]Foo, error) {
-	rows, err := q.db.QueryContext(ctx, listFoo)
+func (q *Queries) ListFoo(ctx context.Context, aq ...AdditionalQuery) ([]Foo, error) {
+	query := listFoo
+	queryParams := []interface{}{}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.QueryContext(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/endtoend/testdata/datatype/mysql/go/db.go
+++ b/internal/endtoend/testdata/datatype/mysql/go/db.go
@@ -29,3 +29,8 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/datatype/mysql/go/db.go
+++ b/internal/endtoend/testdata/datatype/mysql/go/db.go
@@ -32,5 +32,5 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/datatype/pgx/v4/go/db.go
+++ b/internal/endtoend/testdata/datatype/pgx/v4/go/db.go
@@ -33,5 +33,5 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/datatype/pgx/v4/go/db.go
+++ b/internal/endtoend/testdata/datatype/pgx/v4/go/db.go
@@ -30,3 +30,8 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/datatype/pgx/v5/go/db.go
+++ b/internal/endtoend/testdata/datatype/pgx/v5/go/db.go
@@ -33,5 +33,5 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/datatype/pgx/v5/go/db.go
+++ b/internal/endtoend/testdata/datatype/pgx/v5/go/db.go
@@ -30,3 +30,8 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/datatype/sqlite/go/db.go
+++ b/internal/endtoend/testdata/datatype/sqlite/go/db.go
@@ -29,3 +29,8 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/datatype/sqlite/go/db.go
+++ b/internal/endtoend/testdata/datatype/sqlite/go/db.go
@@ -32,5 +32,5 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/datatype/stdlib/go/db.go
+++ b/internal/endtoend/testdata/datatype/stdlib/go/db.go
@@ -29,3 +29,8 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/datatype/stdlib/go/db.go
+++ b/internal/endtoend/testdata/datatype/stdlib/go/db.go
@@ -32,5 +32,5 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/ddl_alter_table_add_column/mysql/go/db.go
+++ b/internal/endtoend/testdata/ddl_alter_table_add_column/mysql/go/db.go
@@ -29,3 +29,8 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/ddl_alter_table_add_column/mysql/go/db.go
+++ b/internal/endtoend/testdata/ddl_alter_table_add_column/mysql/go/db.go
@@ -32,5 +32,5 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/ddl_alter_table_add_column/mysql/go/query.sql.go
+++ b/internal/endtoend/testdata/ddl_alter_table_add_column/mysql/go/query.sql.go
@@ -14,6 +14,9 @@ SELECT 1
 `
 
 func (q *Queries) Placeholder(ctx context.Context) error {
-	_, err := q.db.ExecContext(ctx, placeholder)
+	query := placeholder
+	queryParams := []interface{}{}
+
+	_, err := q.db.ExecContext(ctx, query, queryParams...)
 	return err
 }

--- a/internal/endtoend/testdata/ddl_alter_table_add_column/postgresql/pgx/v4/go/db.go
+++ b/internal/endtoend/testdata/ddl_alter_table_add_column/postgresql/pgx/v4/go/db.go
@@ -33,5 +33,5 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/ddl_alter_table_add_column/postgresql/pgx/v4/go/db.go
+++ b/internal/endtoend/testdata/ddl_alter_table_add_column/postgresql/pgx/v4/go/db.go
@@ -30,3 +30,8 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/ddl_alter_table_add_column/postgresql/pgx/v5/go/db.go
+++ b/internal/endtoend/testdata/ddl_alter_table_add_column/postgresql/pgx/v5/go/db.go
@@ -33,5 +33,5 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/ddl_alter_table_add_column/postgresql/pgx/v5/go/db.go
+++ b/internal/endtoend/testdata/ddl_alter_table_add_column/postgresql/pgx/v5/go/db.go
@@ -30,3 +30,8 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/ddl_alter_table_add_column/postgresql/stdlib/go/db.go
+++ b/internal/endtoend/testdata/ddl_alter_table_add_column/postgresql/stdlib/go/db.go
@@ -29,3 +29,8 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/ddl_alter_table_add_column/postgresql/stdlib/go/db.go
+++ b/internal/endtoend/testdata/ddl_alter_table_add_column/postgresql/stdlib/go/db.go
@@ -32,5 +32,5 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/ddl_alter_table_add_column/postgresql/stdlib/go/query.sql.go
+++ b/internal/endtoend/testdata/ddl_alter_table_add_column/postgresql/stdlib/go/query.sql.go
@@ -14,6 +14,9 @@ SELECT 1
 `
 
 func (q *Queries) Placeholder(ctx context.Context) error {
-	_, err := q.db.ExecContext(ctx, placeholder)
+	query := placeholder
+	queryParams := []interface{}{}
+
+	_, err := q.db.ExecContext(ctx, query, queryParams...)
 	return err
 }

--- a/internal/endtoend/testdata/ddl_alter_table_add_column/sqlite/go/db.go
+++ b/internal/endtoend/testdata/ddl_alter_table_add_column/sqlite/go/db.go
@@ -29,3 +29,8 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/ddl_alter_table_add_column/sqlite/go/db.go
+++ b/internal/endtoend/testdata/ddl_alter_table_add_column/sqlite/go/db.go
@@ -32,5 +32,5 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/ddl_alter_table_add_column/sqlite/go/query.sql.go
+++ b/internal/endtoend/testdata/ddl_alter_table_add_column/sqlite/go/query.sql.go
@@ -13,8 +13,16 @@ const placeholder = `-- name: Placeholder :many
 SELECT name, location, size from venues
 `
 
-func (q *Queries) Placeholder(ctx context.Context) ([]Venue, error) {
-	rows, err := q.db.QueryContext(ctx, placeholder)
+func (q *Queries) Placeholder(ctx context.Context, aq ...AdditionalQuery) ([]Venue, error) {
+	query := placeholder
+	queryParams := []interface{}{}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.QueryContext(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/endtoend/testdata/ddl_alter_table_add_column_if_not_exists/postgresql/pgx/v4/go/db.go
+++ b/internal/endtoend/testdata/ddl_alter_table_add_column_if_not_exists/postgresql/pgx/v4/go/db.go
@@ -33,5 +33,5 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/ddl_alter_table_add_column_if_not_exists/postgresql/pgx/v4/go/db.go
+++ b/internal/endtoend/testdata/ddl_alter_table_add_column_if_not_exists/postgresql/pgx/v4/go/db.go
@@ -30,3 +30,8 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/ddl_alter_table_add_column_if_not_exists/postgresql/pgx/v5/go/db.go
+++ b/internal/endtoend/testdata/ddl_alter_table_add_column_if_not_exists/postgresql/pgx/v5/go/db.go
@@ -33,5 +33,5 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/ddl_alter_table_add_column_if_not_exists/postgresql/pgx/v5/go/db.go
+++ b/internal/endtoend/testdata/ddl_alter_table_add_column_if_not_exists/postgresql/pgx/v5/go/db.go
@@ -30,3 +30,8 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/ddl_alter_table_add_column_if_not_exists/postgresql/stdlib/go/db.go
+++ b/internal/endtoend/testdata/ddl_alter_table_add_column_if_not_exists/postgresql/stdlib/go/db.go
@@ -29,3 +29,8 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/ddl_alter_table_add_column_if_not_exists/postgresql/stdlib/go/db.go
+++ b/internal/endtoend/testdata/ddl_alter_table_add_column_if_not_exists/postgresql/stdlib/go/db.go
@@ -32,5 +32,5 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/ddl_alter_table_add_column_if_not_exists/postgresql/stdlib/go/query.sql.go
+++ b/internal/endtoend/testdata/ddl_alter_table_add_column_if_not_exists/postgresql/stdlib/go/query.sql.go
@@ -14,6 +14,9 @@ SELECT 1
 `
 
 func (q *Queries) Placeholder(ctx context.Context) error {
-	_, err := q.db.ExecContext(ctx, placeholder)
+	query := placeholder
+	queryParams := []interface{}{}
+
+	_, err := q.db.ExecContext(ctx, query, queryParams...)
 	return err
 }

--- a/internal/endtoend/testdata/ddl_alter_table_alter_type/mysql/go/db.go
+++ b/internal/endtoend/testdata/ddl_alter_table_alter_type/mysql/go/db.go
@@ -29,3 +29,8 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/ddl_alter_table_alter_type/mysql/go/db.go
+++ b/internal/endtoend/testdata/ddl_alter_table_alter_type/mysql/go/db.go
@@ -32,5 +32,5 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/ddl_alter_table_alter_type/mysql/go/query.sql.go
+++ b/internal/endtoend/testdata/ddl_alter_table_alter_type/mysql/go/query.sql.go
@@ -14,6 +14,9 @@ SELECT 1
 `
 
 func (q *Queries) Placeholder(ctx context.Context) error {
-	_, err := q.db.ExecContext(ctx, placeholder)
+	query := placeholder
+	queryParams := []interface{}{}
+
+	_, err := q.db.ExecContext(ctx, query, queryParams...)
 	return err
 }

--- a/internal/endtoend/testdata/ddl_alter_table_alter_type/postgresql/pgx/v4/go/db.go
+++ b/internal/endtoend/testdata/ddl_alter_table_alter_type/postgresql/pgx/v4/go/db.go
@@ -33,5 +33,5 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/ddl_alter_table_alter_type/postgresql/pgx/v4/go/db.go
+++ b/internal/endtoend/testdata/ddl_alter_table_alter_type/postgresql/pgx/v4/go/db.go
@@ -30,3 +30,8 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/ddl_alter_table_alter_type/postgresql/pgx/v5/go/db.go
+++ b/internal/endtoend/testdata/ddl_alter_table_alter_type/postgresql/pgx/v5/go/db.go
@@ -33,5 +33,5 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/ddl_alter_table_alter_type/postgresql/pgx/v5/go/db.go
+++ b/internal/endtoend/testdata/ddl_alter_table_alter_type/postgresql/pgx/v5/go/db.go
@@ -30,3 +30,8 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/ddl_alter_table_alter_type/postgresql/stdlib/go/db.go
+++ b/internal/endtoend/testdata/ddl_alter_table_alter_type/postgresql/stdlib/go/db.go
@@ -29,3 +29,8 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/ddl_alter_table_alter_type/postgresql/stdlib/go/db.go
+++ b/internal/endtoend/testdata/ddl_alter_table_alter_type/postgresql/stdlib/go/db.go
@@ -32,5 +32,5 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/ddl_alter_table_alter_type/postgresql/stdlib/go/query.sql.go
+++ b/internal/endtoend/testdata/ddl_alter_table_alter_type/postgresql/stdlib/go/query.sql.go
@@ -14,6 +14,9 @@ SELECT 1
 `
 
 func (q *Queries) Placeholder(ctx context.Context) error {
-	_, err := q.db.ExecContext(ctx, placeholder)
+	query := placeholder
+	queryParams := []interface{}{}
+
+	_, err := q.db.ExecContext(ctx, query, queryParams...)
 	return err
 }

--- a/internal/endtoend/testdata/ddl_alter_table_change_column/mysql/go/db.go
+++ b/internal/endtoend/testdata/ddl_alter_table_change_column/mysql/go/db.go
@@ -29,3 +29,8 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/ddl_alter_table_change_column/mysql/go/db.go
+++ b/internal/endtoend/testdata/ddl_alter_table_change_column/mysql/go/db.go
@@ -32,5 +32,5 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/ddl_alter_table_change_column/mysql/go/query.sql.go
+++ b/internal/endtoend/testdata/ddl_alter_table_change_column/mysql/go/query.sql.go
@@ -14,6 +14,9 @@ SELECT 1
 `
 
 func (q *Queries) Placeholder(ctx context.Context) error {
-	_, err := q.db.ExecContext(ctx, placeholder)
+	query := placeholder
+	queryParams := []interface{}{}
+
+	_, err := q.db.ExecContext(ctx, query, queryParams...)
 	return err
 }

--- a/internal/endtoend/testdata/ddl_alter_table_change_column/postgresql/pgx/v4/go/db.go
+++ b/internal/endtoend/testdata/ddl_alter_table_change_column/postgresql/pgx/v4/go/db.go
@@ -33,5 +33,5 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/ddl_alter_table_change_column/postgresql/pgx/v4/go/db.go
+++ b/internal/endtoend/testdata/ddl_alter_table_change_column/postgresql/pgx/v4/go/db.go
@@ -30,3 +30,8 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/ddl_alter_table_change_column/postgresql/pgx/v5/go/db.go
+++ b/internal/endtoend/testdata/ddl_alter_table_change_column/postgresql/pgx/v5/go/db.go
@@ -33,5 +33,5 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/ddl_alter_table_change_column/postgresql/pgx/v5/go/db.go
+++ b/internal/endtoend/testdata/ddl_alter_table_change_column/postgresql/pgx/v5/go/db.go
@@ -30,3 +30,8 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/ddl_alter_table_change_column/postgresql/stdlib/go/db.go
+++ b/internal/endtoend/testdata/ddl_alter_table_change_column/postgresql/stdlib/go/db.go
@@ -29,3 +29,8 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/ddl_alter_table_change_column/postgresql/stdlib/go/db.go
+++ b/internal/endtoend/testdata/ddl_alter_table_change_column/postgresql/stdlib/go/db.go
@@ -32,5 +32,5 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/ddl_alter_table_change_column/postgresql/stdlib/go/query.sql.go
+++ b/internal/endtoend/testdata/ddl_alter_table_change_column/postgresql/stdlib/go/query.sql.go
@@ -14,6 +14,9 @@ SELECT 1
 `
 
 func (q *Queries) Placeholder(ctx context.Context) error {
-	_, err := q.db.ExecContext(ctx, placeholder)
+	query := placeholder
+	queryParams := []interface{}{}
+
+	_, err := q.db.ExecContext(ctx, query, queryParams...)
 	return err
 }

--- a/internal/endtoend/testdata/ddl_alter_table_column_drop_not_null/mysql/go/db.go
+++ b/internal/endtoend/testdata/ddl_alter_table_column_drop_not_null/mysql/go/db.go
@@ -29,3 +29,8 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/ddl_alter_table_column_drop_not_null/mysql/go/db.go
+++ b/internal/endtoend/testdata/ddl_alter_table_column_drop_not_null/mysql/go/db.go
@@ -32,5 +32,5 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/ddl_alter_table_column_drop_not_null/mysql/go/query.sql.go
+++ b/internal/endtoend/testdata/ddl_alter_table_column_drop_not_null/mysql/go/query.sql.go
@@ -14,6 +14,9 @@ SELECT 1
 `
 
 func (q *Queries) Placeholder(ctx context.Context) error {
-	_, err := q.db.ExecContext(ctx, placeholder)
+	query := placeholder
+	queryParams := []interface{}{}
+
+	_, err := q.db.ExecContext(ctx, query, queryParams...)
 	return err
 }

--- a/internal/endtoend/testdata/ddl_alter_table_column_drop_not_null/postgresql/pgx/v4/go/db.go
+++ b/internal/endtoend/testdata/ddl_alter_table_column_drop_not_null/postgresql/pgx/v4/go/db.go
@@ -33,5 +33,5 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/ddl_alter_table_column_drop_not_null/postgresql/pgx/v4/go/db.go
+++ b/internal/endtoend/testdata/ddl_alter_table_column_drop_not_null/postgresql/pgx/v4/go/db.go
@@ -30,3 +30,8 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/ddl_alter_table_column_drop_not_null/postgresql/pgx/v5/go/db.go
+++ b/internal/endtoend/testdata/ddl_alter_table_column_drop_not_null/postgresql/pgx/v5/go/db.go
@@ -33,5 +33,5 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/ddl_alter_table_column_drop_not_null/postgresql/pgx/v5/go/db.go
+++ b/internal/endtoend/testdata/ddl_alter_table_column_drop_not_null/postgresql/pgx/v5/go/db.go
@@ -30,3 +30,8 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/ddl_alter_table_column_drop_not_null/postgresql/stdlib/go/db.go
+++ b/internal/endtoend/testdata/ddl_alter_table_column_drop_not_null/postgresql/stdlib/go/db.go
@@ -29,3 +29,8 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/ddl_alter_table_column_drop_not_null/postgresql/stdlib/go/db.go
+++ b/internal/endtoend/testdata/ddl_alter_table_column_drop_not_null/postgresql/stdlib/go/db.go
@@ -32,5 +32,5 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/ddl_alter_table_column_drop_not_null/postgresql/stdlib/go/query.sql.go
+++ b/internal/endtoend/testdata/ddl_alter_table_column_drop_not_null/postgresql/stdlib/go/query.sql.go
@@ -14,6 +14,9 @@ SELECT 1
 `
 
 func (q *Queries) Placeholder(ctx context.Context) error {
-	_, err := q.db.ExecContext(ctx, placeholder)
+	query := placeholder
+	queryParams := []interface{}{}
+
+	_, err := q.db.ExecContext(ctx, query, queryParams...)
 	return err
 }

--- a/internal/endtoend/testdata/ddl_alter_table_drop_column/mysql/go/db.go
+++ b/internal/endtoend/testdata/ddl_alter_table_drop_column/mysql/go/db.go
@@ -29,3 +29,8 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/ddl_alter_table_drop_column/mysql/go/db.go
+++ b/internal/endtoend/testdata/ddl_alter_table_drop_column/mysql/go/db.go
@@ -32,5 +32,5 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/ddl_alter_table_drop_column/mysql/go/query.sql.go
+++ b/internal/endtoend/testdata/ddl_alter_table_drop_column/mysql/go/query.sql.go
@@ -14,6 +14,9 @@ SELECT 1
 `
 
 func (q *Queries) Placeholder(ctx context.Context) error {
-	_, err := q.db.ExecContext(ctx, placeholder)
+	query := placeholder
+	queryParams := []interface{}{}
+
+	_, err := q.db.ExecContext(ctx, query, queryParams...)
 	return err
 }

--- a/internal/endtoend/testdata/ddl_alter_table_drop_column/postgresql/pgx/v4/go/db.go
+++ b/internal/endtoend/testdata/ddl_alter_table_drop_column/postgresql/pgx/v4/go/db.go
@@ -33,5 +33,5 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/ddl_alter_table_drop_column/postgresql/pgx/v4/go/db.go
+++ b/internal/endtoend/testdata/ddl_alter_table_drop_column/postgresql/pgx/v4/go/db.go
@@ -30,3 +30,8 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/ddl_alter_table_drop_column/postgresql/pgx/v5/go/db.go
+++ b/internal/endtoend/testdata/ddl_alter_table_drop_column/postgresql/pgx/v5/go/db.go
@@ -33,5 +33,5 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/ddl_alter_table_drop_column/postgresql/pgx/v5/go/db.go
+++ b/internal/endtoend/testdata/ddl_alter_table_drop_column/postgresql/pgx/v5/go/db.go
@@ -30,3 +30,8 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/ddl_alter_table_drop_column/postgresql/stdlib/go/db.go
+++ b/internal/endtoend/testdata/ddl_alter_table_drop_column/postgresql/stdlib/go/db.go
@@ -29,3 +29,8 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/ddl_alter_table_drop_column/postgresql/stdlib/go/db.go
+++ b/internal/endtoend/testdata/ddl_alter_table_drop_column/postgresql/stdlib/go/db.go
@@ -32,5 +32,5 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/ddl_alter_table_drop_column/postgresql/stdlib/go/query.sql.go
+++ b/internal/endtoend/testdata/ddl_alter_table_drop_column/postgresql/stdlib/go/query.sql.go
@@ -14,6 +14,9 @@ SELECT 1
 `
 
 func (q *Queries) Placeholder(ctx context.Context) error {
-	_, err := q.db.ExecContext(ctx, placeholder)
+	query := placeholder
+	queryParams := []interface{}{}
+
+	_, err := q.db.ExecContext(ctx, query, queryParams...)
 	return err
 }

--- a/internal/endtoend/testdata/ddl_alter_table_drop_column/sqlite/go/db.go
+++ b/internal/endtoend/testdata/ddl_alter_table_drop_column/sqlite/go/db.go
@@ -29,3 +29,8 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/ddl_alter_table_drop_column/sqlite/go/db.go
+++ b/internal/endtoend/testdata/ddl_alter_table_drop_column/sqlite/go/db.go
@@ -32,5 +32,5 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/ddl_alter_table_drop_column/sqlite/go/query.sql.go
+++ b/internal/endtoend/testdata/ddl_alter_table_drop_column/sqlite/go/query.sql.go
@@ -14,6 +14,9 @@ SELECT baz from foo
 `
 
 func (q *Queries) Placeholder(ctx context.Context) error {
-	_, err := q.db.ExecContext(ctx, placeholder)
+	query := placeholder
+	queryParams := []interface{}{}
+
+	_, err := q.db.ExecContext(ctx, query, queryParams...)
 	return err
 }

--- a/internal/endtoend/testdata/ddl_alter_table_drop_column_if_exists/mysql/go/db.go
+++ b/internal/endtoend/testdata/ddl_alter_table_drop_column_if_exists/mysql/go/db.go
@@ -29,3 +29,8 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/ddl_alter_table_drop_column_if_exists/mysql/go/db.go
+++ b/internal/endtoend/testdata/ddl_alter_table_drop_column_if_exists/mysql/go/db.go
@@ -32,5 +32,5 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/ddl_alter_table_drop_column_if_exists/mysql/go/query.sql.go
+++ b/internal/endtoend/testdata/ddl_alter_table_drop_column_if_exists/mysql/go/query.sql.go
@@ -14,6 +14,9 @@ SELECT 1
 `
 
 func (q *Queries) Placeholder(ctx context.Context) error {
-	_, err := q.db.ExecContext(ctx, placeholder)
+	query := placeholder
+	queryParams := []interface{}{}
+
+	_, err := q.db.ExecContext(ctx, query, queryParams...)
 	return err
 }

--- a/internal/endtoend/testdata/ddl_alter_table_drop_column_if_exists/postgresql/pgx/v4/go/db.go
+++ b/internal/endtoend/testdata/ddl_alter_table_drop_column_if_exists/postgresql/pgx/v4/go/db.go
@@ -33,5 +33,5 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/ddl_alter_table_drop_column_if_exists/postgresql/pgx/v4/go/db.go
+++ b/internal/endtoend/testdata/ddl_alter_table_drop_column_if_exists/postgresql/pgx/v4/go/db.go
@@ -30,3 +30,8 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/ddl_alter_table_drop_column_if_exists/postgresql/pgx/v5/go/db.go
+++ b/internal/endtoend/testdata/ddl_alter_table_drop_column_if_exists/postgresql/pgx/v5/go/db.go
@@ -33,5 +33,5 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/ddl_alter_table_drop_column_if_exists/postgresql/pgx/v5/go/db.go
+++ b/internal/endtoend/testdata/ddl_alter_table_drop_column_if_exists/postgresql/pgx/v5/go/db.go
@@ -30,3 +30,8 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/ddl_alter_table_drop_column_if_exists/postgresql/stdlib/go/db.go
+++ b/internal/endtoend/testdata/ddl_alter_table_drop_column_if_exists/postgresql/stdlib/go/db.go
@@ -29,3 +29,8 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/ddl_alter_table_drop_column_if_exists/postgresql/stdlib/go/db.go
+++ b/internal/endtoend/testdata/ddl_alter_table_drop_column_if_exists/postgresql/stdlib/go/db.go
@@ -32,5 +32,5 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/ddl_alter_table_drop_column_if_exists/postgresql/stdlib/go/query.sql.go
+++ b/internal/endtoend/testdata/ddl_alter_table_drop_column_if_exists/postgresql/stdlib/go/query.sql.go
@@ -14,6 +14,9 @@ SELECT 1
 `
 
 func (q *Queries) Placeholder(ctx context.Context) error {
-	_, err := q.db.ExecContext(ctx, placeholder)
+	query := placeholder
+	queryParams := []interface{}{}
+
+	_, err := q.db.ExecContext(ctx, query, queryParams...)
 	return err
 }

--- a/internal/endtoend/testdata/ddl_alter_table_drop_constraint/mysql/go/db.go
+++ b/internal/endtoend/testdata/ddl_alter_table_drop_constraint/mysql/go/db.go
@@ -29,3 +29,8 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/ddl_alter_table_drop_constraint/mysql/go/db.go
+++ b/internal/endtoend/testdata/ddl_alter_table_drop_constraint/mysql/go/db.go
@@ -32,5 +32,5 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/ddl_alter_table_drop_constraint/mysql/go/query.sql.go
+++ b/internal/endtoend/testdata/ddl_alter_table_drop_constraint/mysql/go/query.sql.go
@@ -14,6 +14,9 @@ SELECT 1
 `
 
 func (q *Queries) Placeholder(ctx context.Context) error {
-	_, err := q.db.ExecContext(ctx, placeholder)
+	query := placeholder
+	queryParams := []interface{}{}
+
+	_, err := q.db.ExecContext(ctx, query, queryParams...)
 	return err
 }

--- a/internal/endtoend/testdata/ddl_alter_table_drop_constraint/postgresql/pgx/v4/go/db.go
+++ b/internal/endtoend/testdata/ddl_alter_table_drop_constraint/postgresql/pgx/v4/go/db.go
@@ -33,5 +33,5 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/ddl_alter_table_drop_constraint/postgresql/pgx/v4/go/db.go
+++ b/internal/endtoend/testdata/ddl_alter_table_drop_constraint/postgresql/pgx/v4/go/db.go
@@ -30,3 +30,8 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/ddl_alter_table_drop_constraint/postgresql/pgx/v5/go/db.go
+++ b/internal/endtoend/testdata/ddl_alter_table_drop_constraint/postgresql/pgx/v5/go/db.go
@@ -33,5 +33,5 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/ddl_alter_table_drop_constraint/postgresql/pgx/v5/go/db.go
+++ b/internal/endtoend/testdata/ddl_alter_table_drop_constraint/postgresql/pgx/v5/go/db.go
@@ -30,3 +30,8 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/ddl_alter_table_drop_constraint/postgresql/stdlib/go/db.go
+++ b/internal/endtoend/testdata/ddl_alter_table_drop_constraint/postgresql/stdlib/go/db.go
@@ -29,3 +29,8 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/ddl_alter_table_drop_constraint/postgresql/stdlib/go/db.go
+++ b/internal/endtoend/testdata/ddl_alter_table_drop_constraint/postgresql/stdlib/go/db.go
@@ -32,5 +32,5 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/ddl_alter_table_drop_constraint/postgresql/stdlib/go/query.sql.go
+++ b/internal/endtoend/testdata/ddl_alter_table_drop_constraint/postgresql/stdlib/go/query.sql.go
@@ -14,6 +14,9 @@ SELECT 1
 `
 
 func (q *Queries) Placeholder(ctx context.Context) error {
-	_, err := q.db.ExecContext(ctx, placeholder)
+	query := placeholder
+	queryParams := []interface{}{}
+
+	_, err := q.db.ExecContext(ctx, query, queryParams...)
 	return err
 }

--- a/internal/endtoend/testdata/ddl_alter_table_if_exists/postgresql/pgx/v4/go/db.go
+++ b/internal/endtoend/testdata/ddl_alter_table_if_exists/postgresql/pgx/v4/go/db.go
@@ -33,5 +33,5 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/ddl_alter_table_if_exists/postgresql/pgx/v4/go/db.go
+++ b/internal/endtoend/testdata/ddl_alter_table_if_exists/postgresql/pgx/v4/go/db.go
@@ -30,3 +30,8 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/ddl_alter_table_if_exists/postgresql/pgx/v5/go/db.go
+++ b/internal/endtoend/testdata/ddl_alter_table_if_exists/postgresql/pgx/v5/go/db.go
@@ -33,5 +33,5 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/ddl_alter_table_if_exists/postgresql/pgx/v5/go/db.go
+++ b/internal/endtoend/testdata/ddl_alter_table_if_exists/postgresql/pgx/v5/go/db.go
@@ -30,3 +30,8 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/ddl_alter_table_if_exists/postgresql/stdlib/go/db.go
+++ b/internal/endtoend/testdata/ddl_alter_table_if_exists/postgresql/stdlib/go/db.go
@@ -29,3 +29,8 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/ddl_alter_table_if_exists/postgresql/stdlib/go/db.go
+++ b/internal/endtoend/testdata/ddl_alter_table_if_exists/postgresql/stdlib/go/db.go
@@ -32,5 +32,5 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/ddl_alter_table_if_exists/postgresql/stdlib/go/query.sql.go
+++ b/internal/endtoend/testdata/ddl_alter_table_if_exists/postgresql/stdlib/go/query.sql.go
@@ -14,6 +14,9 @@ SELECT 1
 `
 
 func (q *Queries) Placeholder(ctx context.Context) error {
-	_, err := q.db.ExecContext(ctx, placeholder)
+	query := placeholder
+	queryParams := []interface{}{}
+
+	_, err := q.db.ExecContext(ctx, query, queryParams...)
 	return err
 }

--- a/internal/endtoend/testdata/ddl_alter_table_index/postgresql/pgx/v4/go/db.go
+++ b/internal/endtoend/testdata/ddl_alter_table_index/postgresql/pgx/v4/go/db.go
@@ -33,5 +33,5 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/ddl_alter_table_index/postgresql/pgx/v4/go/db.go
+++ b/internal/endtoend/testdata/ddl_alter_table_index/postgresql/pgx/v4/go/db.go
@@ -30,3 +30,8 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/ddl_alter_table_index/postgresql/pgx/v5/go/db.go
+++ b/internal/endtoend/testdata/ddl_alter_table_index/postgresql/pgx/v5/go/db.go
@@ -33,5 +33,5 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/ddl_alter_table_index/postgresql/pgx/v5/go/db.go
+++ b/internal/endtoend/testdata/ddl_alter_table_index/postgresql/pgx/v5/go/db.go
@@ -30,3 +30,8 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/ddl_alter_table_index/postgresql/stdlib/go/db.go
+++ b/internal/endtoend/testdata/ddl_alter_table_index/postgresql/stdlib/go/db.go
@@ -29,3 +29,8 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/ddl_alter_table_index/postgresql/stdlib/go/db.go
+++ b/internal/endtoend/testdata/ddl_alter_table_index/postgresql/stdlib/go/db.go
@@ -32,5 +32,5 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/ddl_alter_table_index/postgresql/stdlib/go/query.sql.go
+++ b/internal/endtoend/testdata/ddl_alter_table_index/postgresql/stdlib/go/query.sql.go
@@ -14,6 +14,9 @@ SELECT 1
 `
 
 func (q *Queries) Placeholder(ctx context.Context) error {
-	_, err := q.db.ExecContext(ctx, placeholder)
+	query := placeholder
+	queryParams := []interface{}{}
+
+	_, err := q.db.ExecContext(ctx, query, queryParams...)
 	return err
 }

--- a/internal/endtoend/testdata/ddl_alter_table_rename/mysql/go/db.go
+++ b/internal/endtoend/testdata/ddl_alter_table_rename/mysql/go/db.go
@@ -29,3 +29,8 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/ddl_alter_table_rename/mysql/go/db.go
+++ b/internal/endtoend/testdata/ddl_alter_table_rename/mysql/go/db.go
@@ -32,5 +32,5 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/ddl_alter_table_rename/mysql/go/query.sql.go
+++ b/internal/endtoend/testdata/ddl_alter_table_rename/mysql/go/query.sql.go
@@ -14,6 +14,9 @@ SELECT 1
 `
 
 func (q *Queries) Placeholder(ctx context.Context) error {
-	_, err := q.db.ExecContext(ctx, placeholder)
+	query := placeholder
+	queryParams := []interface{}{}
+
+	_, err := q.db.ExecContext(ctx, query, queryParams...)
 	return err
 }

--- a/internal/endtoend/testdata/ddl_alter_table_rename/postgresql/pgx/v4/go/db.go
+++ b/internal/endtoend/testdata/ddl_alter_table_rename/postgresql/pgx/v4/go/db.go
@@ -33,5 +33,5 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/ddl_alter_table_rename/postgresql/pgx/v4/go/db.go
+++ b/internal/endtoend/testdata/ddl_alter_table_rename/postgresql/pgx/v4/go/db.go
@@ -30,3 +30,8 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/ddl_alter_table_rename/postgresql/pgx/v5/go/db.go
+++ b/internal/endtoend/testdata/ddl_alter_table_rename/postgresql/pgx/v5/go/db.go
@@ -33,5 +33,5 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/ddl_alter_table_rename/postgresql/pgx/v5/go/db.go
+++ b/internal/endtoend/testdata/ddl_alter_table_rename/postgresql/pgx/v5/go/db.go
@@ -30,3 +30,8 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/ddl_alter_table_rename/postgresql/stdlib/go/db.go
+++ b/internal/endtoend/testdata/ddl_alter_table_rename/postgresql/stdlib/go/db.go
@@ -29,3 +29,8 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/ddl_alter_table_rename/postgresql/stdlib/go/db.go
+++ b/internal/endtoend/testdata/ddl_alter_table_rename/postgresql/stdlib/go/db.go
@@ -32,5 +32,5 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/ddl_alter_table_rename/postgresql/stdlib/go/query.sql.go
+++ b/internal/endtoend/testdata/ddl_alter_table_rename/postgresql/stdlib/go/query.sql.go
@@ -14,6 +14,9 @@ SELECT 1
 `
 
 func (q *Queries) Placeholder(ctx context.Context) error {
-	_, err := q.db.ExecContext(ctx, placeholder)
+	query := placeholder
+	queryParams := []interface{}{}
+
+	_, err := q.db.ExecContext(ctx, query, queryParams...)
 	return err
 }

--- a/internal/endtoend/testdata/ddl_alter_table_rename/sqlite/go/db.go
+++ b/internal/endtoend/testdata/ddl_alter_table_rename/sqlite/go/db.go
@@ -29,3 +29,8 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/ddl_alter_table_rename/sqlite/go/db.go
+++ b/internal/endtoend/testdata/ddl_alter_table_rename/sqlite/go/db.go
@@ -32,5 +32,5 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/ddl_alter_table_rename/sqlite/go/query.sql.go
+++ b/internal/endtoend/testdata/ddl_alter_table_rename/sqlite/go/query.sql.go
@@ -14,8 +14,16 @@ const placeholder = `-- name: Placeholder :many
 SELECT name from arenas
 `
 
-func (q *Queries) Placeholder(ctx context.Context) ([]sql.NullString, error) {
-	rows, err := q.db.QueryContext(ctx, placeholder)
+func (q *Queries) Placeholder(ctx context.Context, aq ...AdditionalQuery) ([]sql.NullString, error) {
+	query := placeholder
+	queryParams := []interface{}{}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.QueryContext(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/endtoend/testdata/ddl_alter_table_rename_column/mysql/go/db.go
+++ b/internal/endtoend/testdata/ddl_alter_table_rename_column/mysql/go/db.go
@@ -29,3 +29,8 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/ddl_alter_table_rename_column/mysql/go/db.go
+++ b/internal/endtoend/testdata/ddl_alter_table_rename_column/mysql/go/db.go
@@ -32,5 +32,5 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/ddl_alter_table_rename_column/mysql/go/query.sql.go
+++ b/internal/endtoend/testdata/ddl_alter_table_rename_column/mysql/go/query.sql.go
@@ -14,6 +14,9 @@ SELECT 1
 `
 
 func (q *Queries) Placeholder(ctx context.Context) error {
-	_, err := q.db.ExecContext(ctx, placeholder)
+	query := placeholder
+	queryParams := []interface{}{}
+
+	_, err := q.db.ExecContext(ctx, query, queryParams...)
 	return err
 }

--- a/internal/endtoend/testdata/ddl_alter_table_rename_column/postgresql/pgx/v4/go/db.go
+++ b/internal/endtoend/testdata/ddl_alter_table_rename_column/postgresql/pgx/v4/go/db.go
@@ -33,5 +33,5 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/ddl_alter_table_rename_column/postgresql/pgx/v4/go/db.go
+++ b/internal/endtoend/testdata/ddl_alter_table_rename_column/postgresql/pgx/v4/go/db.go
@@ -30,3 +30,8 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/ddl_alter_table_rename_column/postgresql/pgx/v5/go/db.go
+++ b/internal/endtoend/testdata/ddl_alter_table_rename_column/postgresql/pgx/v5/go/db.go
@@ -33,5 +33,5 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/ddl_alter_table_rename_column/postgresql/pgx/v5/go/db.go
+++ b/internal/endtoend/testdata/ddl_alter_table_rename_column/postgresql/pgx/v5/go/db.go
@@ -30,3 +30,8 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/ddl_alter_table_rename_column/postgresql/stdlib/go/db.go
+++ b/internal/endtoend/testdata/ddl_alter_table_rename_column/postgresql/stdlib/go/db.go
@@ -29,3 +29,8 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/ddl_alter_table_rename_column/postgresql/stdlib/go/db.go
+++ b/internal/endtoend/testdata/ddl_alter_table_rename_column/postgresql/stdlib/go/db.go
@@ -32,5 +32,5 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/ddl_alter_table_rename_column/postgresql/stdlib/go/query.sql.go
+++ b/internal/endtoend/testdata/ddl_alter_table_rename_column/postgresql/stdlib/go/query.sql.go
@@ -14,6 +14,9 @@ SELECT 1
 `
 
 func (q *Queries) Placeholder(ctx context.Context) error {
-	_, err := q.db.ExecContext(ctx, placeholder)
+	query := placeholder
+	queryParams := []interface{}{}
+
+	_, err := q.db.ExecContext(ctx, query, queryParams...)
 	return err
 }

--- a/internal/endtoend/testdata/ddl_alter_table_rename_column/sqlite/go/db.go
+++ b/internal/endtoend/testdata/ddl_alter_table_rename_column/sqlite/go/db.go
@@ -29,3 +29,8 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/ddl_alter_table_rename_column/sqlite/go/db.go
+++ b/internal/endtoend/testdata/ddl_alter_table_rename_column/sqlite/go/db.go
@@ -32,5 +32,5 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/ddl_alter_table_rename_column/sqlite/go/query.sql.go
+++ b/internal/endtoend/testdata/ddl_alter_table_rename_column/sqlite/go/query.sql.go
@@ -14,8 +14,16 @@ const placeholder = `-- name: Placeholder :many
 SELECT boo from foo
 `
 
-func (q *Queries) Placeholder(ctx context.Context) ([]sql.NullString, error) {
-	rows, err := q.db.QueryContext(ctx, placeholder)
+func (q *Queries) Placeholder(ctx context.Context, aq ...AdditionalQuery) ([]sql.NullString, error) {
+	query := placeholder
+	queryParams := []interface{}{}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.QueryContext(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/endtoend/testdata/ddl_alter_table_set_data_type/mysql/go/db.go
+++ b/internal/endtoend/testdata/ddl_alter_table_set_data_type/mysql/go/db.go
@@ -29,3 +29,8 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/ddl_alter_table_set_data_type/mysql/go/db.go
+++ b/internal/endtoend/testdata/ddl_alter_table_set_data_type/mysql/go/db.go
@@ -32,5 +32,5 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/ddl_alter_table_set_data_type/mysql/go/query.sql.go
+++ b/internal/endtoend/testdata/ddl_alter_table_set_data_type/mysql/go/query.sql.go
@@ -14,6 +14,9 @@ SELECT 1
 `
 
 func (q *Queries) Placeholder(ctx context.Context) error {
-	_, err := q.db.ExecContext(ctx, placeholder)
+	query := placeholder
+	queryParams := []interface{}{}
+
+	_, err := q.db.ExecContext(ctx, query, queryParams...)
 	return err
 }

--- a/internal/endtoend/testdata/ddl_alter_table_set_data_type/postgresql/pgx/v4/go/db.go
+++ b/internal/endtoend/testdata/ddl_alter_table_set_data_type/postgresql/pgx/v4/go/db.go
@@ -33,5 +33,5 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/ddl_alter_table_set_data_type/postgresql/pgx/v4/go/db.go
+++ b/internal/endtoend/testdata/ddl_alter_table_set_data_type/postgresql/pgx/v4/go/db.go
@@ -30,3 +30,8 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/ddl_alter_table_set_data_type/postgresql/pgx/v5/go/db.go
+++ b/internal/endtoend/testdata/ddl_alter_table_set_data_type/postgresql/pgx/v5/go/db.go
@@ -33,5 +33,5 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/ddl_alter_table_set_data_type/postgresql/pgx/v5/go/db.go
+++ b/internal/endtoend/testdata/ddl_alter_table_set_data_type/postgresql/pgx/v5/go/db.go
@@ -30,3 +30,8 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/ddl_alter_table_set_data_type/postgresql/stdlib/go/db.go
+++ b/internal/endtoend/testdata/ddl_alter_table_set_data_type/postgresql/stdlib/go/db.go
@@ -29,3 +29,8 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/ddl_alter_table_set_data_type/postgresql/stdlib/go/db.go
+++ b/internal/endtoend/testdata/ddl_alter_table_set_data_type/postgresql/stdlib/go/db.go
@@ -32,5 +32,5 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/ddl_alter_table_set_data_type/postgresql/stdlib/go/query.sql.go
+++ b/internal/endtoend/testdata/ddl_alter_table_set_data_type/postgresql/stdlib/go/query.sql.go
@@ -14,6 +14,9 @@ SELECT 1
 `
 
 func (q *Queries) Placeholder(ctx context.Context) error {
-	_, err := q.db.ExecContext(ctx, placeholder)
+	query := placeholder
+	queryParams := []interface{}{}
+
+	_, err := q.db.ExecContext(ctx, query, queryParams...)
 	return err
 }

--- a/internal/endtoend/testdata/ddl_alter_table_set_not_null/mysql/go/db.go
+++ b/internal/endtoend/testdata/ddl_alter_table_set_not_null/mysql/go/db.go
@@ -29,3 +29,8 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/ddl_alter_table_set_not_null/mysql/go/db.go
+++ b/internal/endtoend/testdata/ddl_alter_table_set_not_null/mysql/go/db.go
@@ -32,5 +32,5 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/ddl_alter_table_set_not_null/mysql/go/query.sql.go
+++ b/internal/endtoend/testdata/ddl_alter_table_set_not_null/mysql/go/query.sql.go
@@ -14,6 +14,9 @@ SELECT 1
 `
 
 func (q *Queries) Placeholder(ctx context.Context) error {
-	_, err := q.db.ExecContext(ctx, placeholder)
+	query := placeholder
+	queryParams := []interface{}{}
+
+	_, err := q.db.ExecContext(ctx, query, queryParams...)
 	return err
 }

--- a/internal/endtoend/testdata/ddl_alter_table_set_not_null/postgresql/pgx/v4/go/db.go
+++ b/internal/endtoend/testdata/ddl_alter_table_set_not_null/postgresql/pgx/v4/go/db.go
@@ -33,5 +33,5 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/ddl_alter_table_set_not_null/postgresql/pgx/v4/go/db.go
+++ b/internal/endtoend/testdata/ddl_alter_table_set_not_null/postgresql/pgx/v4/go/db.go
@@ -30,3 +30,8 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/ddl_alter_table_set_not_null/postgresql/pgx/v5/go/db.go
+++ b/internal/endtoend/testdata/ddl_alter_table_set_not_null/postgresql/pgx/v5/go/db.go
@@ -33,5 +33,5 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/ddl_alter_table_set_not_null/postgresql/pgx/v5/go/db.go
+++ b/internal/endtoend/testdata/ddl_alter_table_set_not_null/postgresql/pgx/v5/go/db.go
@@ -30,3 +30,8 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/ddl_alter_table_set_not_null/postgresql/stdlib/go/db.go
+++ b/internal/endtoend/testdata/ddl_alter_table_set_not_null/postgresql/stdlib/go/db.go
@@ -29,3 +29,8 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/ddl_alter_table_set_not_null/postgresql/stdlib/go/db.go
+++ b/internal/endtoend/testdata/ddl_alter_table_set_not_null/postgresql/stdlib/go/db.go
@@ -32,5 +32,5 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/ddl_alter_table_set_not_null/postgresql/stdlib/go/query.sql.go
+++ b/internal/endtoend/testdata/ddl_alter_table_set_not_null/postgresql/stdlib/go/query.sql.go
@@ -14,6 +14,9 @@ SELECT 1
 `
 
 func (q *Queries) Placeholder(ctx context.Context) error {
-	_, err := q.db.ExecContext(ctx, placeholder)
+	query := placeholder
+	queryParams := []interface{}{}
+
+	_, err := q.db.ExecContext(ctx, query, queryParams...)
 	return err
 }

--- a/internal/endtoend/testdata/ddl_alter_table_set_schema/postgresql/pgx/v4/go/db.go
+++ b/internal/endtoend/testdata/ddl_alter_table_set_schema/postgresql/pgx/v4/go/db.go
@@ -33,5 +33,5 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/ddl_alter_table_set_schema/postgresql/pgx/v4/go/db.go
+++ b/internal/endtoend/testdata/ddl_alter_table_set_schema/postgresql/pgx/v4/go/db.go
@@ -30,3 +30,8 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/ddl_alter_table_set_schema/postgresql/pgx/v5/go/db.go
+++ b/internal/endtoend/testdata/ddl_alter_table_set_schema/postgresql/pgx/v5/go/db.go
@@ -33,5 +33,5 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/ddl_alter_table_set_schema/postgresql/pgx/v5/go/db.go
+++ b/internal/endtoend/testdata/ddl_alter_table_set_schema/postgresql/pgx/v5/go/db.go
@@ -30,3 +30,8 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/ddl_alter_table_set_schema/postgresql/stdlib/go/db.go
+++ b/internal/endtoend/testdata/ddl_alter_table_set_schema/postgresql/stdlib/go/db.go
@@ -29,3 +29,8 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/ddl_alter_table_set_schema/postgresql/stdlib/go/db.go
+++ b/internal/endtoend/testdata/ddl_alter_table_set_schema/postgresql/stdlib/go/db.go
@@ -32,5 +32,5 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/ddl_alter_table_set_schema/postgresql/stdlib/go/query.sql.go
+++ b/internal/endtoend/testdata/ddl_alter_table_set_schema/postgresql/stdlib/go/query.sql.go
@@ -15,7 +15,10 @@ SELECT name FROM foo.bar
 `
 
 func (q *Queries) GetFooBar(ctx context.Context) error {
-	_, err := q.db.ExecContext(ctx, getFooBar)
+	query := getFooBar
+	queryParams := []interface{}{}
+
+	_, err := q.db.ExecContext(ctx, query, queryParams...)
 	return err
 }
 
@@ -24,6 +27,9 @@ UPDATE foo.bar SET name = $1
 `
 
 func (q *Queries) UpdateFooBar(ctx context.Context, name sql.NullString) error {
-	_, err := q.db.ExecContext(ctx, updateFooBar, name)
+	query := updateFooBar
+	queryParams := []interface{}{name}
+
+	_, err := q.db.ExecContext(ctx, query, queryParams...)
 	return err
 }

--- a/internal/endtoend/testdata/ddl_alter_type_add_value/postgresql/pgx/v4/go/db.go
+++ b/internal/endtoend/testdata/ddl_alter_type_add_value/postgresql/pgx/v4/go/db.go
@@ -33,5 +33,5 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/ddl_alter_type_add_value/postgresql/pgx/v4/go/db.go
+++ b/internal/endtoend/testdata/ddl_alter_type_add_value/postgresql/pgx/v4/go/db.go
@@ -30,3 +30,8 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/ddl_alter_type_add_value/postgresql/pgx/v5/go/db.go
+++ b/internal/endtoend/testdata/ddl_alter_type_add_value/postgresql/pgx/v5/go/db.go
@@ -33,5 +33,5 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/ddl_alter_type_add_value/postgresql/pgx/v5/go/db.go
+++ b/internal/endtoend/testdata/ddl_alter_type_add_value/postgresql/pgx/v5/go/db.go
@@ -30,3 +30,8 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/ddl_alter_type_add_value/postgresql/stdlib/go/db.go
+++ b/internal/endtoend/testdata/ddl_alter_type_add_value/postgresql/stdlib/go/db.go
@@ -29,3 +29,8 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/ddl_alter_type_add_value/postgresql/stdlib/go/db.go
+++ b/internal/endtoend/testdata/ddl_alter_type_add_value/postgresql/stdlib/go/db.go
@@ -32,5 +32,5 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/ddl_alter_type_add_value/postgresql/stdlib/go/query.sql.go
+++ b/internal/endtoend/testdata/ddl_alter_type_add_value/postgresql/stdlib/go/query.sql.go
@@ -14,6 +14,9 @@ SELECT 1
 `
 
 func (q *Queries) Placeholder(ctx context.Context) error {
-	_, err := q.db.ExecContext(ctx, placeholder)
+	query := placeholder
+	queryParams := []interface{}{}
+
+	_, err := q.db.ExecContext(ctx, query, queryParams...)
 	return err
 }

--- a/internal/endtoend/testdata/ddl_alter_type_rename/postgresql/pgx/v4/go/db.go
+++ b/internal/endtoend/testdata/ddl_alter_type_rename/postgresql/pgx/v4/go/db.go
@@ -33,5 +33,5 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/ddl_alter_type_rename/postgresql/pgx/v4/go/db.go
+++ b/internal/endtoend/testdata/ddl_alter_type_rename/postgresql/pgx/v4/go/db.go
@@ -30,3 +30,8 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/ddl_alter_type_rename/postgresql/pgx/v4/go/query.sql.go
+++ b/internal/endtoend/testdata/ddl_alter_type_rename/postgresql/pgx/v4/go/query.sql.go
@@ -13,8 +13,16 @@ const listAuthors = `-- name: ListAuthors :many
 SELECT id, status FROM log_lines
 `
 
-func (q *Queries) ListAuthors(ctx context.Context) ([]LogLine, error) {
-	rows, err := q.db.Query(ctx, listAuthors)
+func (q *Queries) ListAuthors(ctx context.Context, aq ...AdditionalQuery) ([]LogLine, error) {
+	query := listAuthors
+	queryParams := []interface{}{}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.Query(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/endtoend/testdata/ddl_alter_type_rename/postgresql/pgx/v5/go/db.go
+++ b/internal/endtoend/testdata/ddl_alter_type_rename/postgresql/pgx/v5/go/db.go
@@ -33,5 +33,5 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/ddl_alter_type_rename/postgresql/pgx/v5/go/db.go
+++ b/internal/endtoend/testdata/ddl_alter_type_rename/postgresql/pgx/v5/go/db.go
@@ -30,3 +30,8 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/ddl_alter_type_rename/postgresql/pgx/v5/go/query.sql.go
+++ b/internal/endtoend/testdata/ddl_alter_type_rename/postgresql/pgx/v5/go/query.sql.go
@@ -13,8 +13,16 @@ const listAuthors = `-- name: ListAuthors :many
 SELECT id, status FROM log_lines
 `
 
-func (q *Queries) ListAuthors(ctx context.Context) ([]LogLine, error) {
-	rows, err := q.db.Query(ctx, listAuthors)
+func (q *Queries) ListAuthors(ctx context.Context, aq ...AdditionalQuery) ([]LogLine, error) {
+	query := listAuthors
+	queryParams := []interface{}{}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.Query(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/endtoend/testdata/ddl_alter_type_rename/postgresql/stdlib/go/db.go
+++ b/internal/endtoend/testdata/ddl_alter_type_rename/postgresql/stdlib/go/db.go
@@ -29,3 +29,8 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/ddl_alter_type_rename/postgresql/stdlib/go/db.go
+++ b/internal/endtoend/testdata/ddl_alter_type_rename/postgresql/stdlib/go/db.go
@@ -32,5 +32,5 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/ddl_alter_type_rename/postgresql/stdlib/go/query.sql.go
+++ b/internal/endtoend/testdata/ddl_alter_type_rename/postgresql/stdlib/go/query.sql.go
@@ -13,8 +13,16 @@ const listAuthors = `-- name: ListAuthors :many
 SELECT id, status FROM log_lines
 `
 
-func (q *Queries) ListAuthors(ctx context.Context) ([]LogLine, error) {
-	rows, err := q.db.QueryContext(ctx, listAuthors)
+func (q *Queries) ListAuthors(ctx context.Context, aq ...AdditionalQuery) ([]LogLine, error) {
+	query := listAuthors
+	queryParams := []interface{}{}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.QueryContext(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/endtoend/testdata/ddl_alter_type_rename_and_update_columns/postgresql/pgx/v4/go/db.go
+++ b/internal/endtoend/testdata/ddl_alter_type_rename_and_update_columns/postgresql/pgx/v4/go/db.go
@@ -33,5 +33,5 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/ddl_alter_type_rename_and_update_columns/postgresql/pgx/v4/go/db.go
+++ b/internal/endtoend/testdata/ddl_alter_type_rename_and_update_columns/postgresql/pgx/v4/go/db.go
@@ -30,3 +30,8 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/ddl_alter_type_rename_and_update_columns/postgresql/pgx/v4/go/query.sql.go
+++ b/internal/endtoend/testdata/ddl_alter_type_rename_and_update_columns/postgresql/pgx/v4/go/query.sql.go
@@ -13,8 +13,16 @@ const listAuthors = `-- name: ListAuthors :many
 SELECT id, status FROM log_lines
 `
 
-func (q *Queries) ListAuthors(ctx context.Context) ([]LogLine, error) {
-	rows, err := q.db.Query(ctx, listAuthors)
+func (q *Queries) ListAuthors(ctx context.Context, aq ...AdditionalQuery) ([]LogLine, error) {
+	query := listAuthors
+	queryParams := []interface{}{}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.Query(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/endtoend/testdata/ddl_alter_type_rename_and_update_columns/postgresql/pgx/v5/go/db.go
+++ b/internal/endtoend/testdata/ddl_alter_type_rename_and_update_columns/postgresql/pgx/v5/go/db.go
@@ -33,5 +33,5 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/ddl_alter_type_rename_and_update_columns/postgresql/pgx/v5/go/db.go
+++ b/internal/endtoend/testdata/ddl_alter_type_rename_and_update_columns/postgresql/pgx/v5/go/db.go
@@ -30,3 +30,8 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/ddl_alter_type_rename_and_update_columns/postgresql/pgx/v5/go/query.sql.go
+++ b/internal/endtoend/testdata/ddl_alter_type_rename_and_update_columns/postgresql/pgx/v5/go/query.sql.go
@@ -13,8 +13,16 @@ const listAuthors = `-- name: ListAuthors :many
 SELECT id, status FROM log_lines
 `
 
-func (q *Queries) ListAuthors(ctx context.Context) ([]LogLine, error) {
-	rows, err := q.db.Query(ctx, listAuthors)
+func (q *Queries) ListAuthors(ctx context.Context, aq ...AdditionalQuery) ([]LogLine, error) {
+	query := listAuthors
+	queryParams := []interface{}{}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.Query(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/endtoend/testdata/ddl_alter_type_rename_and_update_columns/postgresql/stdlib/go/db.go
+++ b/internal/endtoend/testdata/ddl_alter_type_rename_and_update_columns/postgresql/stdlib/go/db.go
@@ -29,3 +29,8 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/ddl_alter_type_rename_and_update_columns/postgresql/stdlib/go/db.go
+++ b/internal/endtoend/testdata/ddl_alter_type_rename_and_update_columns/postgresql/stdlib/go/db.go
@@ -32,5 +32,5 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/ddl_alter_type_rename_and_update_columns/postgresql/stdlib/go/query.sql.go
+++ b/internal/endtoend/testdata/ddl_alter_type_rename_and_update_columns/postgresql/stdlib/go/query.sql.go
@@ -13,8 +13,16 @@ const listAuthors = `-- name: ListAuthors :many
 SELECT id, status FROM log_lines
 `
 
-func (q *Queries) ListAuthors(ctx context.Context) ([]LogLine, error) {
-	rows, err := q.db.QueryContext(ctx, listAuthors)
+func (q *Queries) ListAuthors(ctx context.Context, aq ...AdditionalQuery) ([]LogLine, error) {
+	query := listAuthors
+	queryParams := []interface{}{}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.QueryContext(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/endtoend/testdata/ddl_alter_type_rename_value/postgresql/pgx/v4/go/db.go
+++ b/internal/endtoend/testdata/ddl_alter_type_rename_value/postgresql/pgx/v4/go/db.go
@@ -33,5 +33,5 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/ddl_alter_type_rename_value/postgresql/pgx/v4/go/db.go
+++ b/internal/endtoend/testdata/ddl_alter_type_rename_value/postgresql/pgx/v4/go/db.go
@@ -30,3 +30,8 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/ddl_alter_type_rename_value/postgresql/pgx/v5/go/db.go
+++ b/internal/endtoend/testdata/ddl_alter_type_rename_value/postgresql/pgx/v5/go/db.go
@@ -33,5 +33,5 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/ddl_alter_type_rename_value/postgresql/pgx/v5/go/db.go
+++ b/internal/endtoend/testdata/ddl_alter_type_rename_value/postgresql/pgx/v5/go/db.go
@@ -30,3 +30,8 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/ddl_alter_type_rename_value/postgresql/stdlib/go/db.go
+++ b/internal/endtoend/testdata/ddl_alter_type_rename_value/postgresql/stdlib/go/db.go
@@ -29,3 +29,8 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/ddl_alter_type_rename_value/postgresql/stdlib/go/db.go
+++ b/internal/endtoend/testdata/ddl_alter_type_rename_value/postgresql/stdlib/go/db.go
@@ -32,5 +32,5 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/ddl_alter_type_rename_value/postgresql/stdlib/go/query.sql.go
+++ b/internal/endtoend/testdata/ddl_alter_type_rename_value/postgresql/stdlib/go/query.sql.go
@@ -14,6 +14,9 @@ SELECT 1
 `
 
 func (q *Queries) Placeholder(ctx context.Context) error {
-	_, err := q.db.ExecContext(ctx, placeholder)
+	query := placeholder
+	queryParams := []interface{}{}
+
+	_, err := q.db.ExecContext(ctx, query, queryParams...)
 	return err
 }

--- a/internal/endtoend/testdata/ddl_alter_type_set_schema/postgresql/pgx/v4/go/db.go
+++ b/internal/endtoend/testdata/ddl_alter_type_set_schema/postgresql/pgx/v4/go/db.go
@@ -33,5 +33,5 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/ddl_alter_type_set_schema/postgresql/pgx/v4/go/db.go
+++ b/internal/endtoend/testdata/ddl_alter_type_set_schema/postgresql/pgx/v4/go/db.go
@@ -30,3 +30,8 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/ddl_alter_type_set_schema/postgresql/pgx/v4/go/query.sql.go
+++ b/internal/endtoend/testdata/ddl_alter_type_set_schema/postgresql/pgx/v4/go/query.sql.go
@@ -13,8 +13,16 @@ const listAuthors = `-- name: ListAuthors :many
 SELECT id, status, level FROM log_lines
 `
 
-func (q *Queries) ListAuthors(ctx context.Context) ([]LogLine, error) {
-	rows, err := q.db.Query(ctx, listAuthors)
+func (q *Queries) ListAuthors(ctx context.Context, aq ...AdditionalQuery) ([]LogLine, error) {
+	query := listAuthors
+	queryParams := []interface{}{}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.Query(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/endtoend/testdata/ddl_alter_type_set_schema/postgresql/pgx/v5/go/db.go
+++ b/internal/endtoend/testdata/ddl_alter_type_set_schema/postgresql/pgx/v5/go/db.go
@@ -33,5 +33,5 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/ddl_alter_type_set_schema/postgresql/pgx/v5/go/db.go
+++ b/internal/endtoend/testdata/ddl_alter_type_set_schema/postgresql/pgx/v5/go/db.go
@@ -30,3 +30,8 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/ddl_alter_type_set_schema/postgresql/pgx/v5/go/query.sql.go
+++ b/internal/endtoend/testdata/ddl_alter_type_set_schema/postgresql/pgx/v5/go/query.sql.go
@@ -13,8 +13,16 @@ const listAuthors = `-- name: ListAuthors :many
 SELECT id, status, level FROM log_lines
 `
 
-func (q *Queries) ListAuthors(ctx context.Context) ([]LogLine, error) {
-	rows, err := q.db.Query(ctx, listAuthors)
+func (q *Queries) ListAuthors(ctx context.Context, aq ...AdditionalQuery) ([]LogLine, error) {
+	query := listAuthors
+	queryParams := []interface{}{}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.Query(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/endtoend/testdata/ddl_alter_type_set_schema/postgresql/stdlib/go/db.go
+++ b/internal/endtoend/testdata/ddl_alter_type_set_schema/postgresql/stdlib/go/db.go
@@ -29,3 +29,8 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/ddl_alter_type_set_schema/postgresql/stdlib/go/db.go
+++ b/internal/endtoend/testdata/ddl_alter_type_set_schema/postgresql/stdlib/go/db.go
@@ -32,5 +32,5 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/ddl_alter_type_set_schema/postgresql/stdlib/go/query.sql.go
+++ b/internal/endtoend/testdata/ddl_alter_type_set_schema/postgresql/stdlib/go/query.sql.go
@@ -13,8 +13,16 @@ const listAuthors = `-- name: ListAuthors :many
 SELECT id, status, level FROM log_lines
 `
 
-func (q *Queries) ListAuthors(ctx context.Context) ([]LogLine, error) {
-	rows, err := q.db.QueryContext(ctx, listAuthors)
+func (q *Queries) ListAuthors(ctx context.Context, aq ...AdditionalQuery) ([]LogLine, error) {
+	query := listAuthors
+	queryParams := []interface{}{}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.QueryContext(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/endtoend/testdata/ddl_comment/mysql/go/db.go
+++ b/internal/endtoend/testdata/ddl_comment/mysql/go/db.go
@@ -29,3 +29,8 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/ddl_comment/mysql/go/db.go
+++ b/internal/endtoend/testdata/ddl_comment/mysql/go/db.go
@@ -32,5 +32,5 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/ddl_comment/mysql/go/query.sql.go
+++ b/internal/endtoend/testdata/ddl_comment/mysql/go/query.sql.go
@@ -14,6 +14,9 @@ SELECT 1
 `
 
 func (q *Queries) Placeholder(ctx context.Context) error {
-	_, err := q.db.ExecContext(ctx, placeholder)
+	query := placeholder
+	queryParams := []interface{}{}
+
+	_, err := q.db.ExecContext(ctx, query, queryParams...)
 	return err
 }

--- a/internal/endtoend/testdata/ddl_comment/postgresql/pgx/v4/go/db.go
+++ b/internal/endtoend/testdata/ddl_comment/postgresql/pgx/v4/go/db.go
@@ -33,5 +33,5 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/ddl_comment/postgresql/pgx/v4/go/db.go
+++ b/internal/endtoend/testdata/ddl_comment/postgresql/pgx/v4/go/db.go
@@ -30,3 +30,8 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/ddl_comment/postgresql/pgx/v5/go/db.go
+++ b/internal/endtoend/testdata/ddl_comment/postgresql/pgx/v5/go/db.go
@@ -33,5 +33,5 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/ddl_comment/postgresql/pgx/v5/go/db.go
+++ b/internal/endtoend/testdata/ddl_comment/postgresql/pgx/v5/go/db.go
@@ -30,3 +30,8 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/ddl_comment/postgresql/stdlib/go/db.go
+++ b/internal/endtoend/testdata/ddl_comment/postgresql/stdlib/go/db.go
@@ -29,3 +29,8 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/ddl_comment/postgresql/stdlib/go/db.go
+++ b/internal/endtoend/testdata/ddl_comment/postgresql/stdlib/go/db.go
@@ -32,5 +32,5 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/ddl_comment/postgresql/stdlib/go/query.sql.go
+++ b/internal/endtoend/testdata/ddl_comment/postgresql/stdlib/go/query.sql.go
@@ -14,6 +14,9 @@ SELECT 1
 `
 
 func (q *Queries) Placeholder(ctx context.Context) error {
-	_, err := q.db.ExecContext(ctx, placeholder)
+	query := placeholder
+	queryParams := []interface{}{}
+
+	_, err := q.db.ExecContext(ctx, query, queryParams...)
 	return err
 }

--- a/internal/endtoend/testdata/ddl_create_enum/mysql/go/db.go
+++ b/internal/endtoend/testdata/ddl_create_enum/mysql/go/db.go
@@ -29,3 +29,8 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/ddl_create_enum/mysql/go/db.go
+++ b/internal/endtoend/testdata/ddl_create_enum/mysql/go/db.go
@@ -32,5 +32,5 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/ddl_create_enum/mysql/go/query.sql.go
+++ b/internal/endtoend/testdata/ddl_create_enum/mysql/go/query.sql.go
@@ -13,8 +13,16 @@ const listFoo = `-- name: ListFoo :many
 SELECT foobar, digit FROM foo
 `
 
-func (q *Queries) ListFoo(ctx context.Context) ([]Foo, error) {
-	rows, err := q.db.QueryContext(ctx, listFoo)
+func (q *Queries) ListFoo(ctx context.Context, aq ...AdditionalQuery) ([]Foo, error) {
+	query := listFoo
+	queryParams := []interface{}{}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.QueryContext(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/endtoend/testdata/ddl_create_enum/postgresql/pgx/v4/go/db.go
+++ b/internal/endtoend/testdata/ddl_create_enum/postgresql/pgx/v4/go/db.go
@@ -33,5 +33,5 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/ddl_create_enum/postgresql/pgx/v4/go/db.go
+++ b/internal/endtoend/testdata/ddl_create_enum/postgresql/pgx/v4/go/db.go
@@ -30,3 +30,8 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/ddl_create_enum/postgresql/pgx/v4/go/query.sql.go
+++ b/internal/endtoend/testdata/ddl_create_enum/postgresql/pgx/v4/go/query.sql.go
@@ -13,8 +13,16 @@ const listFoo = `-- name: ListFoo :many
 SELECT val FROM foo
 `
 
-func (q *Queries) ListFoo(ctx context.Context) ([]Foobar, error) {
-	rows, err := q.db.Query(ctx, listFoo)
+func (q *Queries) ListFoo(ctx context.Context, aq ...AdditionalQuery) ([]Foobar, error) {
+	query := listFoo
+	queryParams := []interface{}{}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.Query(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/endtoend/testdata/ddl_create_enum/postgresql/pgx/v5/go/db.go
+++ b/internal/endtoend/testdata/ddl_create_enum/postgresql/pgx/v5/go/db.go
@@ -33,5 +33,5 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/ddl_create_enum/postgresql/pgx/v5/go/db.go
+++ b/internal/endtoend/testdata/ddl_create_enum/postgresql/pgx/v5/go/db.go
@@ -30,3 +30,8 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/ddl_create_enum/postgresql/pgx/v5/go/query.sql.go
+++ b/internal/endtoend/testdata/ddl_create_enum/postgresql/pgx/v5/go/query.sql.go
@@ -13,8 +13,16 @@ const listFoo = `-- name: ListFoo :many
 SELECT val FROM foo
 `
 
-func (q *Queries) ListFoo(ctx context.Context) ([]Foobar, error) {
-	rows, err := q.db.Query(ctx, listFoo)
+func (q *Queries) ListFoo(ctx context.Context, aq ...AdditionalQuery) ([]Foobar, error) {
+	query := listFoo
+	queryParams := []interface{}{}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.Query(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/endtoend/testdata/ddl_create_enum/postgresql/stdlib/go/db.go
+++ b/internal/endtoend/testdata/ddl_create_enum/postgresql/stdlib/go/db.go
@@ -29,3 +29,8 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/ddl_create_enum/postgresql/stdlib/go/db.go
+++ b/internal/endtoend/testdata/ddl_create_enum/postgresql/stdlib/go/db.go
@@ -32,5 +32,5 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/ddl_create_enum/postgresql/stdlib/go/query.sql.go
+++ b/internal/endtoend/testdata/ddl_create_enum/postgresql/stdlib/go/query.sql.go
@@ -13,8 +13,16 @@ const listFoo = `-- name: ListFoo :many
 SELECT val FROM foo
 `
 
-func (q *Queries) ListFoo(ctx context.Context) ([]Foobar, error) {
-	rows, err := q.db.QueryContext(ctx, listFoo)
+func (q *Queries) ListFoo(ctx context.Context, aq ...AdditionalQuery) ([]Foobar, error) {
+	query := listFoo
+	queryParams := []interface{}{}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.QueryContext(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/endtoend/testdata/ddl_create_function/postgresql/pgx/v4/go/db.go
+++ b/internal/endtoend/testdata/ddl_create_function/postgresql/pgx/v4/go/db.go
@@ -33,5 +33,5 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/ddl_create_function/postgresql/pgx/v4/go/db.go
+++ b/internal/endtoend/testdata/ddl_create_function/postgresql/pgx/v4/go/db.go
@@ -30,3 +30,8 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/ddl_create_function/postgresql/pgx/v5/go/db.go
+++ b/internal/endtoend/testdata/ddl_create_function/postgresql/pgx/v5/go/db.go
@@ -33,5 +33,5 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/ddl_create_function/postgresql/pgx/v5/go/db.go
+++ b/internal/endtoend/testdata/ddl_create_function/postgresql/pgx/v5/go/db.go
@@ -30,3 +30,8 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/ddl_create_function/postgresql/stdlib/go/db.go
+++ b/internal/endtoend/testdata/ddl_create_function/postgresql/stdlib/go/db.go
@@ -29,3 +29,8 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/ddl_create_function/postgresql/stdlib/go/db.go
+++ b/internal/endtoend/testdata/ddl_create_function/postgresql/stdlib/go/db.go
@@ -32,5 +32,5 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/ddl_create_function/postgresql/stdlib/go/query.sql.go
+++ b/internal/endtoend/testdata/ddl_create_function/postgresql/stdlib/go/query.sql.go
@@ -14,6 +14,9 @@ SELECT 1
 `
 
 func (q *Queries) Placeholder(ctx context.Context) error {
-	_, err := q.db.ExecContext(ctx, placeholder)
+	query := placeholder
+	queryParams := []interface{}{}
+
+	_, err := q.db.ExecContext(ctx, query, queryParams...)
 	return err
 }

--- a/internal/endtoend/testdata/ddl_create_function_args/postgresql/pgx/v4/go/db.go
+++ b/internal/endtoend/testdata/ddl_create_function_args/postgresql/pgx/v4/go/db.go
@@ -33,5 +33,5 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/ddl_create_function_args/postgresql/pgx/v4/go/db.go
+++ b/internal/endtoend/testdata/ddl_create_function_args/postgresql/pgx/v4/go/db.go
@@ -30,3 +30,8 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/ddl_create_function_args/postgresql/pgx/v5/go/db.go
+++ b/internal/endtoend/testdata/ddl_create_function_args/postgresql/pgx/v5/go/db.go
@@ -33,5 +33,5 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/ddl_create_function_args/postgresql/pgx/v5/go/db.go
+++ b/internal/endtoend/testdata/ddl_create_function_args/postgresql/pgx/v5/go/db.go
@@ -30,3 +30,8 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/ddl_create_function_args/postgresql/stdlib/go/db.go
+++ b/internal/endtoend/testdata/ddl_create_function_args/postgresql/stdlib/go/db.go
@@ -29,3 +29,8 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/ddl_create_function_args/postgresql/stdlib/go/db.go
+++ b/internal/endtoend/testdata/ddl_create_function_args/postgresql/stdlib/go/db.go
@@ -32,5 +32,5 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/ddl_create_function_args/postgresql/stdlib/go/query.sql.go
+++ b/internal/endtoend/testdata/ddl_create_function_args/postgresql/stdlib/go/query.sql.go
@@ -14,6 +14,9 @@ SELECT 1
 `
 
 func (q *Queries) Placeholder(ctx context.Context) error {
-	_, err := q.db.ExecContext(ctx, placeholder)
+	query := placeholder
+	queryParams := []interface{}{}
+
+	_, err := q.db.ExecContext(ctx, query, queryParams...)
 	return err
 }

--- a/internal/endtoend/testdata/ddl_create_function_return/postgresql/pgx/v4/go/db.go
+++ b/internal/endtoend/testdata/ddl_create_function_return/postgresql/pgx/v4/go/db.go
@@ -33,5 +33,5 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/ddl_create_function_return/postgresql/pgx/v4/go/db.go
+++ b/internal/endtoend/testdata/ddl_create_function_return/postgresql/pgx/v4/go/db.go
@@ -30,3 +30,8 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/ddl_create_function_return/postgresql/pgx/v5/go/db.go
+++ b/internal/endtoend/testdata/ddl_create_function_return/postgresql/pgx/v5/go/db.go
@@ -33,5 +33,5 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/ddl_create_function_return/postgresql/pgx/v5/go/db.go
+++ b/internal/endtoend/testdata/ddl_create_function_return/postgresql/pgx/v5/go/db.go
@@ -30,3 +30,8 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/ddl_create_function_return/postgresql/stdlib/go/db.go
+++ b/internal/endtoend/testdata/ddl_create_function_return/postgresql/stdlib/go/db.go
@@ -29,3 +29,8 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/ddl_create_function_return/postgresql/stdlib/go/db.go
+++ b/internal/endtoend/testdata/ddl_create_function_return/postgresql/stdlib/go/db.go
@@ -32,5 +32,5 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/ddl_create_function_return/postgresql/stdlib/go/query.sql.go
+++ b/internal/endtoend/testdata/ddl_create_function_return/postgresql/stdlib/go/query.sql.go
@@ -14,6 +14,9 @@ SELECT 1
 `
 
 func (q *Queries) Placeholder(ctx context.Context) error {
-	_, err := q.db.ExecContext(ctx, placeholder)
+	query := placeholder
+	queryParams := []interface{}{}
+
+	_, err := q.db.ExecContext(ctx, query, queryParams...)
 	return err
 }

--- a/internal/endtoend/testdata/ddl_create_function_types/postgresql/pgx/v4/go/db.go
+++ b/internal/endtoend/testdata/ddl_create_function_types/postgresql/pgx/v4/go/db.go
@@ -33,5 +33,5 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/ddl_create_function_types/postgresql/pgx/v4/go/db.go
+++ b/internal/endtoend/testdata/ddl_create_function_types/postgresql/pgx/v4/go/db.go
@@ -30,3 +30,8 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/ddl_create_function_types/postgresql/pgx/v5/go/db.go
+++ b/internal/endtoend/testdata/ddl_create_function_types/postgresql/pgx/v5/go/db.go
@@ -33,5 +33,5 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/ddl_create_function_types/postgresql/pgx/v5/go/db.go
+++ b/internal/endtoend/testdata/ddl_create_function_types/postgresql/pgx/v5/go/db.go
@@ -30,3 +30,8 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/ddl_create_function_types/postgresql/stdlib/go/db.go
+++ b/internal/endtoend/testdata/ddl_create_function_types/postgresql/stdlib/go/db.go
@@ -29,3 +29,8 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/ddl_create_function_types/postgresql/stdlib/go/db.go
+++ b/internal/endtoend/testdata/ddl_create_function_types/postgresql/stdlib/go/db.go
@@ -32,5 +32,5 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/ddl_create_function_types/postgresql/stdlib/go/query.sql.go
+++ b/internal/endtoend/testdata/ddl_create_function_types/postgresql/stdlib/go/query.sql.go
@@ -14,6 +14,9 @@ SELECT 1
 `
 
 func (q *Queries) Placeholder(ctx context.Context) error {
-	_, err := q.db.ExecContext(ctx, placeholder)
+	query := placeholder
+	queryParams := []interface{}{}
+
+	_, err := q.db.ExecContext(ctx, query, queryParams...)
 	return err
 }

--- a/internal/endtoend/testdata/ddl_create_procedure/postgresql/pgx/v4/go/db.go
+++ b/internal/endtoend/testdata/ddl_create_procedure/postgresql/pgx/v4/go/db.go
@@ -33,5 +33,5 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/ddl_create_procedure/postgresql/pgx/v4/go/db.go
+++ b/internal/endtoend/testdata/ddl_create_procedure/postgresql/pgx/v4/go/db.go
@@ -30,3 +30,8 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/ddl_create_procedure/postgresql/pgx/v5/go/db.go
+++ b/internal/endtoend/testdata/ddl_create_procedure/postgresql/pgx/v5/go/db.go
@@ -33,5 +33,5 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/ddl_create_procedure/postgresql/pgx/v5/go/db.go
+++ b/internal/endtoend/testdata/ddl_create_procedure/postgresql/pgx/v5/go/db.go
@@ -30,3 +30,8 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/ddl_create_procedure/postgresql/stdlib/go/db.go
+++ b/internal/endtoend/testdata/ddl_create_procedure/postgresql/stdlib/go/db.go
@@ -29,3 +29,8 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/ddl_create_procedure/postgresql/stdlib/go/db.go
+++ b/internal/endtoend/testdata/ddl_create_procedure/postgresql/stdlib/go/db.go
@@ -32,5 +32,5 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/ddl_create_procedure/postgresql/stdlib/go/query.sql.go
+++ b/internal/endtoend/testdata/ddl_create_procedure/postgresql/stdlib/go/query.sql.go
@@ -19,7 +19,10 @@ type CallInsertDataParams struct {
 }
 
 func (q *Queries) CallInsertData(ctx context.Context, arg CallInsertDataParams) error {
-	_, err := q.db.ExecContext(ctx, callInsertData, arg.A, arg.B)
+	query := callInsertData
+	queryParams := []interface{}{arg.A, arg.B}
+
+	_, err := q.db.ExecContext(ctx, query, queryParams...)
 	return err
 }
 
@@ -33,7 +36,10 @@ type CallInsertDataNamedParams struct {
 }
 
 func (q *Queries) CallInsertDataNamed(ctx context.Context, arg CallInsertDataNamedParams) error {
-	_, err := q.db.ExecContext(ctx, callInsertDataNamed, arg.B, arg.A)
+	query := callInsertDataNamed
+	queryParams := []interface{}{arg.B, arg.A}
+
+	_, err := q.db.ExecContext(ctx, query, queryParams...)
 	return err
 }
 
@@ -42,7 +48,10 @@ CALL insert_data(1, 2)
 `
 
 func (q *Queries) CallInsertDataNoArgs(ctx context.Context) error {
-	_, err := q.db.ExecContext(ctx, callInsertDataNoArgs)
+	query := callInsertDataNoArgs
+	queryParams := []interface{}{}
+
+	_, err := q.db.ExecContext(ctx, query, queryParams...)
 	return err
 }
 
@@ -56,6 +65,9 @@ type CallInsertDataSqlcArgsParams struct {
 }
 
 func (q *Queries) CallInsertDataSqlcArgs(ctx context.Context, arg CallInsertDataSqlcArgsParams) error {
-	_, err := q.db.ExecContext(ctx, callInsertDataSqlcArgs, arg.Foo, arg.Bar)
+	query := callInsertDataSqlcArgs
+	queryParams := []interface{}{arg.Foo, arg.Bar}
+
+	_, err := q.db.ExecContext(ctx, query, queryParams...)
 	return err
 }

--- a/internal/endtoend/testdata/ddl_create_table/mysql/go/db.go
+++ b/internal/endtoend/testdata/ddl_create_table/mysql/go/db.go
@@ -29,3 +29,8 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/ddl_create_table/mysql/go/db.go
+++ b/internal/endtoend/testdata/ddl_create_table/mysql/go/db.go
@@ -32,5 +32,5 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/ddl_create_table/mysql/go/query.sql.go
+++ b/internal/endtoend/testdata/ddl_create_table/mysql/go/query.sql.go
@@ -14,6 +14,9 @@ SELECT 1
 `
 
 func (q *Queries) Placeholder(ctx context.Context) error {
-	_, err := q.db.ExecContext(ctx, placeholder)
+	query := placeholder
+	queryParams := []interface{}{}
+
+	_, err := q.db.ExecContext(ctx, query, queryParams...)
 	return err
 }

--- a/internal/endtoend/testdata/ddl_create_table/postgresql/pgx/v4/go/db.go
+++ b/internal/endtoend/testdata/ddl_create_table/postgresql/pgx/v4/go/db.go
@@ -33,5 +33,5 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/ddl_create_table/postgresql/pgx/v4/go/db.go
+++ b/internal/endtoend/testdata/ddl_create_table/postgresql/pgx/v4/go/db.go
@@ -30,3 +30,8 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/ddl_create_table/postgresql/pgx/v5/go/db.go
+++ b/internal/endtoend/testdata/ddl_create_table/postgresql/pgx/v5/go/db.go
@@ -33,5 +33,5 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/ddl_create_table/postgresql/pgx/v5/go/db.go
+++ b/internal/endtoend/testdata/ddl_create_table/postgresql/pgx/v5/go/db.go
@@ -30,3 +30,8 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/ddl_create_table/postgresql/stdlib/go/db.go
+++ b/internal/endtoend/testdata/ddl_create_table/postgresql/stdlib/go/db.go
@@ -29,3 +29,8 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/ddl_create_table/postgresql/stdlib/go/db.go
+++ b/internal/endtoend/testdata/ddl_create_table/postgresql/stdlib/go/db.go
@@ -32,5 +32,5 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/ddl_create_table/postgresql/stdlib/go/query.sql.go
+++ b/internal/endtoend/testdata/ddl_create_table/postgresql/stdlib/go/query.sql.go
@@ -14,6 +14,9 @@ SELECT 1
 `
 
 func (q *Queries) Placeholder(ctx context.Context) error {
-	_, err := q.db.ExecContext(ctx, placeholder)
+	query := placeholder
+	queryParams := []interface{}{}
+
+	_, err := q.db.ExecContext(ctx, query, queryParams...)
 	return err
 }

--- a/internal/endtoend/testdata/ddl_create_table/sqlite/go/db.go
+++ b/internal/endtoend/testdata/ddl_create_table/sqlite/go/db.go
@@ -29,3 +29,8 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/ddl_create_table/sqlite/go/db.go
+++ b/internal/endtoend/testdata/ddl_create_table/sqlite/go/db.go
@@ -32,5 +32,5 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/ddl_create_table/sqlite/go/query.sql.go
+++ b/internal/endtoend/testdata/ddl_create_table/sqlite/go/query.sql.go
@@ -14,6 +14,9 @@ SELECT 1
 `
 
 func (q *Queries) Placeholder(ctx context.Context) error {
-	_, err := q.db.ExecContext(ctx, placeholder)
+	query := placeholder
+	queryParams := []interface{}{}
+
+	_, err := q.db.ExecContext(ctx, query, queryParams...)
 	return err
 }

--- a/internal/endtoend/testdata/ddl_create_table_include/postgresql/pgx/v4/go/db.go
+++ b/internal/endtoend/testdata/ddl_create_table_include/postgresql/pgx/v4/go/db.go
@@ -33,5 +33,5 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/ddl_create_table_include/postgresql/pgx/v4/go/db.go
+++ b/internal/endtoend/testdata/ddl_create_table_include/postgresql/pgx/v4/go/db.go
@@ -30,3 +30,8 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/ddl_create_table_include/postgresql/pgx/v5/go/db.go
+++ b/internal/endtoend/testdata/ddl_create_table_include/postgresql/pgx/v5/go/db.go
@@ -33,5 +33,5 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/ddl_create_table_include/postgresql/pgx/v5/go/db.go
+++ b/internal/endtoend/testdata/ddl_create_table_include/postgresql/pgx/v5/go/db.go
@@ -30,3 +30,8 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/ddl_create_table_include/postgresql/stdlib/go/db.go
+++ b/internal/endtoend/testdata/ddl_create_table_include/postgresql/stdlib/go/db.go
@@ -29,3 +29,8 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/ddl_create_table_include/postgresql/stdlib/go/db.go
+++ b/internal/endtoend/testdata/ddl_create_table_include/postgresql/stdlib/go/db.go
@@ -32,5 +32,5 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/ddl_create_table_include/postgresql/stdlib/go/query.sql.go
+++ b/internal/endtoend/testdata/ddl_create_table_include/postgresql/stdlib/go/query.sql.go
@@ -14,6 +14,9 @@ SELECT 1
 `
 
 func (q *Queries) Placeholder(ctx context.Context) error {
-	_, err := q.db.ExecContext(ctx, placeholder)
+	query := placeholder
+	queryParams := []interface{}{}
+
+	_, err := q.db.ExecContext(ctx, query, queryParams...)
 	return err
 }

--- a/internal/endtoend/testdata/ddl_create_table_inherits/postgresql/pgx/v4/go/db.go
+++ b/internal/endtoend/testdata/ddl_create_table_inherits/postgresql/pgx/v4/go/db.go
@@ -33,5 +33,5 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/ddl_create_table_inherits/postgresql/pgx/v4/go/db.go
+++ b/internal/endtoend/testdata/ddl_create_table_inherits/postgresql/pgx/v4/go/db.go
@@ -30,3 +30,8 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/ddl_create_table_inherits/postgresql/pgx/v4/go/query.sql.go
+++ b/internal/endtoend/testdata/ddl_create_table_inherits/postgresql/pgx/v4/go/query.sql.go
@@ -13,8 +13,16 @@ const getAllOrganisations = `-- name: GetAllOrganisations :many
 SELECT party_id, name, legal_name FROM organisation
 `
 
-func (q *Queries) GetAllOrganisations(ctx context.Context) ([]Organisation, error) {
-	rows, err := q.db.Query(ctx, getAllOrganisations)
+func (q *Queries) GetAllOrganisations(ctx context.Context, aq ...AdditionalQuery) ([]Organisation, error) {
+	query := getAllOrganisations
+	queryParams := []interface{}{}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.Query(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}
@@ -37,8 +45,16 @@ const getAllParties = `-- name: GetAllParties :many
 SELECT party_id, name FROM party
 `
 
-func (q *Queries) GetAllParties(ctx context.Context) ([]Party, error) {
-	rows, err := q.db.Query(ctx, getAllParties)
+func (q *Queries) GetAllParties(ctx context.Context, aq ...AdditionalQuery) ([]Party, error) {
+	query := getAllParties
+	queryParams := []interface{}{}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.Query(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}
@@ -61,8 +77,16 @@ const getAllPeople = `-- name: GetAllPeople :many
 SELECT party_id, name, first_name, last_name FROM person
 `
 
-func (q *Queries) GetAllPeople(ctx context.Context) ([]Person, error) {
-	rows, err := q.db.Query(ctx, getAllPeople)
+func (q *Queries) GetAllPeople(ctx context.Context, aq ...AdditionalQuery) ([]Person, error) {
+	query := getAllPeople
+	queryParams := []interface{}{}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.Query(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/endtoend/testdata/ddl_create_table_inherits/postgresql/pgx/v5/go/db.go
+++ b/internal/endtoend/testdata/ddl_create_table_inherits/postgresql/pgx/v5/go/db.go
@@ -33,5 +33,5 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/ddl_create_table_inherits/postgresql/pgx/v5/go/db.go
+++ b/internal/endtoend/testdata/ddl_create_table_inherits/postgresql/pgx/v5/go/db.go
@@ -30,3 +30,8 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/ddl_create_table_inherits/postgresql/pgx/v5/go/query.sql.go
+++ b/internal/endtoend/testdata/ddl_create_table_inherits/postgresql/pgx/v5/go/query.sql.go
@@ -13,8 +13,16 @@ const getAllOrganisations = `-- name: GetAllOrganisations :many
 SELECT party_id, name, legal_name FROM organisation
 `
 
-func (q *Queries) GetAllOrganisations(ctx context.Context) ([]Organisation, error) {
-	rows, err := q.db.Query(ctx, getAllOrganisations)
+func (q *Queries) GetAllOrganisations(ctx context.Context, aq ...AdditionalQuery) ([]Organisation, error) {
+	query := getAllOrganisations
+	queryParams := []interface{}{}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.Query(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}
@@ -37,8 +45,16 @@ const getAllParties = `-- name: GetAllParties :many
 SELECT party_id, name FROM party
 `
 
-func (q *Queries) GetAllParties(ctx context.Context) ([]Party, error) {
-	rows, err := q.db.Query(ctx, getAllParties)
+func (q *Queries) GetAllParties(ctx context.Context, aq ...AdditionalQuery) ([]Party, error) {
+	query := getAllParties
+	queryParams := []interface{}{}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.Query(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}
@@ -61,8 +77,16 @@ const getAllPeople = `-- name: GetAllPeople :many
 SELECT party_id, name, first_name, last_name FROM person
 `
 
-func (q *Queries) GetAllPeople(ctx context.Context) ([]Person, error) {
-	rows, err := q.db.Query(ctx, getAllPeople)
+func (q *Queries) GetAllPeople(ctx context.Context, aq ...AdditionalQuery) ([]Person, error) {
+	query := getAllPeople
+	queryParams := []interface{}{}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.Query(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/endtoend/testdata/ddl_create_table_inherits/postgresql/stdlib/go/db.go
+++ b/internal/endtoend/testdata/ddl_create_table_inherits/postgresql/stdlib/go/db.go
@@ -29,3 +29,8 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/ddl_create_table_inherits/postgresql/stdlib/go/db.go
+++ b/internal/endtoend/testdata/ddl_create_table_inherits/postgresql/stdlib/go/db.go
@@ -32,5 +32,5 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/ddl_create_table_inherits/postgresql/stdlib/go/query.sql.go
+++ b/internal/endtoend/testdata/ddl_create_table_inherits/postgresql/stdlib/go/query.sql.go
@@ -13,8 +13,16 @@ const getAllOrganisations = `-- name: GetAllOrganisations :many
 SELECT party_id, name, legal_name FROM organisation
 `
 
-func (q *Queries) GetAllOrganisations(ctx context.Context) ([]Organisation, error) {
-	rows, err := q.db.QueryContext(ctx, getAllOrganisations)
+func (q *Queries) GetAllOrganisations(ctx context.Context, aq ...AdditionalQuery) ([]Organisation, error) {
+	query := getAllOrganisations
+	queryParams := []interface{}{}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.QueryContext(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}
@@ -40,8 +48,16 @@ const getAllParties = `-- name: GetAllParties :many
 SELECT party_id, name FROM party
 `
 
-func (q *Queries) GetAllParties(ctx context.Context) ([]Party, error) {
-	rows, err := q.db.QueryContext(ctx, getAllParties)
+func (q *Queries) GetAllParties(ctx context.Context, aq ...AdditionalQuery) ([]Party, error) {
+	query := getAllParties
+	queryParams := []interface{}{}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.QueryContext(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}
@@ -67,8 +83,16 @@ const getAllPeople = `-- name: GetAllPeople :many
 SELECT party_id, name, first_name, last_name FROM person
 `
 
-func (q *Queries) GetAllPeople(ctx context.Context) ([]Person, error) {
-	rows, err := q.db.QueryContext(ctx, getAllPeople)
+func (q *Queries) GetAllPeople(ctx context.Context, aq ...AdditionalQuery) ([]Person, error) {
+	query := getAllPeople
+	queryParams := []interface{}{}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.QueryContext(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/endtoend/testdata/ddl_create_table_partition/postgresql/pgx/v4/go/db.go
+++ b/internal/endtoend/testdata/ddl_create_table_partition/postgresql/pgx/v4/go/db.go
@@ -33,5 +33,5 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/ddl_create_table_partition/postgresql/pgx/v4/go/db.go
+++ b/internal/endtoend/testdata/ddl_create_table_partition/postgresql/pgx/v4/go/db.go
@@ -30,3 +30,8 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/ddl_create_table_partition/postgresql/pgx/v5/go/db.go
+++ b/internal/endtoend/testdata/ddl_create_table_partition/postgresql/pgx/v5/go/db.go
@@ -33,5 +33,5 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/ddl_create_table_partition/postgresql/pgx/v5/go/db.go
+++ b/internal/endtoend/testdata/ddl_create_table_partition/postgresql/pgx/v5/go/db.go
@@ -30,3 +30,8 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/ddl_create_table_partition/postgresql/stdlib/go/db.go
+++ b/internal/endtoend/testdata/ddl_create_table_partition/postgresql/stdlib/go/db.go
@@ -29,3 +29,8 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/ddl_create_table_partition/postgresql/stdlib/go/db.go
+++ b/internal/endtoend/testdata/ddl_create_table_partition/postgresql/stdlib/go/db.go
@@ -32,5 +32,5 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/ddl_create_table_partition/postgresql/stdlib/go/query.sql.go
+++ b/internal/endtoend/testdata/ddl_create_table_partition/postgresql/stdlib/go/query.sql.go
@@ -14,6 +14,9 @@ SELECT 1
 `
 
 func (q *Queries) Placeholder(ctx context.Context) error {
-	_, err := q.db.ExecContext(ctx, placeholder)
+	query := placeholder
+	queryParams := []interface{}{}
+
+	_, err := q.db.ExecContext(ctx, query, queryParams...)
 	return err
 }

--- a/internal/endtoend/testdata/ddl_create_table_reserved/mysql/go/db.go
+++ b/internal/endtoend/testdata/ddl_create_table_reserved/mysql/go/db.go
@@ -29,3 +29,8 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/ddl_create_table_reserved/mysql/go/db.go
+++ b/internal/endtoend/testdata/ddl_create_table_reserved/mysql/go/db.go
@@ -32,5 +32,5 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/ddl_create_table_reserved/mysql/go/query.sql.go
+++ b/internal/endtoend/testdata/ddl_create_table_reserved/mysql/go/query.sql.go
@@ -14,6 +14,9 @@ SELECT 1
 `
 
 func (q *Queries) Placeholder(ctx context.Context) error {
-	_, err := q.db.ExecContext(ctx, placeholder)
+	query := placeholder
+	queryParams := []interface{}{}
+
+	_, err := q.db.ExecContext(ctx, query, queryParams...)
 	return err
 }

--- a/internal/endtoend/testdata/ddl_create_table_reserved/postgresql/pgx/v4/go/db.go
+++ b/internal/endtoend/testdata/ddl_create_table_reserved/postgresql/pgx/v4/go/db.go
@@ -33,5 +33,5 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/ddl_create_table_reserved/postgresql/pgx/v4/go/db.go
+++ b/internal/endtoend/testdata/ddl_create_table_reserved/postgresql/pgx/v4/go/db.go
@@ -30,3 +30,8 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/ddl_create_table_reserved/postgresql/pgx/v5/go/db.go
+++ b/internal/endtoend/testdata/ddl_create_table_reserved/postgresql/pgx/v5/go/db.go
@@ -33,5 +33,5 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/ddl_create_table_reserved/postgresql/pgx/v5/go/db.go
+++ b/internal/endtoend/testdata/ddl_create_table_reserved/postgresql/pgx/v5/go/db.go
@@ -30,3 +30,8 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/ddl_create_table_reserved/postgresql/stdlib/go/db.go
+++ b/internal/endtoend/testdata/ddl_create_table_reserved/postgresql/stdlib/go/db.go
@@ -29,3 +29,8 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/ddl_create_table_reserved/postgresql/stdlib/go/db.go
+++ b/internal/endtoend/testdata/ddl_create_table_reserved/postgresql/stdlib/go/db.go
@@ -32,5 +32,5 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/ddl_create_table_reserved/postgresql/stdlib/go/query.sql.go
+++ b/internal/endtoend/testdata/ddl_create_table_reserved/postgresql/stdlib/go/query.sql.go
@@ -14,6 +14,9 @@ SELECT 1
 `
 
 func (q *Queries) Placeholder(ctx context.Context) error {
-	_, err := q.db.ExecContext(ctx, placeholder)
+	query := placeholder
+	queryParams := []interface{}{}
+
+	_, err := q.db.ExecContext(ctx, query, queryParams...)
 	return err
 }

--- a/internal/endtoend/testdata/ddl_create_table_strict/sqlite/go/db.go
+++ b/internal/endtoend/testdata/ddl_create_table_strict/sqlite/go/db.go
@@ -29,3 +29,8 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/ddl_create_table_strict/sqlite/go/db.go
+++ b/internal/endtoend/testdata/ddl_create_table_strict/sqlite/go/db.go
@@ -32,5 +32,5 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/ddl_create_table_strict/sqlite/go/query.sql.go
+++ b/internal/endtoend/testdata/ddl_create_table_strict/sqlite/go/query.sql.go
@@ -14,6 +14,9 @@ SELECT 1
 `
 
 func (q *Queries) Placeholder(ctx context.Context) error {
-	_, err := q.db.ExecContext(ctx, placeholder)
+	query := placeholder
+	queryParams := []interface{}{}
+
+	_, err := q.db.ExecContext(ctx, query, queryParams...)
 	return err
 }

--- a/internal/endtoend/testdata/ddl_create_table_without_rowid/sqlite/go/db.go
+++ b/internal/endtoend/testdata/ddl_create_table_without_rowid/sqlite/go/db.go
@@ -29,3 +29,8 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/ddl_create_table_without_rowid/sqlite/go/db.go
+++ b/internal/endtoend/testdata/ddl_create_table_without_rowid/sqlite/go/db.go
@@ -32,5 +32,5 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/ddl_create_table_without_rowid/sqlite/go/query.sql.go
+++ b/internal/endtoend/testdata/ddl_create_table_without_rowid/sqlite/go/query.sql.go
@@ -14,6 +14,9 @@ SELECT 1
 `
 
 func (q *Queries) Placeholder(ctx context.Context) error {
-	_, err := q.db.ExecContext(ctx, placeholder)
+	query := placeholder
+	queryParams := []interface{}{}
+
+	_, err := q.db.ExecContext(ctx, query, queryParams...)
 	return err
 }

--- a/internal/endtoend/testdata/ddl_create_trigger/postgresql/pgx/v4/go/db.go
+++ b/internal/endtoend/testdata/ddl_create_trigger/postgresql/pgx/v4/go/db.go
@@ -33,5 +33,5 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/ddl_create_trigger/postgresql/pgx/v4/go/db.go
+++ b/internal/endtoend/testdata/ddl_create_trigger/postgresql/pgx/v4/go/db.go
@@ -30,3 +30,8 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/ddl_create_trigger/postgresql/pgx/v5/go/db.go
+++ b/internal/endtoend/testdata/ddl_create_trigger/postgresql/pgx/v5/go/db.go
@@ -33,5 +33,5 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/ddl_create_trigger/postgresql/pgx/v5/go/db.go
+++ b/internal/endtoend/testdata/ddl_create_trigger/postgresql/pgx/v5/go/db.go
@@ -30,3 +30,8 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/ddl_create_trigger/postgresql/stdlib/go/db.go
+++ b/internal/endtoend/testdata/ddl_create_trigger/postgresql/stdlib/go/db.go
@@ -29,3 +29,8 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/ddl_create_trigger/postgresql/stdlib/go/db.go
+++ b/internal/endtoend/testdata/ddl_create_trigger/postgresql/stdlib/go/db.go
@@ -32,5 +32,5 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/ddl_create_trigger/postgresql/stdlib/go/query.sql.go
+++ b/internal/endtoend/testdata/ddl_create_trigger/postgresql/stdlib/go/query.sql.go
@@ -14,6 +14,9 @@ SELECT 1
 `
 
 func (q *Queries) Placeholder(ctx context.Context) error {
-	_, err := q.db.ExecContext(ctx, placeholder)
+	query := placeholder
+	queryParams := []interface{}{}
+
+	_, err := q.db.ExecContext(ctx, query, queryParams...)
 	return err
 }

--- a/internal/endtoend/testdata/ddl_create_trigger/sqlite/go/db.go
+++ b/internal/endtoend/testdata/ddl_create_trigger/sqlite/go/db.go
@@ -29,3 +29,8 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/ddl_create_trigger/sqlite/go/db.go
+++ b/internal/endtoend/testdata/ddl_create_trigger/sqlite/go/db.go
@@ -32,5 +32,5 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/ddl_create_trigger/sqlite/go/query.sql.go
+++ b/internal/endtoend/testdata/ddl_create_trigger/sqlite/go/query.sql.go
@@ -14,6 +14,9 @@ SELECT 1
 `
 
 func (q *Queries) Placeholder(ctx context.Context) error {
-	_, err := q.db.ExecContext(ctx, placeholder)
+	query := placeholder
+	queryParams := []interface{}{}
+
+	_, err := q.db.ExecContext(ctx, query, queryParams...)
 	return err
 }

--- a/internal/endtoend/testdata/ddl_drop_function/postgresql/pgx/v4/go/db.go
+++ b/internal/endtoend/testdata/ddl_drop_function/postgresql/pgx/v4/go/db.go
@@ -33,5 +33,5 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/ddl_drop_function/postgresql/pgx/v4/go/db.go
+++ b/internal/endtoend/testdata/ddl_drop_function/postgresql/pgx/v4/go/db.go
@@ -30,3 +30,8 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/ddl_drop_function/postgresql/pgx/v5/go/db.go
+++ b/internal/endtoend/testdata/ddl_drop_function/postgresql/pgx/v5/go/db.go
@@ -33,5 +33,5 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/ddl_drop_function/postgresql/pgx/v5/go/db.go
+++ b/internal/endtoend/testdata/ddl_drop_function/postgresql/pgx/v5/go/db.go
@@ -30,3 +30,8 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/ddl_drop_function/postgresql/stdlib/go/db.go
+++ b/internal/endtoend/testdata/ddl_drop_function/postgresql/stdlib/go/db.go
@@ -29,3 +29,8 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/ddl_drop_function/postgresql/stdlib/go/db.go
+++ b/internal/endtoend/testdata/ddl_drop_function/postgresql/stdlib/go/db.go
@@ -32,5 +32,5 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/ddl_drop_function/postgresql/stdlib/go/query.sql.go
+++ b/internal/endtoend/testdata/ddl_drop_function/postgresql/stdlib/go/query.sql.go
@@ -14,6 +14,9 @@ SELECT 1
 `
 
 func (q *Queries) Placeholder(ctx context.Context) error {
-	_, err := q.db.ExecContext(ctx, placeholder)
+	query := placeholder
+	queryParams := []interface{}{}
+
+	_, err := q.db.ExecContext(ctx, query, queryParams...)
 	return err
 }

--- a/internal/endtoend/testdata/ddl_drop_function_args/postgresql/pgx/v4/go/db.go
+++ b/internal/endtoend/testdata/ddl_drop_function_args/postgresql/pgx/v4/go/db.go
@@ -33,5 +33,5 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/ddl_drop_function_args/postgresql/pgx/v4/go/db.go
+++ b/internal/endtoend/testdata/ddl_drop_function_args/postgresql/pgx/v4/go/db.go
@@ -30,3 +30,8 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/ddl_drop_function_args/postgresql/pgx/v5/go/db.go
+++ b/internal/endtoend/testdata/ddl_drop_function_args/postgresql/pgx/v5/go/db.go
@@ -33,5 +33,5 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/ddl_drop_function_args/postgresql/pgx/v5/go/db.go
+++ b/internal/endtoend/testdata/ddl_drop_function_args/postgresql/pgx/v5/go/db.go
@@ -30,3 +30,8 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/ddl_drop_function_args/postgresql/stdlib/go/db.go
+++ b/internal/endtoend/testdata/ddl_drop_function_args/postgresql/stdlib/go/db.go
@@ -29,3 +29,8 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/ddl_drop_function_args/postgresql/stdlib/go/db.go
+++ b/internal/endtoend/testdata/ddl_drop_function_args/postgresql/stdlib/go/db.go
@@ -32,5 +32,5 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/ddl_drop_function_args/postgresql/stdlib/go/query.sql.go
+++ b/internal/endtoend/testdata/ddl_drop_function_args/postgresql/stdlib/go/query.sql.go
@@ -14,6 +14,9 @@ SELECT 1
 `
 
 func (q *Queries) Placeholder(ctx context.Context) error {
-	_, err := q.db.ExecContext(ctx, placeholder)
+	query := placeholder
+	queryParams := []interface{}{}
+
+	_, err := q.db.ExecContext(ctx, query, queryParams...)
 	return err
 }

--- a/internal/endtoend/testdata/ddl_drop_function_if_exists/postgresql/pgx/v4/go/db.go
+++ b/internal/endtoend/testdata/ddl_drop_function_if_exists/postgresql/pgx/v4/go/db.go
@@ -33,5 +33,5 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/ddl_drop_function_if_exists/postgresql/pgx/v4/go/db.go
+++ b/internal/endtoend/testdata/ddl_drop_function_if_exists/postgresql/pgx/v4/go/db.go
@@ -30,3 +30,8 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/ddl_drop_function_if_exists/postgresql/pgx/v5/go/db.go
+++ b/internal/endtoend/testdata/ddl_drop_function_if_exists/postgresql/pgx/v5/go/db.go
@@ -33,5 +33,5 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/ddl_drop_function_if_exists/postgresql/pgx/v5/go/db.go
+++ b/internal/endtoend/testdata/ddl_drop_function_if_exists/postgresql/pgx/v5/go/db.go
@@ -30,3 +30,8 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/ddl_drop_function_if_exists/postgresql/stdlib/go/db.go
+++ b/internal/endtoend/testdata/ddl_drop_function_if_exists/postgresql/stdlib/go/db.go
@@ -29,3 +29,8 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/ddl_drop_function_if_exists/postgresql/stdlib/go/db.go
+++ b/internal/endtoend/testdata/ddl_drop_function_if_exists/postgresql/stdlib/go/db.go
@@ -32,5 +32,5 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/ddl_drop_function_if_exists/postgresql/stdlib/go/query.sql.go
+++ b/internal/endtoend/testdata/ddl_drop_function_if_exists/postgresql/stdlib/go/query.sql.go
@@ -14,6 +14,9 @@ SELECT 1
 `
 
 func (q *Queries) Placeholder(ctx context.Context) error {
-	_, err := q.db.ExecContext(ctx, placeholder)
+	query := placeholder
+	queryParams := []interface{}{}
+
+	_, err := q.db.ExecContext(ctx, query, queryParams...)
 	return err
 }

--- a/internal/endtoend/testdata/ddl_drop_schema/mysql/go/db.go
+++ b/internal/endtoend/testdata/ddl_drop_schema/mysql/go/db.go
@@ -29,3 +29,8 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/ddl_drop_schema/mysql/go/db.go
+++ b/internal/endtoend/testdata/ddl_drop_schema/mysql/go/db.go
@@ -32,5 +32,5 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/ddl_drop_schema/mysql/go/query.sql.go
+++ b/internal/endtoend/testdata/ddl_drop_schema/mysql/go/query.sql.go
@@ -14,6 +14,9 @@ SELECT 1
 `
 
 func (q *Queries) Placeholder(ctx context.Context) error {
-	_, err := q.db.ExecContext(ctx, placeholder)
+	query := placeholder
+	queryParams := []interface{}{}
+
+	_, err := q.db.ExecContext(ctx, query, queryParams...)
 	return err
 }

--- a/internal/endtoend/testdata/ddl_drop_schema/postgresql/pgx/v4/go/db.go
+++ b/internal/endtoend/testdata/ddl_drop_schema/postgresql/pgx/v4/go/db.go
@@ -33,5 +33,5 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/ddl_drop_schema/postgresql/pgx/v4/go/db.go
+++ b/internal/endtoend/testdata/ddl_drop_schema/postgresql/pgx/v4/go/db.go
@@ -30,3 +30,8 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/ddl_drop_schema/postgresql/pgx/v5/go/db.go
+++ b/internal/endtoend/testdata/ddl_drop_schema/postgresql/pgx/v5/go/db.go
@@ -33,5 +33,5 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/ddl_drop_schema/postgresql/pgx/v5/go/db.go
+++ b/internal/endtoend/testdata/ddl_drop_schema/postgresql/pgx/v5/go/db.go
@@ -30,3 +30,8 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/ddl_drop_schema/postgresql/stdlib/go/db.go
+++ b/internal/endtoend/testdata/ddl_drop_schema/postgresql/stdlib/go/db.go
@@ -29,3 +29,8 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/ddl_drop_schema/postgresql/stdlib/go/db.go
+++ b/internal/endtoend/testdata/ddl_drop_schema/postgresql/stdlib/go/db.go
@@ -32,5 +32,5 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/ddl_drop_schema/postgresql/stdlib/go/query.sql.go
+++ b/internal/endtoend/testdata/ddl_drop_schema/postgresql/stdlib/go/query.sql.go
@@ -14,6 +14,9 @@ SELECT 1
 `
 
 func (q *Queries) Placeholder(ctx context.Context) error {
-	_, err := q.db.ExecContext(ctx, placeholder)
+	query := placeholder
+	queryParams := []interface{}{}
+
+	_, err := q.db.ExecContext(ctx, query, queryParams...)
 	return err
 }

--- a/internal/endtoend/testdata/ddl_drop_schema_if_exists/postgresql/pgx/v4/go/db.go
+++ b/internal/endtoend/testdata/ddl_drop_schema_if_exists/postgresql/pgx/v4/go/db.go
@@ -33,5 +33,5 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/ddl_drop_schema_if_exists/postgresql/pgx/v4/go/db.go
+++ b/internal/endtoend/testdata/ddl_drop_schema_if_exists/postgresql/pgx/v4/go/db.go
@@ -30,3 +30,8 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/ddl_drop_schema_if_exists/postgresql/pgx/v5/go/db.go
+++ b/internal/endtoend/testdata/ddl_drop_schema_if_exists/postgresql/pgx/v5/go/db.go
@@ -33,5 +33,5 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/ddl_drop_schema_if_exists/postgresql/pgx/v5/go/db.go
+++ b/internal/endtoend/testdata/ddl_drop_schema_if_exists/postgresql/pgx/v5/go/db.go
@@ -30,3 +30,8 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/ddl_drop_schema_if_exists/postgresql/stdlib/go/db.go
+++ b/internal/endtoend/testdata/ddl_drop_schema_if_exists/postgresql/stdlib/go/db.go
@@ -29,3 +29,8 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/ddl_drop_schema_if_exists/postgresql/stdlib/go/db.go
+++ b/internal/endtoend/testdata/ddl_drop_schema_if_exists/postgresql/stdlib/go/db.go
@@ -32,5 +32,5 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/ddl_drop_schema_if_exists/postgresql/stdlib/go/query.sql.go
+++ b/internal/endtoend/testdata/ddl_drop_schema_if_exists/postgresql/stdlib/go/query.sql.go
@@ -14,6 +14,9 @@ SELECT 1
 `
 
 func (q *Queries) Placeholder(ctx context.Context) error {
-	_, err := q.db.ExecContext(ctx, placeholder)
+	query := placeholder
+	queryParams := []interface{}{}
+
+	_, err := q.db.ExecContext(ctx, query, queryParams...)
 	return err
 }

--- a/internal/endtoend/testdata/ddl_drop_table/postgresql/pgx/v4/go/db.go
+++ b/internal/endtoend/testdata/ddl_drop_table/postgresql/pgx/v4/go/db.go
@@ -33,5 +33,5 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/ddl_drop_table/postgresql/pgx/v4/go/db.go
+++ b/internal/endtoend/testdata/ddl_drop_table/postgresql/pgx/v4/go/db.go
@@ -30,3 +30,8 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/ddl_drop_table/postgresql/pgx/v5/go/db.go
+++ b/internal/endtoend/testdata/ddl_drop_table/postgresql/pgx/v5/go/db.go
@@ -33,5 +33,5 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/ddl_drop_table/postgresql/pgx/v5/go/db.go
+++ b/internal/endtoend/testdata/ddl_drop_table/postgresql/pgx/v5/go/db.go
@@ -30,3 +30,8 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/ddl_drop_table/postgresql/stdlib/go/db.go
+++ b/internal/endtoend/testdata/ddl_drop_table/postgresql/stdlib/go/db.go
@@ -29,3 +29,8 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/ddl_drop_table/postgresql/stdlib/go/db.go
+++ b/internal/endtoend/testdata/ddl_drop_table/postgresql/stdlib/go/db.go
@@ -32,5 +32,5 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/ddl_drop_table/postgresql/stdlib/go/query.sql.go
+++ b/internal/endtoend/testdata/ddl_drop_table/postgresql/stdlib/go/query.sql.go
@@ -14,6 +14,9 @@ SELECT 1
 `
 
 func (q *Queries) Placeholder(ctx context.Context) error {
-	_, err := q.db.ExecContext(ctx, placeholder)
+	query := placeholder
+	queryParams := []interface{}{}
+
+	_, err := q.db.ExecContext(ctx, query, queryParams...)
 	return err
 }

--- a/internal/endtoend/testdata/ddl_drop_table/sqlite/go/db.go
+++ b/internal/endtoend/testdata/ddl_drop_table/sqlite/go/db.go
@@ -29,3 +29,8 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/ddl_drop_table/sqlite/go/db.go
+++ b/internal/endtoend/testdata/ddl_drop_table/sqlite/go/db.go
@@ -32,5 +32,5 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/ddl_drop_table/sqlite/go/query.sql.go
+++ b/internal/endtoend/testdata/ddl_drop_table/sqlite/go/query.sql.go
@@ -14,6 +14,9 @@ SELECT 1
 `
 
 func (q *Queries) Placeholder(ctx context.Context) error {
-	_, err := q.db.ExecContext(ctx, placeholder)
+	query := placeholder
+	queryParams := []interface{}{}
+
+	_, err := q.db.ExecContext(ctx, query, queryParams...)
 	return err
 }

--- a/internal/endtoend/testdata/ddl_drop_table_if_exists/postgresql/pgx/v4/go/db.go
+++ b/internal/endtoend/testdata/ddl_drop_table_if_exists/postgresql/pgx/v4/go/db.go
@@ -33,5 +33,5 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/ddl_drop_table_if_exists/postgresql/pgx/v4/go/db.go
+++ b/internal/endtoend/testdata/ddl_drop_table_if_exists/postgresql/pgx/v4/go/db.go
@@ -30,3 +30,8 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/ddl_drop_table_if_exists/postgresql/pgx/v5/go/db.go
+++ b/internal/endtoend/testdata/ddl_drop_table_if_exists/postgresql/pgx/v5/go/db.go
@@ -33,5 +33,5 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/ddl_drop_table_if_exists/postgresql/pgx/v5/go/db.go
+++ b/internal/endtoend/testdata/ddl_drop_table_if_exists/postgresql/pgx/v5/go/db.go
@@ -30,3 +30,8 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/ddl_drop_table_if_exists/postgresql/stdlib/go/db.go
+++ b/internal/endtoend/testdata/ddl_drop_table_if_exists/postgresql/stdlib/go/db.go
@@ -29,3 +29,8 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/ddl_drop_table_if_exists/postgresql/stdlib/go/db.go
+++ b/internal/endtoend/testdata/ddl_drop_table_if_exists/postgresql/stdlib/go/db.go
@@ -32,5 +32,5 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/ddl_drop_table_if_exists/postgresql/stdlib/go/query.sql.go
+++ b/internal/endtoend/testdata/ddl_drop_table_if_exists/postgresql/stdlib/go/query.sql.go
@@ -14,6 +14,9 @@ SELECT 1
 `
 
 func (q *Queries) Placeholder(ctx context.Context) error {
-	_, err := q.db.ExecContext(ctx, placeholder)
+	query := placeholder
+	queryParams := []interface{}{}
+
+	_, err := q.db.ExecContext(ctx, query, queryParams...)
 	return err
 }

--- a/internal/endtoend/testdata/ddl_drop_table_if_exists/sqlite/go/db.go
+++ b/internal/endtoend/testdata/ddl_drop_table_if_exists/sqlite/go/db.go
@@ -29,3 +29,8 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/ddl_drop_table_if_exists/sqlite/go/db.go
+++ b/internal/endtoend/testdata/ddl_drop_table_if_exists/sqlite/go/db.go
@@ -32,5 +32,5 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/ddl_drop_table_if_exists/sqlite/go/query.sql.go
+++ b/internal/endtoend/testdata/ddl_drop_table_if_exists/sqlite/go/query.sql.go
@@ -14,6 +14,9 @@ SELECT 1
 `
 
 func (q *Queries) Placeholder(ctx context.Context) error {
-	_, err := q.db.ExecContext(ctx, placeholder)
+	query := placeholder
+	queryParams := []interface{}{}
+
+	_, err := q.db.ExecContext(ctx, query, queryParams...)
 	return err
 }

--- a/internal/endtoend/testdata/ddl_drop_table_in_schema/postgresql/pgx/v4/go/db.go
+++ b/internal/endtoend/testdata/ddl_drop_table_in_schema/postgresql/pgx/v4/go/db.go
@@ -33,5 +33,5 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/ddl_drop_table_in_schema/postgresql/pgx/v4/go/db.go
+++ b/internal/endtoend/testdata/ddl_drop_table_in_schema/postgresql/pgx/v4/go/db.go
@@ -30,3 +30,8 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/ddl_drop_table_in_schema/postgresql/pgx/v5/go/db.go
+++ b/internal/endtoend/testdata/ddl_drop_table_in_schema/postgresql/pgx/v5/go/db.go
@@ -33,5 +33,5 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/ddl_drop_table_in_schema/postgresql/pgx/v5/go/db.go
+++ b/internal/endtoend/testdata/ddl_drop_table_in_schema/postgresql/pgx/v5/go/db.go
@@ -30,3 +30,8 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/ddl_drop_table_in_schema/postgresql/stdlib/go/db.go
+++ b/internal/endtoend/testdata/ddl_drop_table_in_schema/postgresql/stdlib/go/db.go
@@ -29,3 +29,8 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/ddl_drop_table_in_schema/postgresql/stdlib/go/db.go
+++ b/internal/endtoend/testdata/ddl_drop_table_in_schema/postgresql/stdlib/go/db.go
@@ -32,5 +32,5 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/ddl_drop_table_in_schema/postgresql/stdlib/go/query.sql.go
+++ b/internal/endtoend/testdata/ddl_drop_table_in_schema/postgresql/stdlib/go/query.sql.go
@@ -14,6 +14,9 @@ SELECT 1
 `
 
 func (q *Queries) Placeholder(ctx context.Context) error {
-	_, err := q.db.ExecContext(ctx, placeholder)
+	query := placeholder
+	queryParams := []interface{}{}
+
+	_, err := q.db.ExecContext(ctx, query, queryParams...)
 	return err
 }

--- a/internal/endtoend/testdata/ddl_drop_type/postgresql/pgx/v4/go/db.go
+++ b/internal/endtoend/testdata/ddl_drop_type/postgresql/pgx/v4/go/db.go
@@ -33,5 +33,5 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/ddl_drop_type/postgresql/pgx/v4/go/db.go
+++ b/internal/endtoend/testdata/ddl_drop_type/postgresql/pgx/v4/go/db.go
@@ -30,3 +30,8 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/ddl_drop_type/postgresql/pgx/v5/go/db.go
+++ b/internal/endtoend/testdata/ddl_drop_type/postgresql/pgx/v5/go/db.go
@@ -33,5 +33,5 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/ddl_drop_type/postgresql/pgx/v5/go/db.go
+++ b/internal/endtoend/testdata/ddl_drop_type/postgresql/pgx/v5/go/db.go
@@ -30,3 +30,8 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/ddl_drop_type/postgresql/stdlib/go/db.go
+++ b/internal/endtoend/testdata/ddl_drop_type/postgresql/stdlib/go/db.go
@@ -29,3 +29,8 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/ddl_drop_type/postgresql/stdlib/go/db.go
+++ b/internal/endtoend/testdata/ddl_drop_type/postgresql/stdlib/go/db.go
@@ -32,5 +32,5 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/ddl_drop_type/postgresql/stdlib/go/query.sql.go
+++ b/internal/endtoend/testdata/ddl_drop_type/postgresql/stdlib/go/query.sql.go
@@ -14,6 +14,9 @@ SELECT 1
 `
 
 func (q *Queries) Placeholder(ctx context.Context) error {
-	_, err := q.db.ExecContext(ctx, placeholder)
+	query := placeholder
+	queryParams := []interface{}{}
+
+	_, err := q.db.ExecContext(ctx, query, queryParams...)
 	return err
 }

--- a/internal/endtoend/testdata/ddl_drop_type_if_exists/postgresql/pgx/v4/go/db.go
+++ b/internal/endtoend/testdata/ddl_drop_type_if_exists/postgresql/pgx/v4/go/db.go
@@ -33,5 +33,5 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/ddl_drop_type_if_exists/postgresql/pgx/v4/go/db.go
+++ b/internal/endtoend/testdata/ddl_drop_type_if_exists/postgresql/pgx/v4/go/db.go
@@ -30,3 +30,8 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/ddl_drop_type_if_exists/postgresql/pgx/v5/go/db.go
+++ b/internal/endtoend/testdata/ddl_drop_type_if_exists/postgresql/pgx/v5/go/db.go
@@ -33,5 +33,5 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/ddl_drop_type_if_exists/postgresql/pgx/v5/go/db.go
+++ b/internal/endtoend/testdata/ddl_drop_type_if_exists/postgresql/pgx/v5/go/db.go
@@ -30,3 +30,8 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/ddl_drop_type_if_exists/postgresql/stdlib/go/db.go
+++ b/internal/endtoend/testdata/ddl_drop_type_if_exists/postgresql/stdlib/go/db.go
@@ -29,3 +29,8 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/ddl_drop_type_if_exists/postgresql/stdlib/go/db.go
+++ b/internal/endtoend/testdata/ddl_drop_type_if_exists/postgresql/stdlib/go/db.go
@@ -32,5 +32,5 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/ddl_drop_type_if_exists/postgresql/stdlib/go/query.sql.go
+++ b/internal/endtoend/testdata/ddl_drop_type_if_exists/postgresql/stdlib/go/query.sql.go
@@ -14,6 +14,9 @@ SELECT 1
 `
 
 func (q *Queries) Placeholder(ctx context.Context) error {
-	_, err := q.db.ExecContext(ctx, placeholder)
+	query := placeholder
+	queryParams := []interface{}{}
+
+	_, err := q.db.ExecContext(ctx, query, queryParams...)
 	return err
 }

--- a/internal/endtoend/testdata/ddl_drop_type_in_schema/postgresql/pgx/v4/go/db.go
+++ b/internal/endtoend/testdata/ddl_drop_type_in_schema/postgresql/pgx/v4/go/db.go
@@ -33,5 +33,5 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/ddl_drop_type_in_schema/postgresql/pgx/v4/go/db.go
+++ b/internal/endtoend/testdata/ddl_drop_type_in_schema/postgresql/pgx/v4/go/db.go
@@ -30,3 +30,8 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/ddl_drop_type_in_schema/postgresql/pgx/v5/go/db.go
+++ b/internal/endtoend/testdata/ddl_drop_type_in_schema/postgresql/pgx/v5/go/db.go
@@ -33,5 +33,5 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/ddl_drop_type_in_schema/postgresql/pgx/v5/go/db.go
+++ b/internal/endtoend/testdata/ddl_drop_type_in_schema/postgresql/pgx/v5/go/db.go
@@ -30,3 +30,8 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/ddl_drop_type_in_schema/postgresql/stdlib/go/db.go
+++ b/internal/endtoend/testdata/ddl_drop_type_in_schema/postgresql/stdlib/go/db.go
@@ -29,3 +29,8 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/ddl_drop_type_in_schema/postgresql/stdlib/go/db.go
+++ b/internal/endtoend/testdata/ddl_drop_type_in_schema/postgresql/stdlib/go/db.go
@@ -32,5 +32,5 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/ddl_drop_type_in_schema/postgresql/stdlib/go/query.sql.go
+++ b/internal/endtoend/testdata/ddl_drop_type_in_schema/postgresql/stdlib/go/query.sql.go
@@ -14,6 +14,9 @@ SELECT 1
 `
 
 func (q *Queries) Placeholder(ctx context.Context) error {
-	_, err := q.db.ExecContext(ctx, placeholder)
+	query := placeholder
+	queryParams := []interface{}{}
+
+	_, err := q.db.ExecContext(ctx, query, queryParams...)
 	return err
 }

--- a/internal/endtoend/testdata/ddl_generated_columns/postgresql/pgx/v4/go/db.go
+++ b/internal/endtoend/testdata/ddl_generated_columns/postgresql/pgx/v4/go/db.go
@@ -33,5 +33,5 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/ddl_generated_columns/postgresql/pgx/v4/go/db.go
+++ b/internal/endtoend/testdata/ddl_generated_columns/postgresql/pgx/v4/go/db.go
@@ -30,3 +30,8 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/ddl_generated_columns/postgresql/pgx/v5/go/db.go
+++ b/internal/endtoend/testdata/ddl_generated_columns/postgresql/pgx/v5/go/db.go
@@ -33,5 +33,5 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/ddl_generated_columns/postgresql/pgx/v5/go/db.go
+++ b/internal/endtoend/testdata/ddl_generated_columns/postgresql/pgx/v5/go/db.go
@@ -30,3 +30,8 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/ddl_generated_columns/postgresql/stdlib/go/db.go
+++ b/internal/endtoend/testdata/ddl_generated_columns/postgresql/stdlib/go/db.go
@@ -29,3 +29,8 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/ddl_generated_columns/postgresql/stdlib/go/db.go
+++ b/internal/endtoend/testdata/ddl_generated_columns/postgresql/stdlib/go/db.go
@@ -32,5 +32,5 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/ddl_generated_columns/postgresql/stdlib/go/query.sql.go
+++ b/internal/endtoend/testdata/ddl_generated_columns/postgresql/stdlib/go/query.sql.go
@@ -14,6 +14,9 @@ SELECT 1
 `
 
 func (q *Queries) Placeholder(ctx context.Context) error {
-	_, err := q.db.ExecContext(ctx, placeholder)
+	query := placeholder
+	queryParams := []interface{}{}
+
+	_, err := q.db.ExecContext(ctx, query, queryParams...)
 	return err
 }

--- a/internal/endtoend/testdata/ddl_pg_temp/postgresql/pgx/v4/go/db.go
+++ b/internal/endtoend/testdata/ddl_pg_temp/postgresql/pgx/v4/go/db.go
@@ -33,5 +33,5 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/ddl_pg_temp/postgresql/pgx/v4/go/db.go
+++ b/internal/endtoend/testdata/ddl_pg_temp/postgresql/pgx/v4/go/db.go
@@ -30,3 +30,8 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/ddl_pg_temp/postgresql/pgx/v5/go/db.go
+++ b/internal/endtoend/testdata/ddl_pg_temp/postgresql/pgx/v5/go/db.go
@@ -33,5 +33,5 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/ddl_pg_temp/postgresql/pgx/v5/go/db.go
+++ b/internal/endtoend/testdata/ddl_pg_temp/postgresql/pgx/v5/go/db.go
@@ -30,3 +30,8 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/ddl_pg_temp/postgresql/stdlib/go/db.go
+++ b/internal/endtoend/testdata/ddl_pg_temp/postgresql/stdlib/go/db.go
@@ -29,3 +29,8 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/ddl_pg_temp/postgresql/stdlib/go/db.go
+++ b/internal/endtoend/testdata/ddl_pg_temp/postgresql/stdlib/go/db.go
@@ -32,5 +32,5 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/ddl_pg_temp/postgresql/stdlib/go/query.sql.go
+++ b/internal/endtoend/testdata/ddl_pg_temp/postgresql/stdlib/go/query.sql.go
@@ -14,6 +14,9 @@ SELECT 1
 `
 
 func (q *Queries) Placeholder(ctx context.Context) error {
-	_, err := q.db.ExecContext(ctx, placeholder)
+	query := placeholder
+	queryParams := []interface{}{}
+
+	_, err := q.db.ExecContext(ctx, query, queryParams...)
 	return err
 }

--- a/internal/endtoend/testdata/delete_from/mysql/go/db.go
+++ b/internal/endtoend/testdata/delete_from/mysql/go/db.go
@@ -29,3 +29,8 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/delete_from/mysql/go/db.go
+++ b/internal/endtoend/testdata/delete_from/mysql/go/db.go
@@ -32,5 +32,5 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/delete_from/mysql/go/query.sql.go
+++ b/internal/endtoend/testdata/delete_from/mysql/go/query.sql.go
@@ -14,6 +14,9 @@ DELETE FROM foo WHERE id = ?
 `
 
 func (q *Queries) DeleteFrom(ctx context.Context, id string) error {
-	_, err := q.db.ExecContext(ctx, deleteFrom, id)
+	query := deleteFrom
+	queryParams := []interface{}{id}
+
+	_, err := q.db.ExecContext(ctx, query, queryParams...)
 	return err
 }

--- a/internal/endtoend/testdata/delete_from/postgresql/pgx/v4/go/db.go
+++ b/internal/endtoend/testdata/delete_from/postgresql/pgx/v4/go/db.go
@@ -33,5 +33,5 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/delete_from/postgresql/pgx/v4/go/db.go
+++ b/internal/endtoend/testdata/delete_from/postgresql/pgx/v4/go/db.go
@@ -30,3 +30,8 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/delete_from/postgresql/pgx/v5/go/db.go
+++ b/internal/endtoend/testdata/delete_from/postgresql/pgx/v5/go/db.go
@@ -33,5 +33,5 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/delete_from/postgresql/pgx/v5/go/db.go
+++ b/internal/endtoend/testdata/delete_from/postgresql/pgx/v5/go/db.go
@@ -30,3 +30,8 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/delete_from/postgresql/stdlib/go/db.go
+++ b/internal/endtoend/testdata/delete_from/postgresql/stdlib/go/db.go
@@ -29,3 +29,8 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/delete_from/postgresql/stdlib/go/db.go
+++ b/internal/endtoend/testdata/delete_from/postgresql/stdlib/go/db.go
@@ -32,5 +32,5 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/delete_from/postgresql/stdlib/go/query.sql.go
+++ b/internal/endtoend/testdata/delete_from/postgresql/stdlib/go/query.sql.go
@@ -14,6 +14,9 @@ DELETE FROM foo WHERE id = $1
 `
 
 func (q *Queries) DeleteFrom(ctx context.Context, id string) error {
-	_, err := q.db.ExecContext(ctx, deleteFrom, id)
+	query := deleteFrom
+	queryParams := []interface{}{id}
+
+	_, err := q.db.ExecContext(ctx, query, queryParams...)
 	return err
 }

--- a/internal/endtoend/testdata/delete_from/sqlite/go/db.go
+++ b/internal/endtoend/testdata/delete_from/sqlite/go/db.go
@@ -29,3 +29,8 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/delete_from/sqlite/go/db.go
+++ b/internal/endtoend/testdata/delete_from/sqlite/go/db.go
@@ -32,5 +32,5 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/delete_from/sqlite/go/query.sql.go
+++ b/internal/endtoend/testdata/delete_from/sqlite/go/query.sql.go
@@ -14,6 +14,9 @@ DELETE FROM foo WHERE id = ?
 `
 
 func (q *Queries) DeleteFrom(ctx context.Context, id string) error {
-	_, err := q.db.ExecContext(ctx, deleteFrom, id)
+	query := deleteFrom
+	queryParams := []interface{}{id}
+
+	_, err := q.db.ExecContext(ctx, query, queryParams...)
 	return err
 }

--- a/internal/endtoend/testdata/delete_inner_join/mysql/go/db.go
+++ b/internal/endtoend/testdata/delete_inner_join/mysql/go/db.go
@@ -29,3 +29,8 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/delete_inner_join/mysql/go/db.go
+++ b/internal/endtoend/testdata/delete_inner_join/mysql/go/db.go
@@ -32,5 +32,5 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/delete_inner_join/mysql/go/query.sql.go
+++ b/internal/endtoend/testdata/delete_inner_join/mysql/go/query.sql.go
@@ -19,6 +19,9 @@ WHERE
 `
 
 func (q *Queries) RemoveAllAuthorsFromTheGreatGatsby(ctx context.Context) error {
-	_, err := q.db.ExecContext(ctx, removeAllAuthorsFromTheGreatGatsby)
+	query := removeAllAuthorsFromTheGreatGatsby
+	queryParams := []interface{}{}
+
+	_, err := q.db.ExecContext(ctx, query, queryParams...)
 	return err
 }

--- a/internal/endtoend/testdata/delete_join/mysql/db/db.go
+++ b/internal/endtoend/testdata/delete_join/mysql/db/db.go
@@ -29,3 +29,8 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/delete_join/mysql/db/db.go
+++ b/internal/endtoend/testdata/delete_join/mysql/db/db.go
@@ -32,5 +32,5 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/delete_join/mysql/db/query.sql.go
+++ b/internal/endtoend/testdata/delete_join/mysql/db/query.sql.go
@@ -26,7 +26,10 @@ type DeleteJoinParams struct {
 }
 
 func (q *Queries) DeleteJoin(ctx context.Context, arg DeleteJoinParams) error {
-	_, err := q.db.ExecContext(ctx, deleteJoin, arg.ID, arg.UserID)
+	query := deleteJoin
+	queryParams := []interface{}{arg.ID, arg.UserID}
+
+	_, err := q.db.ExecContext(ctx, query, queryParams...)
 	return err
 }
 
@@ -47,7 +50,10 @@ type DeleteLeftJoinParams struct {
 }
 
 func (q *Queries) DeleteLeftJoin(ctx context.Context, arg DeleteLeftJoinParams) error {
-	_, err := q.db.ExecContext(ctx, deleteLeftJoin, arg.ID, arg.UserID)
+	query := deleteLeftJoin
+	queryParams := []interface{}{arg.ID, arg.UserID}
+
+	_, err := q.db.ExecContext(ctx, query, queryParams...)
 	return err
 }
 
@@ -68,6 +74,9 @@ type DeleteRightJoinParams struct {
 }
 
 func (q *Queries) DeleteRightJoin(ctx context.Context, arg DeleteRightJoinParams) error {
-	_, err := q.db.ExecContext(ctx, deleteRightJoin, arg.ID, arg.UserID)
+	query := deleteRightJoin
+	queryParams := []interface{}{arg.ID, arg.UserID}
+
+	_, err := q.db.ExecContext(ctx, query, queryParams...)
 	return err
 }

--- a/internal/endtoend/testdata/diff_no_output/go/db.go
+++ b/internal/endtoend/testdata/diff_no_output/go/db.go
@@ -29,3 +29,8 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/diff_no_output/go/db.go
+++ b/internal/endtoend/testdata/diff_no_output/go/db.go
@@ -32,5 +32,5 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/diff_no_output/go/query.sql.go
+++ b/internal/endtoend/testdata/diff_no_output/go/query.sql.go
@@ -24,8 +24,16 @@ type CreateAuthorParams struct {
 	Bio  sql.NullString
 }
 
-func (q *Queries) CreateAuthor(ctx context.Context, arg CreateAuthorParams) (Author, error) {
-	row := q.db.QueryRowContext(ctx, createAuthor, arg.Name, arg.Bio)
+func (q *Queries) CreateAuthor(ctx context.Context, arg CreateAuthorParams, aq ...AdditionalQuery) (Author, error) {
+	query := createAuthor
+	queryParams := []interface{}{arg.Name, arg.Bio}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	row := q.db.QueryRowContext(ctx, query, queryParams...)
 	var i Author
 	err := row.Scan(&i.ID, &i.Name, &i.Bio)
 	return i, err
@@ -36,8 +44,16 @@ SELECT id, name, bio FROM authors
 WHERE id = $1 LIMIT 1
 `
 
-func (q *Queries) GetAuthor(ctx context.Context, id int64) (Author, error) {
-	row := q.db.QueryRowContext(ctx, getAuthor, id)
+func (q *Queries) GetAuthor(ctx context.Context, id int64, aq ...AdditionalQuery) (Author, error) {
+	query := getAuthor
+	queryParams := []interface{}{id}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	row := q.db.QueryRowContext(ctx, query, queryParams...)
 	var i Author
 	err := row.Scan(&i.ID, &i.Name, &i.Bio)
 	return i, err
@@ -48,8 +64,16 @@ SELECT id, name, bio FROM authors
 ORDER BY bio
 `
 
-func (q *Queries) ListAuthors(ctx context.Context) ([]Author, error) {
-	rows, err := q.db.QueryContext(ctx, listAuthors)
+func (q *Queries) ListAuthors(ctx context.Context, aq ...AdditionalQuery) ([]Author, error) {
+	query := listAuthors
+	queryParams := []interface{}{}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.QueryContext(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}
@@ -75,8 +99,16 @@ const selectOne = `-- name: SelectOne :one
 SELECT 1
 `
 
-func (q *Queries) SelectOne(ctx context.Context) (int32, error) {
-	row := q.db.QueryRowContext(ctx, selectOne)
+func (q *Queries) SelectOne(ctx context.Context, aq ...AdditionalQuery) (int32, error) {
+	query := selectOne
+	queryParams := []interface{}{}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	row := q.db.QueryRowContext(ctx, query, queryParams...)
 	var column_1 int32
 	err := row.Scan(&column_1)
 	return column_1, err

--- a/internal/endtoend/testdata/diff_output/stderr.txt
+++ b/internal/endtoend/testdata/diff_output/stderr.txt
@@ -1,3 +1,14 @@
+--- a/go/db.go
++++ b/go/db.go
+@@ -29,3 +29,8 @@
+ 		db: tx,
+ 	}
+ }
++
++type AdditionalQuery struct {
++	SQL  string
++	Args []any
++}
 --- a/go/models.go
 +++ b/go/models.go
 @@ -13,3 +13,8 @@
@@ -11,8 +22,26 @@
 +}
 --- a/go/query.sql.go
 +++ b/go/query.sql.go
-@@ -31,16 +31,6 @@
+@@ -24,8 +24,16 @@
+ 	Bio  sql.NullString
+ }
+ 
++func (q *Queries) CreateAuthor(ctx context.Context, arg CreateAuthorParams, aq ...AdditionalQuery) (Author, error) {
++	query := createAuthor
++	queryParams := []interface{}{arg.Name, arg.Bio}
++
++	if len(aq) > 0 {
++		query += " " + aq[0].SQL
++		queryParams = append(queryParams, aq[0].Args...)
++	}
++
++	row := q.db.QueryRowContext(ctx, query, queryParams...)
+-func (q *Queries) CreateAuthor(ctx context.Context, arg CreateAuthorParams) (Author, error) {
+-	row := q.db.QueryRowContext(ctx, createAuthor, arg.Name, arg.Bio)
+ 	var i Author
+ 	err := row.Scan(&i.ID, &i.Name, &i.Bio)
  	return i, err
+@@ -32,15 +40,5 @@
  }
  
 -const deleteAuthor = `-- name: DeleteAuthor :exec
@@ -28,7 +57,25 @@
  const getAuthor = `-- name: GetAuthor :one
  SELECT id, name, bio FROM authors
  WHERE id = $1 LIMIT 1
-@@ -55,7 +45,7 @@
+@@ -47,7 +45,15 @@
+ `
+ 
++func (q *Queries) GetAuthor(ctx context.Context, id int64, aq ...AdditionalQuery) (Author, error) {
++	query := getAuthor
++	queryParams := []interface{}{id}
++
++	if len(aq) > 0 {
++		query += " " + aq[0].SQL
++		queryParams = append(queryParams, aq[0].Args...)
++	}
++
++	row := q.db.QueryRowContext(ctx, query, queryParams...)
+-func (q *Queries) GetAuthor(ctx context.Context, id int64) (Author, error) {
+-	row := q.db.QueryRowContext(ctx, getAuthor, id)
+ 	var i Author
+ 	err := row.Scan(&i.ID, &i.Name, &i.Bio)
+ 	return i, err
+@@ -55,11 +61,19 @@
  
  const listAuthors = `-- name: ListAuthors :many
  SELECT id, name, bio FROM authors
@@ -36,8 +83,22 @@
 -ORDER BY name
  `
  
- func (q *Queries) ListAuthors(ctx context.Context) ([]Author, error) {
-@@ -80,3 +70,14 @@
++func (q *Queries) ListAuthors(ctx context.Context, aq ...AdditionalQuery) ([]Author, error) {
++	query := listAuthors
++	queryParams := []interface{}{}
++
++	if len(aq) > 0 {
++		query += " " + aq[0].SQL
++		queryParams = append(queryParams, aq[0].Args...)
++	}
++
++	rows, err := q.db.QueryContext(ctx, query, queryParams...)
+-func (q *Queries) ListAuthors(ctx context.Context) ([]Author, error) {
+-	rows, err := q.db.QueryContext(ctx, listAuthors)
+ 	if err != nil {
+ 		return nil, err
+ 	}
+@@ -80,3 +94,22 @@
  	}
  	return items, nil
  }
@@ -46,8 +107,16 @@
 +SELECT 1
 +`
 +
-+func (q *Queries) SelectOne(ctx context.Context) (int32, error) {
-+	row := q.db.QueryRowContext(ctx, selectOne)
++func (q *Queries) SelectOne(ctx context.Context, aq ...AdditionalQuery) (int32, error) {
++	query := selectOne
++	queryParams := []interface{}{}
++
++	if len(aq) > 0 {
++		query += " " + aq[0].SQL
++		queryParams = append(queryParams, aq[0].Args...)
++	}
++
++	row := q.db.QueryRowContext(ctx, query, queryParams...)
 +	var column_1 int32
 +	err := row.Scan(&column_1)
 +	return column_1, err

--- a/internal/endtoend/testdata/diff_output/stderr.txt
+++ b/internal/endtoend/testdata/diff_output/stderr.txt
@@ -7,7 +7,7 @@
 +
 +type AdditionalQuery struct {
 +	SQL  string
-+	Args []any
++	Args []interface{}
 +}
 --- a/go/models.go
 +++ b/go/models.go

--- a/internal/endtoend/testdata/emit_db_and_json_tags/mysql/go/db.go
+++ b/internal/endtoend/testdata/emit_db_and_json_tags/mysql/go/db.go
@@ -29,3 +29,8 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/emit_db_and_json_tags/mysql/go/db.go
+++ b/internal/endtoend/testdata/emit_db_and_json_tags/mysql/go/db.go
@@ -32,5 +32,5 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/emit_db_and_json_tags/mysql/go/query.sql.go
+++ b/internal/endtoend/testdata/emit_db_and_json_tags/mysql/go/query.sql.go
@@ -13,8 +13,16 @@ const getAll = `-- name: GetAll :many
 SELECT id, first_name, last_name, age FROM users
 `
 
-func (q *Queries) GetAll(ctx context.Context) ([]User, error) {
-	rows, err := q.db.QueryContext(ctx, getAll)
+func (q *Queries) GetAll(ctx context.Context, aq ...AdditionalQuery) ([]User, error) {
+	query := getAll
+	queryParams := []interface{}{}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.QueryContext(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/endtoend/testdata/emit_db_and_json_tags/postgresql/pgx/v4/go/db.go
+++ b/internal/endtoend/testdata/emit_db_and_json_tags/postgresql/pgx/v4/go/db.go
@@ -33,5 +33,5 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/emit_db_and_json_tags/postgresql/pgx/v4/go/db.go
+++ b/internal/endtoend/testdata/emit_db_and_json_tags/postgresql/pgx/v4/go/db.go
@@ -30,3 +30,8 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/emit_db_and_json_tags/postgresql/pgx/v4/go/query.sql.go
+++ b/internal/endtoend/testdata/emit_db_and_json_tags/postgresql/pgx/v4/go/query.sql.go
@@ -13,8 +13,16 @@ const getAll = `-- name: GetAll :many
 SELECT id, first_name, last_name, age FROM users
 `
 
-func (q *Queries) GetAll(ctx context.Context) ([]User, error) {
-	rows, err := q.db.Query(ctx, getAll)
+func (q *Queries) GetAll(ctx context.Context, aq ...AdditionalQuery) ([]User, error) {
+	query := getAll
+	queryParams := []interface{}{}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.Query(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/endtoend/testdata/emit_db_and_json_tags/postgresql/pgx/v5/go/db.go
+++ b/internal/endtoend/testdata/emit_db_and_json_tags/postgresql/pgx/v5/go/db.go
@@ -33,5 +33,5 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/emit_db_and_json_tags/postgresql/pgx/v5/go/db.go
+++ b/internal/endtoend/testdata/emit_db_and_json_tags/postgresql/pgx/v5/go/db.go
@@ -30,3 +30,8 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/emit_db_and_json_tags/postgresql/pgx/v5/go/query.sql.go
+++ b/internal/endtoend/testdata/emit_db_and_json_tags/postgresql/pgx/v5/go/query.sql.go
@@ -13,8 +13,16 @@ const getAll = `-- name: GetAll :many
 SELECT id, first_name, last_name, age FROM users
 `
 
-func (q *Queries) GetAll(ctx context.Context) ([]User, error) {
-	rows, err := q.db.Query(ctx, getAll)
+func (q *Queries) GetAll(ctx context.Context, aq ...AdditionalQuery) ([]User, error) {
+	query := getAll
+	queryParams := []interface{}{}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.Query(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/endtoend/testdata/emit_db_and_json_tags/postgresql/stdlib/go/db.go
+++ b/internal/endtoend/testdata/emit_db_and_json_tags/postgresql/stdlib/go/db.go
@@ -29,3 +29,8 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/emit_db_and_json_tags/postgresql/stdlib/go/db.go
+++ b/internal/endtoend/testdata/emit_db_and_json_tags/postgresql/stdlib/go/db.go
@@ -32,5 +32,5 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/emit_db_and_json_tags/postgresql/stdlib/go/query.sql.go
+++ b/internal/endtoend/testdata/emit_db_and_json_tags/postgresql/stdlib/go/query.sql.go
@@ -13,8 +13,16 @@ const getAll = `-- name: GetAll :many
 SELECT id, first_name, last_name, age FROM users
 `
 
-func (q *Queries) GetAll(ctx context.Context) ([]User, error) {
-	rows, err := q.db.QueryContext(ctx, getAll)
+func (q *Queries) GetAll(ctx context.Context, aq ...AdditionalQuery) ([]User, error) {
+	query := getAll
+	queryParams := []interface{}{}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.QueryContext(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/endtoend/testdata/emit_db_and_json_tags/sqlite/go/db.go
+++ b/internal/endtoend/testdata/emit_db_and_json_tags/sqlite/go/db.go
@@ -29,3 +29,8 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/emit_db_and_json_tags/sqlite/go/db.go
+++ b/internal/endtoend/testdata/emit_db_and_json_tags/sqlite/go/db.go
@@ -32,5 +32,5 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/emit_db_and_json_tags/sqlite/go/query.sql.go
+++ b/internal/endtoend/testdata/emit_db_and_json_tags/sqlite/go/query.sql.go
@@ -13,8 +13,16 @@ const getAll = `-- name: GetAll :many
 SELECT id, first_name, last_name, age FROM users
 `
 
-func (q *Queries) GetAll(ctx context.Context) ([]User, error) {
-	rows, err := q.db.QueryContext(ctx, getAll)
+func (q *Queries) GetAll(ctx context.Context, aq ...AdditionalQuery) ([]User, error) {
+	query := getAll
+	queryParams := []interface{}{}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.QueryContext(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/endtoend/testdata/emit_db_tags/mysql/go/db.go
+++ b/internal/endtoend/testdata/emit_db_tags/mysql/go/db.go
@@ -29,3 +29,8 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/emit_db_tags/mysql/go/db.go
+++ b/internal/endtoend/testdata/emit_db_tags/mysql/go/db.go
@@ -32,5 +32,5 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/emit_db_tags/mysql/go/query.sql.go
+++ b/internal/endtoend/testdata/emit_db_tags/mysql/go/query.sql.go
@@ -13,8 +13,16 @@ const getAll = `-- name: GetAll :many
 SELECT id, first_name, last_name, age FROM users
 `
 
-func (q *Queries) GetAll(ctx context.Context) ([]User, error) {
-	rows, err := q.db.QueryContext(ctx, getAll)
+func (q *Queries) GetAll(ctx context.Context, aq ...AdditionalQuery) ([]User, error) {
+	query := getAll
+	queryParams := []interface{}{}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.QueryContext(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/endtoend/testdata/emit_db_tags/postgresql/pgx/v4/go/db.go
+++ b/internal/endtoend/testdata/emit_db_tags/postgresql/pgx/v4/go/db.go
@@ -33,5 +33,5 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/emit_db_tags/postgresql/pgx/v4/go/db.go
+++ b/internal/endtoend/testdata/emit_db_tags/postgresql/pgx/v4/go/db.go
@@ -30,3 +30,8 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/emit_db_tags/postgresql/pgx/v4/go/query.sql.go
+++ b/internal/endtoend/testdata/emit_db_tags/postgresql/pgx/v4/go/query.sql.go
@@ -13,8 +13,16 @@ const getAll = `-- name: GetAll :many
 SELECT id, first_name, last_name, age FROM users
 `
 
-func (q *Queries) GetAll(ctx context.Context) ([]User, error) {
-	rows, err := q.db.Query(ctx, getAll)
+func (q *Queries) GetAll(ctx context.Context, aq ...AdditionalQuery) ([]User, error) {
+	query := getAll
+	queryParams := []interface{}{}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.Query(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/endtoend/testdata/emit_db_tags/postgresql/pgx/v5/go/db.go
+++ b/internal/endtoend/testdata/emit_db_tags/postgresql/pgx/v5/go/db.go
@@ -33,5 +33,5 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/emit_db_tags/postgresql/pgx/v5/go/db.go
+++ b/internal/endtoend/testdata/emit_db_tags/postgresql/pgx/v5/go/db.go
@@ -30,3 +30,8 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/emit_db_tags/postgresql/pgx/v5/go/query.sql.go
+++ b/internal/endtoend/testdata/emit_db_tags/postgresql/pgx/v5/go/query.sql.go
@@ -13,8 +13,16 @@ const getAll = `-- name: GetAll :many
 SELECT id, first_name, last_name, age FROM users
 `
 
-func (q *Queries) GetAll(ctx context.Context) ([]User, error) {
-	rows, err := q.db.Query(ctx, getAll)
+func (q *Queries) GetAll(ctx context.Context, aq ...AdditionalQuery) ([]User, error) {
+	query := getAll
+	queryParams := []interface{}{}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.Query(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/endtoend/testdata/emit_db_tags/postgresql/stdlib/go/db.go
+++ b/internal/endtoend/testdata/emit_db_tags/postgresql/stdlib/go/db.go
@@ -29,3 +29,8 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/emit_db_tags/postgresql/stdlib/go/db.go
+++ b/internal/endtoend/testdata/emit_db_tags/postgresql/stdlib/go/db.go
@@ -32,5 +32,5 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/emit_db_tags/postgresql/stdlib/go/query.sql.go
+++ b/internal/endtoend/testdata/emit_db_tags/postgresql/stdlib/go/query.sql.go
@@ -13,8 +13,16 @@ const getAll = `-- name: GetAll :many
 SELECT id, first_name, last_name, age FROM users
 `
 
-func (q *Queries) GetAll(ctx context.Context) ([]User, error) {
-	rows, err := q.db.QueryContext(ctx, getAll)
+func (q *Queries) GetAll(ctx context.Context, aq ...AdditionalQuery) ([]User, error) {
+	query := getAll
+	queryParams := []interface{}{}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.QueryContext(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/endtoend/testdata/emit_db_tags/sqlite/go/db.go
+++ b/internal/endtoend/testdata/emit_db_tags/sqlite/go/db.go
@@ -29,3 +29,8 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/emit_db_tags/sqlite/go/db.go
+++ b/internal/endtoend/testdata/emit_db_tags/sqlite/go/db.go
@@ -32,5 +32,5 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/emit_db_tags/sqlite/go/query.sql.go
+++ b/internal/endtoend/testdata/emit_db_tags/sqlite/go/query.sql.go
@@ -13,8 +13,16 @@ const getAll = `-- name: GetAll :many
 SELECT id, first_name, last_name, age FROM users
 `
 
-func (q *Queries) GetAll(ctx context.Context) ([]User, error) {
-	rows, err := q.db.QueryContext(ctx, getAll)
+func (q *Queries) GetAll(ctx context.Context, aq ...AdditionalQuery) ([]User, error) {
+	query := getAll
+	queryParams := []interface{}{}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.QueryContext(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/endtoend/testdata/emit_empty_slices/pgx/v4/go/db.go
+++ b/internal/endtoend/testdata/emit_empty_slices/pgx/v4/go/db.go
@@ -33,5 +33,5 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/emit_empty_slices/pgx/v4/go/db.go
+++ b/internal/endtoend/testdata/emit_empty_slices/pgx/v4/go/db.go
@@ -30,3 +30,8 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/emit_empty_slices/pgx/v4/go/query.sql.go
+++ b/internal/endtoend/testdata/emit_empty_slices/pgx/v4/go/query.sql.go
@@ -13,8 +13,16 @@ const listBar = `-- name: ListBar :many
 SELECT id FROM bar
 `
 
-func (q *Queries) ListBar(ctx context.Context) ([]int32, error) {
-	rows, err := q.db.Query(ctx, listBar)
+func (q *Queries) ListBar(ctx context.Context, aq ...AdditionalQuery) ([]int32, error) {
+	query := listBar
+	queryParams := []interface{}{}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.Query(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/endtoend/testdata/emit_empty_slices/pgx/v5/go/db.go
+++ b/internal/endtoend/testdata/emit_empty_slices/pgx/v5/go/db.go
@@ -33,5 +33,5 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/emit_empty_slices/pgx/v5/go/db.go
+++ b/internal/endtoend/testdata/emit_empty_slices/pgx/v5/go/db.go
@@ -30,3 +30,8 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/emit_empty_slices/pgx/v5/go/query.sql.go
+++ b/internal/endtoend/testdata/emit_empty_slices/pgx/v5/go/query.sql.go
@@ -13,8 +13,16 @@ const listBar = `-- name: ListBar :many
 SELECT id FROM bar
 `
 
-func (q *Queries) ListBar(ctx context.Context) ([]int32, error) {
-	rows, err := q.db.Query(ctx, listBar)
+func (q *Queries) ListBar(ctx context.Context, aq ...AdditionalQuery) ([]int32, error) {
+	query := listBar
+	queryParams := []interface{}{}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.Query(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/endtoend/testdata/emit_empty_slices/stdlib/go/db.go
+++ b/internal/endtoend/testdata/emit_empty_slices/stdlib/go/db.go
@@ -29,3 +29,8 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/emit_empty_slices/stdlib/go/db.go
+++ b/internal/endtoend/testdata/emit_empty_slices/stdlib/go/db.go
@@ -32,5 +32,5 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/emit_empty_slices/stdlib/go/query.sql.go
+++ b/internal/endtoend/testdata/emit_empty_slices/stdlib/go/query.sql.go
@@ -13,8 +13,16 @@ const listBar = `-- name: ListBar :many
 SELECT id FROM bar
 `
 
-func (q *Queries) ListBar(ctx context.Context) ([]int32, error) {
-	rows, err := q.db.QueryContext(ctx, listBar)
+func (q *Queries) ListBar(ctx context.Context, aq ...AdditionalQuery) ([]int32, error) {
+	query := listBar
+	queryParams := []interface{}{}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.QueryContext(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/endtoend/testdata/emit_enum_valid_and_values/go/db.go
+++ b/internal/endtoend/testdata/emit_enum_valid_and_values/go/db.go
@@ -33,5 +33,5 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/emit_enum_valid_and_values/go/db.go
+++ b/internal/endtoend/testdata/emit_enum_valid_and_values/go/db.go
@@ -30,3 +30,8 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/emit_enum_valid_and_values/go/query.sql.go
+++ b/internal/endtoend/testdata/emit_enum_valid_and_values/go/query.sql.go
@@ -13,8 +13,16 @@ const listBar = `-- name: ListBar :many
 SELECT id_old, ip_old FROM bar_old
 `
 
-func (q *Queries) ListBar(ctx context.Context) ([]BarNew, error) {
-	rows, err := q.db.Query(ctx, listBar)
+func (q *Queries) ListBar(ctx context.Context, aq ...AdditionalQuery) ([]BarNew, error) {
+	query := listBar
+	queryParams := []interface{}{}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.Query(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}
@@ -49,8 +57,16 @@ type ListFooRow struct {
 	BazOld int32
 }
 
-func (q *Queries) ListFoo(ctx context.Context, arg ListFooParams) ([]ListFooRow, error) {
-	rows, err := q.db.Query(ctx, listFoo, arg.IpOld, arg.IDNew)
+func (q *Queries) ListFoo(ctx context.Context, arg ListFooParams, aq ...AdditionalQuery) ([]ListFooRow, error) {
+	query := listFoo
+	queryParams := []interface{}{arg.IpOld, arg.IDNew}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.Query(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/endtoend/testdata/emit_exported_queries/pgx/v4/go/db.go
+++ b/internal/endtoend/testdata/emit_exported_queries/pgx/v4/go/db.go
@@ -33,5 +33,5 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/emit_exported_queries/pgx/v4/go/db.go
+++ b/internal/endtoend/testdata/emit_exported_queries/pgx/v4/go/db.go
@@ -30,3 +30,8 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/emit_exported_queries/pgx/v5/go/db.go
+++ b/internal/endtoend/testdata/emit_exported_queries/pgx/v5/go/db.go
@@ -33,5 +33,5 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/emit_exported_queries/pgx/v5/go/db.go
+++ b/internal/endtoend/testdata/emit_exported_queries/pgx/v5/go/db.go
@@ -30,3 +30,8 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/emit_exported_queries/stdlib/go/db.go
+++ b/internal/endtoend/testdata/emit_exported_queries/stdlib/go/db.go
@@ -29,3 +29,8 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/emit_exported_queries/stdlib/go/db.go
+++ b/internal/endtoend/testdata/emit_exported_queries/stdlib/go/db.go
@@ -32,5 +32,5 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/emit_exported_queries/stdlib/go/query.sql.go
+++ b/internal/endtoend/testdata/emit_exported_queries/stdlib/go/query.sql.go
@@ -19,6 +19,9 @@ type UpdateBarIDParams struct {
 }
 
 func (q *Queries) UpdateBarID(ctx context.Context, arg UpdateBarIDParams) error {
-	_, err := q.db.ExecContext(ctx, UpdateBarID, arg.ID, arg.ID_2)
+	query := UpdateBarID
+	queryParams := []interface{}{arg.ID, arg.ID_2}
+
+	_, err := q.db.ExecContext(ctx, query, queryParams...)
 	return err
 }

--- a/internal/endtoend/testdata/emit_methods_with_db_argument/mysql/go/db.go
+++ b/internal/endtoend/testdata/emit_methods_with_db_argument/mysql/go/db.go
@@ -25,5 +25,5 @@ type Queries struct {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/emit_methods_with_db_argument/mysql/go/db.go
+++ b/internal/endtoend/testdata/emit_methods_with_db_argument/mysql/go/db.go
@@ -22,3 +22,8 @@ func New() *Queries {
 
 type Queries struct {
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/emit_methods_with_db_argument/mysql/go/query.sql.go
+++ b/internal/endtoend/testdata/emit_methods_with_db_argument/mysql/go/query.sql.go
@@ -13,8 +13,16 @@ const getAll = `-- name: GetAll :many
 SELECT id, first_name, last_name, age FROM users
 `
 
-func (q *Queries) GetAll(ctx context.Context, db DBTX) ([]User, error) {
-	rows, err := db.QueryContext(ctx, getAll)
+func (q *Queries) GetAll(ctx context.Context, db DBTX, aq ...AdditionalQuery) ([]User, error) {
+	query := getAll
+	queryParams := []interface{}{}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := db.QueryContext(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/endtoend/testdata/emit_methods_with_db_argument/postgresql/pgx/v4/go/db.go
+++ b/internal/endtoend/testdata/emit_methods_with_db_argument/postgresql/pgx/v4/go/db.go
@@ -23,3 +23,8 @@ func New() *Queries {
 
 type Queries struct {
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/emit_methods_with_db_argument/postgresql/pgx/v4/go/db.go
+++ b/internal/endtoend/testdata/emit_methods_with_db_argument/postgresql/pgx/v4/go/db.go
@@ -26,5 +26,5 @@ type Queries struct {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/emit_methods_with_db_argument/postgresql/pgx/v4/go/query.sql.go
+++ b/internal/endtoend/testdata/emit_methods_with_db_argument/postgresql/pgx/v4/go/query.sql.go
@@ -13,8 +13,16 @@ const getAll = `-- name: GetAll :many
 SELECT id, first_name, last_name, age FROM users
 `
 
-func (q *Queries) GetAll(ctx context.Context, db DBTX) ([]User, error) {
-	rows, err := db.Query(ctx, getAll)
+func (q *Queries) GetAll(ctx context.Context, db DBTX, aq ...AdditionalQuery) ([]User, error) {
+	query := getAll
+	queryParams := []interface{}{}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := db.Query(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/endtoend/testdata/emit_methods_with_db_argument/postgresql/pgx/v5/go/db.go
+++ b/internal/endtoend/testdata/emit_methods_with_db_argument/postgresql/pgx/v5/go/db.go
@@ -23,3 +23,8 @@ func New() *Queries {
 
 type Queries struct {
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/emit_methods_with_db_argument/postgresql/pgx/v5/go/db.go
+++ b/internal/endtoend/testdata/emit_methods_with_db_argument/postgresql/pgx/v5/go/db.go
@@ -26,5 +26,5 @@ type Queries struct {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/emit_methods_with_db_argument/postgresql/pgx/v5/go/query.sql.go
+++ b/internal/endtoend/testdata/emit_methods_with_db_argument/postgresql/pgx/v5/go/query.sql.go
@@ -13,8 +13,16 @@ const getAll = `-- name: GetAll :many
 SELECT id, first_name, last_name, age FROM users
 `
 
-func (q *Queries) GetAll(ctx context.Context, db DBTX) ([]User, error) {
-	rows, err := db.Query(ctx, getAll)
+func (q *Queries) GetAll(ctx context.Context, db DBTX, aq ...AdditionalQuery) ([]User, error) {
+	query := getAll
+	queryParams := []interface{}{}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := db.Query(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/endtoend/testdata/emit_methods_with_db_argument/postgresql/stdlib/go/db.go
+++ b/internal/endtoend/testdata/emit_methods_with_db_argument/postgresql/stdlib/go/db.go
@@ -25,5 +25,5 @@ type Queries struct {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/emit_methods_with_db_argument/postgresql/stdlib/go/db.go
+++ b/internal/endtoend/testdata/emit_methods_with_db_argument/postgresql/stdlib/go/db.go
@@ -22,3 +22,8 @@ func New() *Queries {
 
 type Queries struct {
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/emit_methods_with_db_argument/postgresql/stdlib/go/query.sql.go
+++ b/internal/endtoend/testdata/emit_methods_with_db_argument/postgresql/stdlib/go/query.sql.go
@@ -13,8 +13,16 @@ const getAll = `-- name: GetAll :many
 SELECT id, first_name, last_name, age FROM users
 `
 
-func (q *Queries) GetAll(ctx context.Context, db DBTX) ([]User, error) {
-	rows, err := db.QueryContext(ctx, getAll)
+func (q *Queries) GetAll(ctx context.Context, db DBTX, aq ...AdditionalQuery) ([]User, error) {
+	query := getAll
+	queryParams := []interface{}{}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := db.QueryContext(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/endtoend/testdata/emit_methods_with_db_argument/sqlite/go/db.go
+++ b/internal/endtoend/testdata/emit_methods_with_db_argument/sqlite/go/db.go
@@ -25,5 +25,5 @@ type Queries struct {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/emit_methods_with_db_argument/sqlite/go/db.go
+++ b/internal/endtoend/testdata/emit_methods_with_db_argument/sqlite/go/db.go
@@ -22,3 +22,8 @@ func New() *Queries {
 
 type Queries struct {
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/emit_methods_with_db_argument/sqlite/go/query.sql.go
+++ b/internal/endtoend/testdata/emit_methods_with_db_argument/sqlite/go/query.sql.go
@@ -13,8 +13,16 @@ const getAll = `-- name: GetAll :many
 SELECT id, first_name, last_name, age FROM users
 `
 
-func (q *Queries) GetAll(ctx context.Context, db DBTX) ([]User, error) {
-	rows, err := db.QueryContext(ctx, getAll)
+func (q *Queries) GetAll(ctx context.Context, db DBTX, aq ...AdditionalQuery) ([]User, error) {
+	query := getAll
+	queryParams := []interface{}{}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := db.QueryContext(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/endtoend/testdata/emit_pointers_for_null_types/pgx/v4/go/db.go
+++ b/internal/endtoend/testdata/emit_pointers_for_null_types/pgx/v4/go/db.go
@@ -33,5 +33,5 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/emit_pointers_for_null_types/pgx/v4/go/db.go
+++ b/internal/endtoend/testdata/emit_pointers_for_null_types/pgx/v4/go/db.go
@@ -30,3 +30,8 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/emit_pointers_for_null_types/pgx/v5/go/db.go
+++ b/internal/endtoend/testdata/emit_pointers_for_null_types/pgx/v5/go/db.go
@@ -33,5 +33,5 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/emit_pointers_for_null_types/pgx/v5/go/db.go
+++ b/internal/endtoend/testdata/emit_pointers_for_null_types/pgx/v5/go/db.go
@@ -30,3 +30,8 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/emit_pointers_for_null_types/stdlib/go/db.go
+++ b/internal/endtoend/testdata/emit_pointers_for_null_types/stdlib/go/db.go
@@ -29,3 +29,8 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/emit_pointers_for_null_types/stdlib/go/db.go
+++ b/internal/endtoend/testdata/emit_pointers_for_null_types/stdlib/go/db.go
@@ -32,5 +32,5 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/emit_result_and_params_struct_pointers/mysql/go/db.go
+++ b/internal/endtoend/testdata/emit_result_and_params_struct_pointers/mysql/go/db.go
@@ -29,3 +29,8 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/emit_result_and_params_struct_pointers/mysql/go/db.go
+++ b/internal/endtoend/testdata/emit_result_and_params_struct_pointers/mysql/go/db.go
@@ -32,5 +32,5 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/emit_result_and_params_struct_pointers/mysql/go/querier.go
+++ b/internal/endtoend/testdata/emit_result_and_params_struct_pointers/mysql/go/querier.go
@@ -10,9 +10,9 @@ import (
 )
 
 type Querier interface {
-	GetAll(ctx context.Context) ([]*Foo, error)
-	GetAllAByB(ctx context.Context, b sql.NullInt32) ([]sql.NullInt32, error)
-	GetOne(ctx context.Context, arg *GetOneParams) (*Foo, error)
+	GetAll(ctx context.Context, aq ...AdditionalQuery) ([]*Foo, error)
+	GetAllAByB(ctx context.Context, b sql.NullInt32, aq ...AdditionalQuery) ([]sql.NullInt32, error)
+	GetOne(ctx context.Context, arg *GetOneParams, aq ...AdditionalQuery) (*Foo, error)
 }
 
 var _ Querier = (*Queries)(nil)

--- a/internal/endtoend/testdata/emit_result_and_params_struct_pointers/mysql/go/query.sql.go
+++ b/internal/endtoend/testdata/emit_result_and_params_struct_pointers/mysql/go/query.sql.go
@@ -14,8 +14,16 @@ const getAll = `-- name: GetAll :many
 SELECT a, b FROM foo
 `
 
-func (q *Queries) GetAll(ctx context.Context) ([]*Foo, error) {
-	rows, err := q.db.QueryContext(ctx, getAll)
+func (q *Queries) GetAll(ctx context.Context, aq ...AdditionalQuery) ([]*Foo, error) {
+	query := getAll
+	queryParams := []interface{}{}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.QueryContext(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}
@@ -41,8 +49,16 @@ const getAllAByB = `-- name: GetAllAByB :many
 SELECT a FROM foo WHERE b = ?
 `
 
-func (q *Queries) GetAllAByB(ctx context.Context, b sql.NullInt32) ([]sql.NullInt32, error) {
-	rows, err := q.db.QueryContext(ctx, getAllAByB, b)
+func (q *Queries) GetAllAByB(ctx context.Context, b sql.NullInt32, aq ...AdditionalQuery) ([]sql.NullInt32, error) {
+	query := getAllAByB
+	queryParams := []interface{}{b}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.QueryContext(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}
@@ -73,8 +89,16 @@ type GetOneParams struct {
 	B sql.NullInt32
 }
 
-func (q *Queries) GetOne(ctx context.Context, arg *GetOneParams) (*Foo, error) {
-	row := q.db.QueryRowContext(ctx, getOne, arg.A, arg.B)
+func (q *Queries) GetOne(ctx context.Context, arg *GetOneParams, aq ...AdditionalQuery) (*Foo, error) {
+	query := getOne
+	queryParams := []interface{}{arg.A, arg.B}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	row := q.db.QueryRowContext(ctx, query, queryParams...)
 	var i Foo
 	err := row.Scan(&i.A, &i.B)
 	return &i, err

--- a/internal/endtoend/testdata/emit_result_and_params_struct_pointers/postgresql/pgx/v4/go/db.go
+++ b/internal/endtoend/testdata/emit_result_and_params_struct_pointers/postgresql/pgx/v4/go/db.go
@@ -31,3 +31,8 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/emit_result_and_params_struct_pointers/postgresql/pgx/v4/go/db.go
+++ b/internal/endtoend/testdata/emit_result_and_params_struct_pointers/postgresql/pgx/v4/go/db.go
@@ -34,5 +34,5 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/emit_result_and_params_struct_pointers/postgresql/pgx/v4/go/query.sql.go
+++ b/internal/endtoend/testdata/emit_result_and_params_struct_pointers/postgresql/pgx/v4/go/query.sql.go
@@ -14,8 +14,16 @@ const getAll = `-- name: GetAll :many
 SELECT a, b FROM foo
 `
 
-func (q *Queries) GetAll(ctx context.Context) ([]*Foo, error) {
-	rows, err := q.db.Query(ctx, getAll)
+func (q *Queries) GetAll(ctx context.Context, aq ...AdditionalQuery) ([]*Foo, error) {
+	query := getAll
+	queryParams := []interface{}{}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.Query(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}
@@ -38,8 +46,16 @@ const getAllAByB = `-- name: GetAllAByB :many
 SELECT a FROM foo WHERE b = $1
 `
 
-func (q *Queries) GetAllAByB(ctx context.Context, b sql.NullInt32) ([]sql.NullInt32, error) {
-	rows, err := q.db.Query(ctx, getAllAByB, b)
+func (q *Queries) GetAllAByB(ctx context.Context, b sql.NullInt32, aq ...AdditionalQuery) ([]sql.NullInt32, error) {
+	query := getAllAByB
+	queryParams := []interface{}{b}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.Query(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}
@@ -67,8 +83,10 @@ type GetOneParams struct {
 	B sql.NullInt32
 }
 
-func (q *Queries) GetOne(ctx context.Context, arg *GetOneParams) (*Foo, error) {
-	row := q.db.QueryRow(ctx, getOne, arg.A, arg.B)
+func (q *Queries) GetOne(ctx context.Context, arg *GetOneParams, aq ...AdditionalQuery) (*Foo, error) {
+	query := getOne
+	queryParams := []interface{}{arg.A, arg.B}
+	row := q.db.QueryRow(ctx, query, queryParams...)
 	var i Foo
 	err := row.Scan(&i.A, &i.B)
 	return &i, err

--- a/internal/endtoend/testdata/emit_result_and_params_struct_pointers/postgresql/pgx/v5/go/db.go
+++ b/internal/endtoend/testdata/emit_result_and_params_struct_pointers/postgresql/pgx/v5/go/db.go
@@ -31,3 +31,8 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/emit_result_and_params_struct_pointers/postgresql/pgx/v5/go/db.go
+++ b/internal/endtoend/testdata/emit_result_and_params_struct_pointers/postgresql/pgx/v5/go/db.go
@@ -34,5 +34,5 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/enum/mysql/go/db.go
+++ b/internal/endtoend/testdata/enum/mysql/go/db.go
@@ -25,5 +25,5 @@ type Queries struct {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/enum/mysql/go/db.go
+++ b/internal/endtoend/testdata/enum/mysql/go/db.go
@@ -22,3 +22,8 @@ func New() *Queries {
 
 type Queries struct {
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/enum/mysql/go/query.sql.go
+++ b/internal/endtoend/testdata/enum/mysql/go/query.sql.go
@@ -21,7 +21,10 @@ type DeleteBySizeParams struct {
 }
 
 func (q *Queries) DeleteBySize(ctx context.Context, db DBTX, arg DeleteBySizeParams) error {
-	_, err := db.ExecContext(ctx, deleteBySize, arg.ShoeSize, arg.ShirtSize)
+	query := deleteBySize
+	queryParams := []interface{}{arg.ShoeSize, arg.ShirtSize}
+
+	_, err := db.ExecContext(ctx, query, queryParams...)
 	return err
 }
 
@@ -29,8 +32,16 @@ const getAll = `-- name: GetAll :many
 SELECT id, first_name, last_name, age, shoe_size, shirt_size FROM users
 `
 
-func (q *Queries) GetAll(ctx context.Context, db DBTX) ([]User, error) {
-	rows, err := db.QueryContext(ctx, getAll)
+func (q *Queries) GetAll(ctx context.Context, db DBTX, aq ...AdditionalQuery) ([]User, error) {
+	query := getAll
+	queryParams := []interface{}{}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := db.QueryContext(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}
@@ -81,14 +92,17 @@ type NewUserParams struct {
 }
 
 func (q *Queries) NewUser(ctx context.Context, db DBTX, arg NewUserParams) error {
-	_, err := db.ExecContext(ctx, newUser,
+	query := newUser
+	queryParams := []interface{}{
 		arg.ID,
 		arg.FirstName,
 		arg.LastName,
 		arg.Age,
 		arg.ShoeSize,
 		arg.ShirtSize,
-	)
+	}
+
+	_, err := db.ExecContext(ctx, query, queryParams...)
 	return err
 }
 
@@ -105,6 +119,9 @@ type UpdateSizesParams struct {
 }
 
 func (q *Queries) UpdateSizes(ctx context.Context, db DBTX, arg UpdateSizesParams) error {
-	_, err := db.ExecContext(ctx, updateSizes, arg.ShoeSize, arg.ShirtSize, arg.ID)
+	query := updateSizes
+	queryParams := []interface{}{arg.ShoeSize, arg.ShirtSize, arg.ID}
+
+	_, err := db.ExecContext(ctx, query, queryParams...)
 	return err
 }

--- a/internal/endtoend/testdata/enum/postgresql/pgx/v4/go/db.go
+++ b/internal/endtoend/testdata/enum/postgresql/pgx/v4/go/db.go
@@ -23,3 +23,8 @@ func New() *Queries {
 
 type Queries struct {
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/enum/postgresql/pgx/v4/go/db.go
+++ b/internal/endtoend/testdata/enum/postgresql/pgx/v4/go/db.go
@@ -26,5 +26,5 @@ type Queries struct {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/enum/postgresql/pgx/v4/go/query.sql.go
+++ b/internal/endtoend/testdata/enum/postgresql/pgx/v4/go/query.sql.go
@@ -29,8 +29,16 @@ const getAll = `-- name: GetAll :many
 SELECT id, first_name, last_name, age, shoe_size, shirt_size FROM users
 `
 
-func (q *Queries) GetAll(ctx context.Context, db DBTX) ([]User, error) {
-	rows, err := db.Query(ctx, getAll)
+func (q *Queries) GetAll(ctx context.Context, db DBTX, aq ...AdditionalQuery) ([]User, error) {
+	query := getAll
+	queryParams := []interface{}{}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := db.Query(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/endtoend/testdata/enum/postgresql/pgx/v5/go/db.go
+++ b/internal/endtoend/testdata/enum/postgresql/pgx/v5/go/db.go
@@ -23,3 +23,8 @@ func New() *Queries {
 
 type Queries struct {
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/enum/postgresql/pgx/v5/go/db.go
+++ b/internal/endtoend/testdata/enum/postgresql/pgx/v5/go/db.go
@@ -26,5 +26,5 @@ type Queries struct {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/enum/postgresql/pgx/v5/go/query.sql.go
+++ b/internal/endtoend/testdata/enum/postgresql/pgx/v5/go/query.sql.go
@@ -30,8 +30,16 @@ const getAll = `-- name: GetAll :many
 SELECT id, first_name, last_name, age, shoe_size, shirt_size FROM users
 `
 
-func (q *Queries) GetAll(ctx context.Context, db DBTX) ([]User, error) {
-	rows, err := db.Query(ctx, getAll)
+func (q *Queries) GetAll(ctx context.Context, db DBTX, aq ...AdditionalQuery) ([]User, error) {
+	query := getAll
+	queryParams := []interface{}{}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := db.Query(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/endtoend/testdata/enum/postgresql/stdlib/go/db.go
+++ b/internal/endtoend/testdata/enum/postgresql/stdlib/go/db.go
@@ -25,5 +25,5 @@ type Queries struct {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/enum/postgresql/stdlib/go/db.go
+++ b/internal/endtoend/testdata/enum/postgresql/stdlib/go/db.go
@@ -22,3 +22,8 @@ func New() *Queries {
 
 type Queries struct {
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/enum/postgresql/stdlib/go/query.sql.go
+++ b/internal/endtoend/testdata/enum/postgresql/stdlib/go/query.sql.go
@@ -21,7 +21,10 @@ type DeleteBySizeParams struct {
 }
 
 func (q *Queries) DeleteBySize(ctx context.Context, db DBTX, arg DeleteBySizeParams) error {
-	_, err := db.ExecContext(ctx, deleteBySize, arg.ShoeSize, arg.ShirtSize)
+	query := deleteBySize
+	queryParams := []interface{}{arg.ShoeSize, arg.ShirtSize}
+
+	_, err := db.ExecContext(ctx, query, queryParams...)
 	return err
 }
 
@@ -29,8 +32,16 @@ const getAll = `-- name: GetAll :many
 SELECT id, first_name, last_name, age, shoe_size, shirt_size FROM users
 `
 
-func (q *Queries) GetAll(ctx context.Context, db DBTX) ([]User, error) {
-	rows, err := db.QueryContext(ctx, getAll)
+func (q *Queries) GetAll(ctx context.Context, db DBTX, aq ...AdditionalQuery) ([]User, error) {
+	query := getAll
+	queryParams := []interface{}{}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := db.QueryContext(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}
@@ -81,14 +92,17 @@ type NewUserParams struct {
 }
 
 func (q *Queries) NewUser(ctx context.Context, db DBTX, arg NewUserParams) error {
-	_, err := db.ExecContext(ctx, newUser,
+	query := newUser
+	queryParams := []interface{}{
 		arg.ID,
 		arg.FirstName,
 		arg.LastName,
 		arg.Age,
 		arg.ShoeSize,
 		arg.ShirtSize,
-	)
+	}
+
+	_, err := db.ExecContext(ctx, query, queryParams...)
 	return err
 }
 
@@ -105,6 +119,9 @@ type UpdateSizesParams struct {
 }
 
 func (q *Queries) UpdateSizes(ctx context.Context, db DBTX, arg UpdateSizesParams) error {
-	_, err := db.ExecContext(ctx, updateSizes, arg.ID, arg.ShoeSize, arg.ShirtSize)
+	query := updateSizes
+	queryParams := []interface{}{arg.ID, arg.ShoeSize, arg.ShirtSize}
+
+	_, err := db.ExecContext(ctx, query, queryParams...)
 	return err
 }

--- a/internal/endtoend/testdata/enum_ordering/postgresql/stdlib/go/db.go
+++ b/internal/endtoend/testdata/enum_ordering/postgresql/stdlib/go/db.go
@@ -29,3 +29,8 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/enum_ordering/postgresql/stdlib/go/db.go
+++ b/internal/endtoend/testdata/enum_ordering/postgresql/stdlib/go/db.go
@@ -32,5 +32,5 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/enum_ordering/postgresql/stdlib/go/querier.go
+++ b/internal/endtoend/testdata/enum_ordering/postgresql/stdlib/go/querier.go
@@ -9,7 +9,7 @@ import (
 )
 
 type Querier interface {
-	GetAll(ctx context.Context) ([]int32, error)
+	GetAll(ctx context.Context, aq ...AdditionalQuery) ([]int32, error)
 }
 
 var _ Querier = (*Queries)(nil)

--- a/internal/endtoend/testdata/enum_ordering/postgresql/stdlib/go/query.sql.go
+++ b/internal/endtoend/testdata/enum_ordering/postgresql/stdlib/go/query.sql.go
@@ -13,8 +13,16 @@ const getAll = `-- name: GetAll :many
 SELECT id FROM foo
 `
 
-func (q *Queries) GetAll(ctx context.Context) ([]int32, error) {
-	rows, err := q.db.QueryContext(ctx, getAll)
+func (q *Queries) GetAll(ctx context.Context, aq ...AdditionalQuery) ([]int32, error) {
+	query := getAll
+	queryParams := []interface{}{}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.QueryContext(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/endtoend/testdata/exec_imports/pgx/v4/go/db.go
+++ b/internal/endtoend/testdata/exec_imports/pgx/v4/go/db.go
@@ -33,5 +33,5 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/exec_imports/pgx/v4/go/db.go
+++ b/internal/endtoend/testdata/exec_imports/pgx/v4/go/db.go
@@ -30,3 +30,8 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/exec_imports/pgx/v5/go/db.go
+++ b/internal/endtoend/testdata/exec_imports/pgx/v5/go/db.go
@@ -33,5 +33,5 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/exec_imports/pgx/v5/go/db.go
+++ b/internal/endtoend/testdata/exec_imports/pgx/v5/go/db.go
@@ -30,3 +30,8 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/exec_imports/stdlib/go/db.go
+++ b/internal/endtoend/testdata/exec_imports/stdlib/go/db.go
@@ -29,3 +29,8 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/exec_imports/stdlib/go/db.go
+++ b/internal/endtoend/testdata/exec_imports/stdlib/go/db.go
@@ -32,5 +32,5 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/exec_imports/stdlib/go/query.sql.go
+++ b/internal/endtoend/testdata/exec_imports/stdlib/go/query.sql.go
@@ -15,7 +15,10 @@ FROM foo
 `
 
 func (q *Queries) Bar(ctx context.Context) error {
-	_, err := q.db.ExecContext(ctx, bar)
+	query := bar
+	queryParams := []interface{}{}
+
+	_, err := q.db.ExecContext(ctx, query, queryParams...)
 	return err
 }
 
@@ -25,6 +28,9 @@ FROM foo
 `
 
 func (q *Queries) Bars(ctx context.Context) error {
-	_, err := q.db.ExecContext(ctx, bars)
+	query := bars
+	queryParams := []interface{}{}
+
+	_, err := q.db.ExecContext(ctx, query, queryParams...)
 	return err
 }

--- a/internal/endtoend/testdata/exec_lastid/go_postgresql_stdlib/go/db.go
+++ b/internal/endtoend/testdata/exec_lastid/go_postgresql_stdlib/go/db.go
@@ -29,3 +29,8 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/exec_lastid/go_postgresql_stdlib/go/db.go
+++ b/internal/endtoend/testdata/exec_lastid/go_postgresql_stdlib/go/db.go
@@ -32,5 +32,5 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/exec_lastid/go_postgresql_stdlib/go/query.sql.go
+++ b/internal/endtoend/testdata/exec_lastid/go_postgresql_stdlib/go/query.sql.go
@@ -14,7 +14,10 @@ INSERT INTO bar () VALUES ()
 `
 
 func (q *Queries) InsertBar(ctx context.Context) (int64, error) {
-	result, err := q.db.ExecContext(ctx, insertBar)
+	query := insertBar
+	queryParams := []interface{}{}
+
+	result, err := q.db.ExecContext(ctx, query, queryParams...)
 	if err != nil {
 		return 0, err
 	}

--- a/internal/endtoend/testdata/exec_result/go_postgresql_pgx/v4/go/db.go
+++ b/internal/endtoend/testdata/exec_result/go_postgresql_pgx/v4/go/db.go
@@ -33,5 +33,5 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/exec_result/go_postgresql_pgx/v4/go/db.go
+++ b/internal/endtoend/testdata/exec_result/go_postgresql_pgx/v4/go/db.go
@@ -30,3 +30,8 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/exec_result/go_postgresql_pgx/v5/go/db.go
+++ b/internal/endtoend/testdata/exec_result/go_postgresql_pgx/v5/go/db.go
@@ -33,5 +33,5 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/exec_result/go_postgresql_pgx/v5/go/db.go
+++ b/internal/endtoend/testdata/exec_result/go_postgresql_pgx/v5/go/db.go
@@ -30,3 +30,8 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/exec_result/go_postgresql_stdlib/go/db.go
+++ b/internal/endtoend/testdata/exec_result/go_postgresql_stdlib/go/db.go
@@ -29,3 +29,8 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/exec_result/go_postgresql_stdlib/go/db.go
+++ b/internal/endtoend/testdata/exec_result/go_postgresql_stdlib/go/db.go
@@ -32,5 +32,5 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/exec_result/go_postgresql_stdlib/go/query.sql.go
+++ b/internal/endtoend/testdata/exec_result/go_postgresql_stdlib/go/query.sql.go
@@ -15,5 +15,8 @@ DELETE FROM bar WHERE id = $1
 `
 
 func (q *Queries) DeleteBarByID(ctx context.Context, id int32) (sql.Result, error) {
-	return q.db.ExecContext(ctx, deleteBarByID, id)
+	query := deleteBarByID
+	queryParams := []interface{}{id}
+
+	return q.db.ExecContext(ctx, query, queryParams...)
 }

--- a/internal/endtoend/testdata/exec_rows/go_postgresql_pgx/v4/go/db.go
+++ b/internal/endtoend/testdata/exec_rows/go_postgresql_pgx/v4/go/db.go
@@ -33,5 +33,5 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/exec_rows/go_postgresql_pgx/v4/go/db.go
+++ b/internal/endtoend/testdata/exec_rows/go_postgresql_pgx/v4/go/db.go
@@ -30,3 +30,8 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/exec_rows/go_postgresql_pgx/v5/go/db.go
+++ b/internal/endtoend/testdata/exec_rows/go_postgresql_pgx/v5/go/db.go
@@ -33,5 +33,5 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/exec_rows/go_postgresql_pgx/v5/go/db.go
+++ b/internal/endtoend/testdata/exec_rows/go_postgresql_pgx/v5/go/db.go
@@ -30,3 +30,8 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/exec_rows/go_postgresql_stdlib/go/db.go
+++ b/internal/endtoend/testdata/exec_rows/go_postgresql_stdlib/go/db.go
@@ -29,3 +29,8 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/exec_rows/go_postgresql_stdlib/go/db.go
+++ b/internal/endtoend/testdata/exec_rows/go_postgresql_stdlib/go/db.go
@@ -32,5 +32,5 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/exec_rows/go_postgresql_stdlib/go/query.sql.go
+++ b/internal/endtoend/testdata/exec_rows/go_postgresql_stdlib/go/query.sql.go
@@ -14,7 +14,10 @@ DELETE FROM bar WHERE id = $1
 `
 
 func (q *Queries) DeleteBarByID(ctx context.Context, id int32) (int64, error) {
-	result, err := q.db.ExecContext(ctx, deleteBarByID, id)
+	query := deleteBarByID
+	queryParams := []interface{}{id}
+
+	result, err := q.db.ExecContext(ctx, query, queryParams...)
 	if err != nil {
 		return 0, err
 	}

--- a/internal/endtoend/testdata/full_outer_join/sqlite/go/db.go
+++ b/internal/endtoend/testdata/full_outer_join/sqlite/go/db.go
@@ -29,3 +29,8 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/full_outer_join/sqlite/go/db.go
+++ b/internal/endtoend/testdata/full_outer_join/sqlite/go/db.go
@@ -32,5 +32,5 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/full_outer_join/sqlite/go/query.sql.go
+++ b/internal/endtoend/testdata/full_outer_join/sqlite/go/query.sql.go
@@ -23,8 +23,16 @@ type GetAuthorRow struct {
 	Title string
 }
 
-func (q *Queries) GetAuthor(ctx context.Context, id int64) (GetAuthorRow, error) {
-	row := q.db.QueryRowContext(ctx, getAuthor, id)
+func (q *Queries) GetAuthor(ctx context.Context, id int64, aq ...AdditionalQuery) (GetAuthorRow, error) {
+	query := getAuthor
+	queryParams := []interface{}{id}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	row := q.db.QueryRowContext(ctx, query, queryParams...)
 	var i GetAuthorRow
 	err := row.Scan(
 		&i.ID,

--- a/internal/endtoend/testdata/func_aggregate/go/db.go
+++ b/internal/endtoend/testdata/func_aggregate/go/db.go
@@ -29,3 +29,8 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/func_aggregate/go/db.go
+++ b/internal/endtoend/testdata/func_aggregate/go/db.go
@@ -32,5 +32,5 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/func_aggregate/go/query.sql.go
+++ b/internal/endtoend/testdata/func_aggregate/go/query.sql.go
@@ -14,8 +14,16 @@ select percentile_disc(0.5) within group (order by authors.name)
 from authors
 `
 
-func (q *Queries) Percentile(ctx context.Context) (interface{}, error) {
-	row := q.db.QueryRowContext(ctx, percentile)
+func (q *Queries) Percentile(ctx context.Context, aq ...AdditionalQuery) (interface{}, error) {
+	query := percentile
+	queryParams := []interface{}{}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	row := q.db.QueryRowContext(ctx, query, queryParams...)
 	var percentile_disc interface{}
 	err := row.Scan(&percentile_disc)
 	return percentile_disc, err

--- a/internal/endtoend/testdata/func_args/pgx/v4/go/db.go
+++ b/internal/endtoend/testdata/func_args/pgx/v4/go/db.go
@@ -33,5 +33,5 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/func_args/pgx/v4/go/db.go
+++ b/internal/endtoend/testdata/func_args/pgx/v4/go/db.go
@@ -30,3 +30,8 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/func_args/pgx/v4/go/query.sql.go
+++ b/internal/endtoend/testdata/func_args/pgx/v4/go/query.sql.go
@@ -13,8 +13,10 @@ const makeIntervalDays = `-- name: MakeIntervalDays :one
 SELECT make_interval(days => $1::int)
 `
 
-func (q *Queries) MakeIntervalDays(ctx context.Context, dollar_1 int32) (int64, error) {
-	row := q.db.QueryRow(ctx, makeIntervalDays, dollar_1)
+func (q *Queries) MakeIntervalDays(ctx context.Context, dollar_1 int32, aq ...AdditionalQuery) (int64, error) {
+	query := makeIntervalDays
+	queryParams := []interface{}{dollar_1}
+	row := q.db.QueryRow(ctx, query, queryParams...)
 	var make_interval int64
 	err := row.Scan(&make_interval)
 	return make_interval, err
@@ -24,8 +26,10 @@ const makeIntervalMonths = `-- name: MakeIntervalMonths :one
 SELECT make_interval(months => $1::int)
 `
 
-func (q *Queries) MakeIntervalMonths(ctx context.Context, months int32) (int64, error) {
-	row := q.db.QueryRow(ctx, makeIntervalMonths, months)
+func (q *Queries) MakeIntervalMonths(ctx context.Context, months int32, aq ...AdditionalQuery) (int64, error) {
+	query := makeIntervalMonths
+	queryParams := []interface{}{months}
+	row := q.db.QueryRow(ctx, query, queryParams...)
 	var make_interval int64
 	err := row.Scan(&make_interval)
 	return make_interval, err
@@ -35,8 +39,10 @@ const makeIntervalSecs = `-- name: MakeIntervalSecs :one
 SELECT make_interval(secs => $1)
 `
 
-func (q *Queries) MakeIntervalSecs(ctx context.Context, secs float64) (int64, error) {
-	row := q.db.QueryRow(ctx, makeIntervalSecs, secs)
+func (q *Queries) MakeIntervalSecs(ctx context.Context, secs float64, aq ...AdditionalQuery) (int64, error) {
+	query := makeIntervalSecs
+	queryParams := []interface{}{secs}
+	row := q.db.QueryRow(ctx, query, queryParams...)
 	var make_interval int64
 	err := row.Scan(&make_interval)
 	return make_interval, err
@@ -51,8 +57,10 @@ type PlusParams struct {
 	B int32
 }
 
-func (q *Queries) Plus(ctx context.Context, arg PlusParams) (int32, error) {
-	row := q.db.QueryRow(ctx, plus, arg.A, arg.B)
+func (q *Queries) Plus(ctx context.Context, arg PlusParams, aq ...AdditionalQuery) (int32, error) {
+	query := plus
+	queryParams := []interface{}{arg.A, arg.B}
+	row := q.db.QueryRow(ctx, query, queryParams...)
 	var plus int32
 	err := row.Scan(&plus)
 	return plus, err
@@ -62,8 +70,10 @@ const tableArgs = `-- name: TableArgs :one
 SELECT table_args(x => $1)
 `
 
-func (q *Queries) TableArgs(ctx context.Context, x int32) (int32, error) {
-	row := q.db.QueryRow(ctx, tableArgs, x)
+func (q *Queries) TableArgs(ctx context.Context, x int32, aq ...AdditionalQuery) (int32, error) {
+	query := tableArgs
+	queryParams := []interface{}{x}
+	row := q.db.QueryRow(ctx, query, queryParams...)
 	var table_args int32
 	err := row.Scan(&table_args)
 	return table_args, err

--- a/internal/endtoend/testdata/func_args/pgx/v5/go/db.go
+++ b/internal/endtoend/testdata/func_args/pgx/v5/go/db.go
@@ -33,5 +33,5 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/func_args/pgx/v5/go/db.go
+++ b/internal/endtoend/testdata/func_args/pgx/v5/go/db.go
@@ -30,3 +30,8 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/func_args/pgx/v5/go/query.sql.go
+++ b/internal/endtoend/testdata/func_args/pgx/v5/go/query.sql.go
@@ -15,8 +15,10 @@ const makeIntervalDays = `-- name: MakeIntervalDays :one
 SELECT make_interval(days => $1::int)
 `
 
-func (q *Queries) MakeIntervalDays(ctx context.Context, dollar_1 int32) (pgtype.Interval, error) {
-	row := q.db.QueryRow(ctx, makeIntervalDays, dollar_1)
+func (q *Queries) MakeIntervalDays(ctx context.Context, dollar_1 int32, aq ...AdditionalQuery) (pgtype.Interval, error) {
+	query := makeIntervalDays
+	queryParams := []interface{}{dollar_1}
+	row := q.db.QueryRow(ctx, query, queryParams...)
 	var make_interval pgtype.Interval
 	err := row.Scan(&make_interval)
 	return make_interval, err
@@ -26,8 +28,10 @@ const makeIntervalMonths = `-- name: MakeIntervalMonths :one
 SELECT make_interval(months => $1::int)
 `
 
-func (q *Queries) MakeIntervalMonths(ctx context.Context, months int32) (pgtype.Interval, error) {
-	row := q.db.QueryRow(ctx, makeIntervalMonths, months)
+func (q *Queries) MakeIntervalMonths(ctx context.Context, months int32, aq ...AdditionalQuery) (pgtype.Interval, error) {
+	query := makeIntervalMonths
+	queryParams := []interface{}{months}
+	row := q.db.QueryRow(ctx, query, queryParams...)
 	var make_interval pgtype.Interval
 	err := row.Scan(&make_interval)
 	return make_interval, err
@@ -37,8 +41,10 @@ const makeIntervalSecs = `-- name: MakeIntervalSecs :one
 SELECT make_interval(secs => $1)
 `
 
-func (q *Queries) MakeIntervalSecs(ctx context.Context, secs float64) (pgtype.Interval, error) {
-	row := q.db.QueryRow(ctx, makeIntervalSecs, secs)
+func (q *Queries) MakeIntervalSecs(ctx context.Context, secs float64, aq ...AdditionalQuery) (pgtype.Interval, error) {
+	query := makeIntervalSecs
+	queryParams := []interface{}{secs}
+	row := q.db.QueryRow(ctx, query, queryParams...)
 	var make_interval pgtype.Interval
 	err := row.Scan(&make_interval)
 	return make_interval, err
@@ -53,8 +59,10 @@ type PlusParams struct {
 	B int32
 }
 
-func (q *Queries) Plus(ctx context.Context, arg PlusParams) (int32, error) {
-	row := q.db.QueryRow(ctx, plus, arg.A, arg.B)
+func (q *Queries) Plus(ctx context.Context, arg PlusParams, aq ...AdditionalQuery) (int32, error) {
+	query := plus
+	queryParams := []interface{}{arg.A, arg.B}
+	row := q.db.QueryRow(ctx, query, queryParams...)
 	var plus int32
 	err := row.Scan(&plus)
 	return plus, err
@@ -64,8 +72,10 @@ const tableArgs = `-- name: TableArgs :one
 SELECT table_args(x => $1)
 `
 
-func (q *Queries) TableArgs(ctx context.Context, x int32) (int32, error) {
-	row := q.db.QueryRow(ctx, tableArgs, x)
+func (q *Queries) TableArgs(ctx context.Context, x int32, aq ...AdditionalQuery) (int32, error) {
+	query := tableArgs
+	queryParams := []interface{}{x}
+	row := q.db.QueryRow(ctx, query, queryParams...)
 	var table_args int32
 	err := row.Scan(&table_args)
 	return table_args, err

--- a/internal/endtoend/testdata/func_args/stdlib/go/db.go
+++ b/internal/endtoend/testdata/func_args/stdlib/go/db.go
@@ -29,3 +29,8 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/func_args/stdlib/go/db.go
+++ b/internal/endtoend/testdata/func_args/stdlib/go/db.go
@@ -32,5 +32,5 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/func_args/stdlib/go/query.sql.go
+++ b/internal/endtoend/testdata/func_args/stdlib/go/query.sql.go
@@ -13,8 +13,16 @@ const makeIntervalDays = `-- name: MakeIntervalDays :one
 SELECT make_interval(days => $1::int)
 `
 
-func (q *Queries) MakeIntervalDays(ctx context.Context, dollar_1 int32) (int64, error) {
-	row := q.db.QueryRowContext(ctx, makeIntervalDays, dollar_1)
+func (q *Queries) MakeIntervalDays(ctx context.Context, dollar_1 int32, aq ...AdditionalQuery) (int64, error) {
+	query := makeIntervalDays
+	queryParams := []interface{}{dollar_1}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	row := q.db.QueryRowContext(ctx, query, queryParams...)
 	var make_interval int64
 	err := row.Scan(&make_interval)
 	return make_interval, err
@@ -24,8 +32,16 @@ const makeIntervalMonths = `-- name: MakeIntervalMonths :one
 SELECT make_interval(months => $1::int)
 `
 
-func (q *Queries) MakeIntervalMonths(ctx context.Context, months int32) (int64, error) {
-	row := q.db.QueryRowContext(ctx, makeIntervalMonths, months)
+func (q *Queries) MakeIntervalMonths(ctx context.Context, months int32, aq ...AdditionalQuery) (int64, error) {
+	query := makeIntervalMonths
+	queryParams := []interface{}{months}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	row := q.db.QueryRowContext(ctx, query, queryParams...)
 	var make_interval int64
 	err := row.Scan(&make_interval)
 	return make_interval, err
@@ -35,8 +51,16 @@ const makeIntervalSecs = `-- name: MakeIntervalSecs :one
 SELECT make_interval(secs => $1)
 `
 
-func (q *Queries) MakeIntervalSecs(ctx context.Context, secs float64) (int64, error) {
-	row := q.db.QueryRowContext(ctx, makeIntervalSecs, secs)
+func (q *Queries) MakeIntervalSecs(ctx context.Context, secs float64, aq ...AdditionalQuery) (int64, error) {
+	query := makeIntervalSecs
+	queryParams := []interface{}{secs}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	row := q.db.QueryRowContext(ctx, query, queryParams...)
 	var make_interval int64
 	err := row.Scan(&make_interval)
 	return make_interval, err
@@ -51,8 +75,16 @@ type PlusParams struct {
 	B int32
 }
 
-func (q *Queries) Plus(ctx context.Context, arg PlusParams) (int32, error) {
-	row := q.db.QueryRowContext(ctx, plus, arg.A, arg.B)
+func (q *Queries) Plus(ctx context.Context, arg PlusParams, aq ...AdditionalQuery) (int32, error) {
+	query := plus
+	queryParams := []interface{}{arg.A, arg.B}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	row := q.db.QueryRowContext(ctx, query, queryParams...)
 	var plus int32
 	err := row.Scan(&plus)
 	return plus, err
@@ -62,8 +94,16 @@ const tableArgs = `-- name: TableArgs :one
 SELECT table_args(x => $1)
 `
 
-func (q *Queries) TableArgs(ctx context.Context, x int32) (int32, error) {
-	row := q.db.QueryRowContext(ctx, tableArgs, x)
+func (q *Queries) TableArgs(ctx context.Context, x int32, aq ...AdditionalQuery) (int32, error) {
+	query := tableArgs
+	queryParams := []interface{}{x}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	row := q.db.QueryRowContext(ctx, query, queryParams...)
 	var table_args int32
 	err := row.Scan(&table_args)
 	return table_args, err

--- a/internal/endtoend/testdata/func_args_typecast/pgx/v4/go/db.go
+++ b/internal/endtoend/testdata/func_args_typecast/pgx/v4/go/db.go
@@ -33,5 +33,5 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/func_args_typecast/pgx/v4/go/db.go
+++ b/internal/endtoend/testdata/func_args_typecast/pgx/v4/go/db.go
@@ -30,3 +30,8 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/func_args_typecast/pgx/v4/go/query.sql.go
+++ b/internal/endtoend/testdata/func_args_typecast/pgx/v4/go/query.sql.go
@@ -18,8 +18,10 @@ type PlusPositionalCastParams struct {
 	Column2 int32
 }
 
-func (q *Queries) PlusPositionalCast(ctx context.Context, arg PlusPositionalCastParams) (int32, error) {
-	row := q.db.QueryRow(ctx, plusPositionalCast, arg.A, arg.Column2)
+func (q *Queries) PlusPositionalCast(ctx context.Context, arg PlusPositionalCastParams, aq ...AdditionalQuery) (int32, error) {
+	query := plusPositionalCast
+	queryParams := []interface{}{arg.A, arg.Column2}
+	row := q.db.QueryRow(ctx, query, queryParams...)
 	var plus int32
 	err := row.Scan(&plus)
 	return plus, err

--- a/internal/endtoend/testdata/func_args_typecast/pgx/v5/go/db.go
+++ b/internal/endtoend/testdata/func_args_typecast/pgx/v5/go/db.go
@@ -33,5 +33,5 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/func_args_typecast/pgx/v5/go/db.go
+++ b/internal/endtoend/testdata/func_args_typecast/pgx/v5/go/db.go
@@ -30,3 +30,8 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/func_args_typecast/pgx/v5/go/query.sql.go
+++ b/internal/endtoend/testdata/func_args_typecast/pgx/v5/go/query.sql.go
@@ -18,8 +18,10 @@ type PlusPositionalCastParams struct {
 	Column2 int32
 }
 
-func (q *Queries) PlusPositionalCast(ctx context.Context, arg PlusPositionalCastParams) (int32, error) {
-	row := q.db.QueryRow(ctx, plusPositionalCast, arg.A, arg.Column2)
+func (q *Queries) PlusPositionalCast(ctx context.Context, arg PlusPositionalCastParams, aq ...AdditionalQuery) (int32, error) {
+	query := plusPositionalCast
+	queryParams := []interface{}{arg.A, arg.Column2}
+	row := q.db.QueryRow(ctx, query, queryParams...)
 	var plus int32
 	err := row.Scan(&plus)
 	return plus, err

--- a/internal/endtoend/testdata/func_args_typecast/stdlib/go/db.go
+++ b/internal/endtoend/testdata/func_args_typecast/stdlib/go/db.go
@@ -29,3 +29,8 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/func_args_typecast/stdlib/go/db.go
+++ b/internal/endtoend/testdata/func_args_typecast/stdlib/go/db.go
@@ -32,5 +32,5 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/func_args_typecast/stdlib/go/query.sql.go
+++ b/internal/endtoend/testdata/func_args_typecast/stdlib/go/query.sql.go
@@ -18,8 +18,16 @@ type PlusPositionalCastParams struct {
 	Column2 int32
 }
 
-func (q *Queries) PlusPositionalCast(ctx context.Context, arg PlusPositionalCastParams) (int32, error) {
-	row := q.db.QueryRowContext(ctx, plusPositionalCast, arg.A, arg.Column2)
+func (q *Queries) PlusPositionalCast(ctx context.Context, arg PlusPositionalCastParams, aq ...AdditionalQuery) (int32, error) {
+	query := plusPositionalCast
+	queryParams := []interface{}{arg.A, arg.Column2}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	row := q.db.QueryRowContext(ctx, query, queryParams...)
 	var plus int32
 	err := row.Scan(&plus)
 	return plus, err

--- a/internal/endtoend/testdata/func_call_cast/mysql/go/db.go
+++ b/internal/endtoend/testdata/func_call_cast/mysql/go/db.go
@@ -29,3 +29,8 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/func_call_cast/mysql/go/db.go
+++ b/internal/endtoend/testdata/func_call_cast/mysql/go/db.go
@@ -32,5 +32,5 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/func_call_cast/mysql/go/query.sql.go
+++ b/internal/endtoend/testdata/func_call_cast/mysql/go/query.sql.go
@@ -13,8 +13,16 @@ const demo = `-- name: Demo :one
 SELECT CAST(GREATEST(1,2,3,4,5) AS UNSIGNED) as col1
 `
 
-func (q *Queries) Demo(ctx context.Context) (int64, error) {
-	row := q.db.QueryRowContext(ctx, demo)
+func (q *Queries) Demo(ctx context.Context, aq ...AdditionalQuery) (int64, error) {
+	query := demo
+	queryParams := []interface{}{}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	row := q.db.QueryRowContext(ctx, query, queryParams...)
 	var col1 int64
 	err := row.Scan(&col1)
 	return col1, err

--- a/internal/endtoend/testdata/func_call_cast/postgresql/pgx/v4/go/db.go
+++ b/internal/endtoend/testdata/func_call_cast/postgresql/pgx/v4/go/db.go
@@ -33,5 +33,5 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/func_call_cast/postgresql/pgx/v4/go/db.go
+++ b/internal/endtoend/testdata/func_call_cast/postgresql/pgx/v4/go/db.go
@@ -30,3 +30,8 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/func_call_cast/postgresql/pgx/v4/go/query.sql.go
+++ b/internal/endtoend/testdata/func_call_cast/postgresql/pgx/v4/go/query.sql.go
@@ -15,8 +15,10 @@ const demo = `-- name: Demo :one
 SELECT uuid_generate_v5('7c4597a0-8cfa-4c19-8da0-b8474a36440d', $1)::uuid as col1
 `
 
-func (q *Queries) Demo(ctx context.Context, uuidGenerateV5 interface{}) (uuid.UUID, error) {
-	row := q.db.QueryRow(ctx, demo, uuidGenerateV5)
+func (q *Queries) Demo(ctx context.Context, uuidGenerateV5 interface{}, aq ...AdditionalQuery) (uuid.UUID, error) {
+	query := demo
+	queryParams := []interface{}{uuidGenerateV5}
+	row := q.db.QueryRow(ctx, query, queryParams...)
 	var col1 uuid.UUID
 	err := row.Scan(&col1)
 	return col1, err

--- a/internal/endtoend/testdata/func_call_cast/postgresql/pgx/v5/go/db.go
+++ b/internal/endtoend/testdata/func_call_cast/postgresql/pgx/v5/go/db.go
@@ -33,5 +33,5 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/func_call_cast/postgresql/pgx/v5/go/db.go
+++ b/internal/endtoend/testdata/func_call_cast/postgresql/pgx/v5/go/db.go
@@ -30,3 +30,8 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/func_call_cast/postgresql/pgx/v5/go/query.sql.go
+++ b/internal/endtoend/testdata/func_call_cast/postgresql/pgx/v5/go/query.sql.go
@@ -15,8 +15,10 @@ const demo = `-- name: Demo :one
 SELECT uuid_generate_v5('7c4597a0-8cfa-4c19-8da0-b8474a36440d', $1)::uuid as col1
 `
 
-func (q *Queries) Demo(ctx context.Context, uuidGenerateV5 interface{}) (pgtype.UUID, error) {
-	row := q.db.QueryRow(ctx, demo, uuidGenerateV5)
+func (q *Queries) Demo(ctx context.Context, uuidGenerateV5 interface{}, aq ...AdditionalQuery) (pgtype.UUID, error) {
+	query := demo
+	queryParams := []interface{}{uuidGenerateV5}
+	row := q.db.QueryRow(ctx, query, queryParams...)
 	var col1 pgtype.UUID
 	err := row.Scan(&col1)
 	return col1, err

--- a/internal/endtoend/testdata/func_call_cast/postgresql/stdlib/go/db.go
+++ b/internal/endtoend/testdata/func_call_cast/postgresql/stdlib/go/db.go
@@ -29,3 +29,8 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/func_call_cast/postgresql/stdlib/go/db.go
+++ b/internal/endtoend/testdata/func_call_cast/postgresql/stdlib/go/db.go
@@ -32,5 +32,5 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/func_call_cast/postgresql/stdlib/go/query.sql.go
+++ b/internal/endtoend/testdata/func_call_cast/postgresql/stdlib/go/query.sql.go
@@ -15,8 +15,16 @@ const demo = `-- name: Demo :one
 SELECT uuid_generate_v5('7c4597a0-8cfa-4c19-8da0-b8474a36440d', $1)::uuid as col1
 `
 
-func (q *Queries) Demo(ctx context.Context, uuidGenerateV5 interface{}) (uuid.UUID, error) {
-	row := q.db.QueryRowContext(ctx, demo, uuidGenerateV5)
+func (q *Queries) Demo(ctx context.Context, uuidGenerateV5 interface{}, aq ...AdditionalQuery) (uuid.UUID, error) {
+	query := demo
+	queryParams := []interface{}{uuidGenerateV5}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	row := q.db.QueryRowContext(ctx, query, queryParams...)
 	var col1 uuid.UUID
 	err := row.Scan(&col1)
 	return col1, err

--- a/internal/endtoend/testdata/func_call_cast/sqlite/go/db.go
+++ b/internal/endtoend/testdata/func_call_cast/sqlite/go/db.go
@@ -29,3 +29,8 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/func_call_cast/sqlite/go/db.go
+++ b/internal/endtoend/testdata/func_call_cast/sqlite/go/db.go
@@ -32,5 +32,5 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/func_call_cast/sqlite/go/query.sql.go
+++ b/internal/endtoend/testdata/func_call_cast/sqlite/go/query.sql.go
@@ -13,8 +13,16 @@ const demo = `-- name: Demo :one
 SELECT CAST(CHAR(1,2,3,4,5) AS BLOB) AS col1
 `
 
-func (q *Queries) Demo(ctx context.Context) ([]byte, error) {
-	row := q.db.QueryRowContext(ctx, demo)
+func (q *Queries) Demo(ctx context.Context, aq ...AdditionalQuery) ([]byte, error) {
+	query := demo
+	queryParams := []interface{}{}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	row := q.db.QueryRowContext(ctx, query, queryParams...)
 	var col1 []byte
 	err := row.Scan(&col1)
 	return col1, err

--- a/internal/endtoend/testdata/func_match_types/mysql/go/db.go
+++ b/internal/endtoend/testdata/func_match_types/mysql/go/db.go
@@ -29,3 +29,8 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/func_match_types/mysql/go/db.go
+++ b/internal/endtoend/testdata/func_match_types/mysql/go/db.go
@@ -32,5 +32,5 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/func_match_types/mysql/go/query.sql.go
+++ b/internal/endtoend/testdata/func_match_types/mysql/go/query.sql.go
@@ -21,8 +21,16 @@ type AuthorPagesRow struct {
 	TotalPages interface{}
 }
 
-func (q *Queries) AuthorPages(ctx context.Context) ([]AuthorPagesRow, error) {
-	rows, err := q.db.QueryContext(ctx, authorPages)
+func (q *Queries) AuthorPages(ctx context.Context, aq ...AdditionalQuery) ([]AuthorPagesRow, error) {
+	query := authorPages
+	queryParams := []interface{}{}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.QueryContext(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/endtoend/testdata/func_match_types/postgresql/go/db.go
+++ b/internal/endtoend/testdata/func_match_types/postgresql/go/db.go
@@ -29,3 +29,8 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/func_match_types/postgresql/go/db.go
+++ b/internal/endtoend/testdata/func_match_types/postgresql/go/db.go
@@ -32,5 +32,5 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/func_match_types/postgresql/go/query.sql.go
+++ b/internal/endtoend/testdata/func_match_types/postgresql/go/query.sql.go
@@ -21,8 +21,16 @@ type AuthorPagesRow struct {
 	TotalPages int64
 }
 
-func (q *Queries) AuthorPages(ctx context.Context) ([]AuthorPagesRow, error) {
-	rows, err := q.db.QueryContext(ctx, authorPages)
+func (q *Queries) AuthorPages(ctx context.Context, aq ...AdditionalQuery) ([]AuthorPagesRow, error) {
+	query := authorPages
+	queryParams := []interface{}{}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.QueryContext(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/endtoend/testdata/func_match_types/sqlite/go/db.go
+++ b/internal/endtoend/testdata/func_match_types/sqlite/go/db.go
@@ -29,3 +29,8 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/func_match_types/sqlite/go/db.go
+++ b/internal/endtoend/testdata/func_match_types/sqlite/go/db.go
@@ -32,5 +32,5 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/func_match_types/sqlite/go/query.sql.go
+++ b/internal/endtoend/testdata/func_match_types/sqlite/go/query.sql.go
@@ -22,8 +22,16 @@ type AuthorPagesRow struct {
 	TotalPages sql.NullFloat64
 }
 
-func (q *Queries) AuthorPages(ctx context.Context) ([]AuthorPagesRow, error) {
-	rows, err := q.db.QueryContext(ctx, authorPages)
+func (q *Queries) AuthorPages(ctx context.Context, aq ...AdditionalQuery) ([]AuthorPagesRow, error) {
+	query := authorPages
+	queryParams := []interface{}{}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.QueryContext(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/endtoend/testdata/func_return/postgresql/pgx/v4/go/db.go
+++ b/internal/endtoend/testdata/func_return/postgresql/pgx/v4/go/db.go
@@ -33,5 +33,5 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/func_return/postgresql/pgx/v4/go/db.go
+++ b/internal/endtoend/testdata/func_return/postgresql/pgx/v4/go/db.go
@@ -30,3 +30,8 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/func_return/postgresql/pgx/v4/go/query.sql.go
+++ b/internal/endtoend/testdata/func_return/postgresql/pgx/v4/go/query.sql.go
@@ -22,8 +22,16 @@ type GenerateSeriesParams struct {
 	Column2 int32
 }
 
-func (q *Queries) GenerateSeries(ctx context.Context, arg GenerateSeriesParams) ([]int32, error) {
-	rows, err := q.db.Query(ctx, generateSeries, arg.Column1, arg.Column2)
+func (q *Queries) GenerateSeries(ctx context.Context, arg GenerateSeriesParams, aq ...AdditionalQuery) ([]int32, error) {
+	query := generateSeries
+	queryParams := []interface{}{arg.Column1, arg.Column2}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.Query(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}
@@ -49,8 +57,10 @@ SELECT  from CURRENT_DATE
 type GetDateRow struct {
 }
 
-func (q *Queries) GetDate(ctx context.Context) (GetDateRow, error) {
-	row := q.db.QueryRow(ctx, getDate)
+func (q *Queries) GetDate(ctx context.Context, aq ...AdditionalQuery) (GetDateRow, error) {
+	query := getDate
+	queryParams := []interface{}{}
+	row := q.db.QueryRow(ctx, query, queryParams...)
 	var i GetDateRow
 	err := row.Scan()
 	return i, err
@@ -62,8 +72,16 @@ FROM users_func()
 WHERE first_name != ''
 `
 
-func (q *Queries) GetUsers(ctx context.Context) ([]User, error) {
-	rows, err := q.db.Query(ctx, getUsers)
+func (q *Queries) GetUsers(ctx context.Context, aq ...AdditionalQuery) ([]User, error) {
+	query := getUsers
+	queryParams := []interface{}{}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.Query(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/endtoend/testdata/func_return/postgresql/pgx/v5/go/db.go
+++ b/internal/endtoend/testdata/func_return/postgresql/pgx/v5/go/db.go
@@ -33,5 +33,5 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/func_return/postgresql/pgx/v5/go/db.go
+++ b/internal/endtoend/testdata/func_return/postgresql/pgx/v5/go/db.go
@@ -30,3 +30,8 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/func_return/postgresql/pgx/v5/go/query.sql.go
+++ b/internal/endtoend/testdata/func_return/postgresql/pgx/v5/go/query.sql.go
@@ -21,8 +21,16 @@ type GenerateSeriesParams struct {
 	Column2 int32
 }
 
-func (q *Queries) GenerateSeries(ctx context.Context, arg GenerateSeriesParams) ([]int32, error) {
-	rows, err := q.db.Query(ctx, generateSeries, arg.Column1, arg.Column2)
+func (q *Queries) GenerateSeries(ctx context.Context, arg GenerateSeriesParams, aq ...AdditionalQuery) ([]int32, error) {
+	query := generateSeries
+	queryParams := []interface{}{arg.Column1, arg.Column2}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.Query(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}
@@ -48,8 +56,10 @@ SELECT  from CURRENT_DATE
 type GetDateRow struct {
 }
 
-func (q *Queries) GetDate(ctx context.Context) (GetDateRow, error) {
-	row := q.db.QueryRow(ctx, getDate)
+func (q *Queries) GetDate(ctx context.Context, aq ...AdditionalQuery) (GetDateRow, error) {
+	query := getDate
+	queryParams := []interface{}{}
+	row := q.db.QueryRow(ctx, query, queryParams...)
 	var i GetDateRow
 	err := row.Scan()
 	return i, err
@@ -61,8 +71,16 @@ FROM users_func()
 WHERE first_name != ''
 `
 
-func (q *Queries) GetUsers(ctx context.Context) ([]User, error) {
-	rows, err := q.db.Query(ctx, getUsers)
+func (q *Queries) GetUsers(ctx context.Context, aq ...AdditionalQuery) ([]User, error) {
+	query := getUsers
+	queryParams := []interface{}{}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.Query(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/endtoend/testdata/func_return/postgresql/stdlib/go/db.go
+++ b/internal/endtoend/testdata/func_return/postgresql/stdlib/go/db.go
@@ -29,3 +29,8 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/func_return/postgresql/stdlib/go/db.go
+++ b/internal/endtoend/testdata/func_return/postgresql/stdlib/go/db.go
@@ -32,5 +32,5 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/func_return/postgresql/stdlib/go/query.sql.go
+++ b/internal/endtoend/testdata/func_return/postgresql/stdlib/go/query.sql.go
@@ -22,8 +22,16 @@ type GenerateSeriesParams struct {
 	Column2 int32
 }
 
-func (q *Queries) GenerateSeries(ctx context.Context, arg GenerateSeriesParams) ([]int32, error) {
-	rows, err := q.db.QueryContext(ctx, generateSeries, arg.Column1, arg.Column2)
+func (q *Queries) GenerateSeries(ctx context.Context, arg GenerateSeriesParams, aq ...AdditionalQuery) ([]int32, error) {
+	query := generateSeries
+	queryParams := []interface{}{arg.Column1, arg.Column2}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.QueryContext(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}
@@ -52,8 +60,16 @@ SELECT  from CURRENT_DATE
 type GetDateRow struct {
 }
 
-func (q *Queries) GetDate(ctx context.Context) (GetDateRow, error) {
-	row := q.db.QueryRowContext(ctx, getDate)
+func (q *Queries) GetDate(ctx context.Context, aq ...AdditionalQuery) (GetDateRow, error) {
+	query := getDate
+	queryParams := []interface{}{}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	row := q.db.QueryRowContext(ctx, query, queryParams...)
 	var i GetDateRow
 	err := row.Scan()
 	return i, err
@@ -65,8 +81,16 @@ FROM users_func()
 WHERE first_name != ''
 `
 
-func (q *Queries) GetUsers(ctx context.Context) ([]User, error) {
-	rows, err := q.db.QueryContext(ctx, getUsers)
+func (q *Queries) GetUsers(ctx context.Context, aq ...AdditionalQuery) ([]User, error) {
+	query := getUsers
+	queryParams := []interface{}{}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.QueryContext(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/endtoend/testdata/func_variadic/postgresql/stdlib/go/db.go
+++ b/internal/endtoend/testdata/func_variadic/postgresql/stdlib/go/db.go
@@ -29,3 +29,8 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/func_variadic/postgresql/stdlib/go/db.go
+++ b/internal/endtoend/testdata/func_variadic/postgresql/stdlib/go/db.go
@@ -32,5 +32,5 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/func_variadic/postgresql/stdlib/go/query.sql.go
+++ b/internal/endtoend/testdata/func_variadic/postgresql/stdlib/go/query.sql.go
@@ -28,12 +28,15 @@ type UpdateJParams struct {
 }
 
 func (q *Queries) UpdateJ(ctx context.Context, arg UpdateJParams) error {
-	_, err := q.db.ExecContext(ctx, updateJ,
+	query := updateJ
+	queryParams := []interface{}{
 		arg.JsonbBuildObject,
 		arg.JsonbBuildObject_2,
 		arg.JsonbBuildObject_3,
 		arg.JsonbBuildObject_4,
 		arg.ID,
-	)
+	}
+
+	_, err := q.db.ExecContext(ctx, query, queryParams...)
 	return err
 }

--- a/internal/endtoend/testdata/geometric/pgx/v5/go/db.go
+++ b/internal/endtoend/testdata/geometric/pgx/v5/go/db.go
@@ -33,5 +33,5 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/geometric/pgx/v5/go/db.go
+++ b/internal/endtoend/testdata/geometric/pgx/v5/go/db.go
@@ -30,3 +30,8 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/geometric/pgx/v5/go/query.sql.go
+++ b/internal/endtoend/testdata/geometric/pgx/v5/go/query.sql.go
@@ -14,8 +14,16 @@ SELECT v_box_null, v_circle_null, v_line_null, v_lseg_null, v_path_null, v_point
 from test_table
 `
 
-func (q *Queries) SelectTest(ctx context.Context) ([]TestTable, error) {
-	rows, err := q.db.Query(ctx, selectTest)
+func (q *Queries) SelectTest(ctx context.Context, aq ...AdditionalQuery) ([]TestTable, error) {
+	query := selectTest
+	queryParams := []interface{}{}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.Query(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/endtoend/testdata/having/mysql/go/db.go
+++ b/internal/endtoend/testdata/having/mysql/go/db.go
@@ -29,3 +29,8 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/having/mysql/go/db.go
+++ b/internal/endtoend/testdata/having/mysql/go/db.go
@@ -32,5 +32,5 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/having/mysql/go/query.sql.go
+++ b/internal/endtoend/testdata/having/mysql/go/query.sql.go
@@ -16,8 +16,16 @@ GROUP BY city
 HAVING max(temp_lo) < ?
 `
 
-func (q *Queries) ColdCities(ctx context.Context, tempLo int32) ([]string, error) {
-	rows, err := q.db.QueryContext(ctx, coldCities, tempLo)
+func (q *Queries) ColdCities(ctx context.Context, tempLo int32, aq ...AdditionalQuery) ([]string, error) {
+	query := coldCities
+	queryParams := []interface{}{tempLo}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.QueryContext(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/endtoend/testdata/having/postgresql/go/db.go
+++ b/internal/endtoend/testdata/having/postgresql/go/db.go
@@ -29,3 +29,8 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/having/postgresql/go/db.go
+++ b/internal/endtoend/testdata/having/postgresql/go/db.go
@@ -32,5 +32,5 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/having/postgresql/go/query.sql.go
+++ b/internal/endtoend/testdata/having/postgresql/go/query.sql.go
@@ -16,8 +16,16 @@ GROUP BY city
 HAVING max(temp_lo) < $1
 `
 
-func (q *Queries) ColdCities(ctx context.Context, tempLo int32) ([]string, error) {
-	rows, err := q.db.QueryContext(ctx, coldCities, tempLo)
+func (q *Queries) ColdCities(ctx context.Context, tempLo int32, aq ...AdditionalQuery) ([]string, error) {
+	query := coldCities
+	queryParams := []interface{}{tempLo}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.QueryContext(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/endtoend/testdata/hstore/pgx/v4/go/db.go
+++ b/internal/endtoend/testdata/hstore/pgx/v4/go/db.go
@@ -33,5 +33,5 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/hstore/pgx/v4/go/db.go
+++ b/internal/endtoend/testdata/hstore/pgx/v4/go/db.go
@@ -30,3 +30,8 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/hstore/pgx/v4/go/hstore.sql.go
+++ b/internal/endtoend/testdata/hstore/pgx/v4/go/hstore.sql.go
@@ -15,8 +15,16 @@ const listBar = `-- name: ListBar :many
 SELECT bar FROM foo
 `
 
-func (q *Queries) ListBar(ctx context.Context) ([]pgtype.Hstore, error) {
-	rows, err := q.db.Query(ctx, listBar)
+func (q *Queries) ListBar(ctx context.Context, aq ...AdditionalQuery) ([]pgtype.Hstore, error) {
+	query := listBar
+	queryParams := []interface{}{}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.Query(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}
@@ -39,8 +47,16 @@ const listBaz = `-- name: ListBaz :many
 SELECT baz FROM foo
 `
 
-func (q *Queries) ListBaz(ctx context.Context) ([]pgtype.Hstore, error) {
-	rows, err := q.db.Query(ctx, listBaz)
+func (q *Queries) ListBaz(ctx context.Context, aq ...AdditionalQuery) ([]pgtype.Hstore, error) {
+	query := listBaz
+	queryParams := []interface{}{}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.Query(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/endtoend/testdata/hstore/pgx/v5/go/db.go
+++ b/internal/endtoend/testdata/hstore/pgx/v5/go/db.go
@@ -33,5 +33,5 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/hstore/pgx/v5/go/db.go
+++ b/internal/endtoend/testdata/hstore/pgx/v5/go/db.go
@@ -30,3 +30,8 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/hstore/pgx/v5/go/hstore.sql.go
+++ b/internal/endtoend/testdata/hstore/pgx/v5/go/hstore.sql.go
@@ -15,8 +15,16 @@ const listBar = `-- name: ListBar :many
 SELECT bar FROM foo
 `
 
-func (q *Queries) ListBar(ctx context.Context) ([]pgtype.Hstore, error) {
-	rows, err := q.db.Query(ctx, listBar)
+func (q *Queries) ListBar(ctx context.Context, aq ...AdditionalQuery) ([]pgtype.Hstore, error) {
+	query := listBar
+	queryParams := []interface{}{}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.Query(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}
@@ -39,8 +47,16 @@ const listBaz = `-- name: ListBaz :many
 SELECT baz FROM foo
 `
 
-func (q *Queries) ListBaz(ctx context.Context) ([]pgtype.Hstore, error) {
-	rows, err := q.db.Query(ctx, listBaz)
+func (q *Queries) ListBaz(ctx context.Context, aq ...AdditionalQuery) ([]pgtype.Hstore, error) {
+	query := listBaz
+	queryParams := []interface{}{}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.Query(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/endtoend/testdata/hstore/stdlib/go/db.go
+++ b/internal/endtoend/testdata/hstore/stdlib/go/db.go
@@ -29,3 +29,8 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/hstore/stdlib/go/db.go
+++ b/internal/endtoend/testdata/hstore/stdlib/go/db.go
@@ -32,5 +32,5 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/hstore/stdlib/go/hstore.sql.go
+++ b/internal/endtoend/testdata/hstore/stdlib/go/hstore.sql.go
@@ -13,8 +13,16 @@ const listBar = `-- name: ListBar :many
 SELECT bar FROM foo
 `
 
-func (q *Queries) ListBar(ctx context.Context) ([]interface{}, error) {
-	rows, err := q.db.QueryContext(ctx, listBar)
+func (q *Queries) ListBar(ctx context.Context, aq ...AdditionalQuery) ([]interface{}, error) {
+	query := listBar
+	queryParams := []interface{}{}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.QueryContext(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}
@@ -40,8 +48,16 @@ const listBaz = `-- name: ListBaz :many
 SELECT baz FROM foo
 `
 
-func (q *Queries) ListBaz(ctx context.Context) ([]interface{}, error) {
-	rows, err := q.db.QueryContext(ctx, listBaz)
+func (q *Queries) ListBaz(ctx context.Context, aq ...AdditionalQuery) ([]interface{}, error) {
+	query := listBaz
+	queryParams := []interface{}{}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.QueryContext(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/endtoend/testdata/identical_tables/mysql/go/db.go
+++ b/internal/endtoend/testdata/identical_tables/mysql/go/db.go
@@ -29,3 +29,8 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/identical_tables/mysql/go/db.go
+++ b/internal/endtoend/testdata/identical_tables/mysql/go/db.go
@@ -32,5 +32,5 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/identical_tables/mysql/go/query.sql.go
+++ b/internal/endtoend/testdata/identical_tables/mysql/go/query.sql.go
@@ -13,8 +13,16 @@ const identicalTable = `-- name: IdenticalTable :many
 SELECT id FROM foo
 `
 
-func (q *Queries) IdenticalTable(ctx context.Context) ([]string, error) {
-	rows, err := q.db.QueryContext(ctx, identicalTable)
+func (q *Queries) IdenticalTable(ctx context.Context, aq ...AdditionalQuery) ([]string, error) {
+	query := identicalTable
+	queryParams := []interface{}{}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.QueryContext(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/endtoend/testdata/identical_tables/postgresql/pgx/v4/go/db.go
+++ b/internal/endtoend/testdata/identical_tables/postgresql/pgx/v4/go/db.go
@@ -33,5 +33,5 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/identical_tables/postgresql/pgx/v4/go/db.go
+++ b/internal/endtoend/testdata/identical_tables/postgresql/pgx/v4/go/db.go
@@ -30,3 +30,8 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/identical_tables/postgresql/pgx/v4/go/query.sql.go
+++ b/internal/endtoend/testdata/identical_tables/postgresql/pgx/v4/go/query.sql.go
@@ -13,8 +13,16 @@ const identicalTable = `-- name: IdenticalTable :many
 SELECT id FROM foo
 `
 
-func (q *Queries) IdenticalTable(ctx context.Context) ([]string, error) {
-	rows, err := q.db.Query(ctx, identicalTable)
+func (q *Queries) IdenticalTable(ctx context.Context, aq ...AdditionalQuery) ([]string, error) {
+	query := identicalTable
+	queryParams := []interface{}{}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.Query(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/endtoend/testdata/identical_tables/postgresql/pgx/v5/go/db.go
+++ b/internal/endtoend/testdata/identical_tables/postgresql/pgx/v5/go/db.go
@@ -33,5 +33,5 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/identical_tables/postgresql/pgx/v5/go/db.go
+++ b/internal/endtoend/testdata/identical_tables/postgresql/pgx/v5/go/db.go
@@ -30,3 +30,8 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/identical_tables/postgresql/pgx/v5/go/query.sql.go
+++ b/internal/endtoend/testdata/identical_tables/postgresql/pgx/v5/go/query.sql.go
@@ -13,8 +13,16 @@ const identicalTable = `-- name: IdenticalTable :many
 SELECT id FROM foo
 `
 
-func (q *Queries) IdenticalTable(ctx context.Context) ([]string, error) {
-	rows, err := q.db.Query(ctx, identicalTable)
+func (q *Queries) IdenticalTable(ctx context.Context, aq ...AdditionalQuery) ([]string, error) {
+	query := identicalTable
+	queryParams := []interface{}{}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.Query(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/endtoend/testdata/identical_tables/postgresql/stdlib/go/db.go
+++ b/internal/endtoend/testdata/identical_tables/postgresql/stdlib/go/db.go
@@ -29,3 +29,8 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/identical_tables/postgresql/stdlib/go/db.go
+++ b/internal/endtoend/testdata/identical_tables/postgresql/stdlib/go/db.go
@@ -32,5 +32,5 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/identical_tables/postgresql/stdlib/go/query.sql.go
+++ b/internal/endtoend/testdata/identical_tables/postgresql/stdlib/go/query.sql.go
@@ -13,8 +13,16 @@ const identicalTable = `-- name: IdenticalTable :many
 SELECT id FROM foo
 `
 
-func (q *Queries) IdenticalTable(ctx context.Context) ([]string, error) {
-	rows, err := q.db.QueryContext(ctx, identicalTable)
+func (q *Queries) IdenticalTable(ctx context.Context, aq ...AdditionalQuery) ([]string, error) {
+	query := identicalTable
+	queryParams := []interface{}{}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.QueryContext(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/endtoend/testdata/identical_tables/sqlite/go/db.go
+++ b/internal/endtoend/testdata/identical_tables/sqlite/go/db.go
@@ -29,3 +29,8 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/identical_tables/sqlite/go/db.go
+++ b/internal/endtoend/testdata/identical_tables/sqlite/go/db.go
@@ -32,5 +32,5 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/identical_tables/sqlite/go/query.sql.go
+++ b/internal/endtoend/testdata/identical_tables/sqlite/go/query.sql.go
@@ -13,8 +13,16 @@ const identicalTable = `-- name: IdenticalTable :many
 SELECT id FROM foo
 `
 
-func (q *Queries) IdenticalTable(ctx context.Context) ([]string, error) {
-	rows, err := q.db.QueryContext(ctx, identicalTable)
+func (q *Queries) IdenticalTable(ctx context.Context, aq ...AdditionalQuery) ([]string, error) {
+	query := identicalTable
+	queryParams := []interface{}{}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.QueryContext(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/endtoend/testdata/identifier_case_sensitivity/db/db.go
+++ b/internal/endtoend/testdata/identifier_case_sensitivity/db/db.go
@@ -29,3 +29,8 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/identifier_case_sensitivity/db/db.go
+++ b/internal/endtoend/testdata/identifier_case_sensitivity/db/db.go
@@ -32,5 +32,5 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/identifier_dollar_sign/db/db.go
+++ b/internal/endtoend/testdata/identifier_dollar_sign/db/db.go
@@ -29,3 +29,8 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/identifier_dollar_sign/db/db.go
+++ b/internal/endtoend/testdata/identifier_dollar_sign/db/db.go
@@ -32,5 +32,5 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/identifier_dollar_sign/db/query.sql.go
+++ b/internal/endtoend/testdata/identifier_dollar_sign/db/query.sql.go
@@ -13,8 +13,16 @@ const fn = `-- name: Fn :one
 SELECT f$n()
 `
 
-func (q *Queries) Fn(ctx context.Context) (int32, error) {
-	row := q.db.QueryRowContext(ctx, fn)
+func (q *Queries) Fn(ctx context.Context, aq ...AdditionalQuery) (int32, error) {
+	query := fn
+	queryParams := []interface{}{}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	row := q.db.QueryRowContext(ctx, query, queryParams...)
 	var f_n int32
 	err := row.Scan(&f_n)
 	return f_n, err

--- a/internal/endtoend/testdata/inflection/mysql/go/db.go
+++ b/internal/endtoend/testdata/inflection/mysql/go/db.go
@@ -29,3 +29,8 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/inflection/mysql/go/db.go
+++ b/internal/endtoend/testdata/inflection/mysql/go/db.go
@@ -32,5 +32,5 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/inflection/mysql/go/query.sql.go
+++ b/internal/endtoend/testdata/inflection/mysql/go/query.sql.go
@@ -13,8 +13,16 @@ const listCalories = `-- name: ListCalories :many
 SELECT id FROM calories
 `
 
-func (q *Queries) ListCalories(ctx context.Context) ([]string, error) {
-	rows, err := q.db.QueryContext(ctx, listCalories)
+func (q *Queries) ListCalories(ctx context.Context, aq ...AdditionalQuery) ([]string, error) {
+	query := listCalories
+	queryParams := []interface{}{}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.QueryContext(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}
@@ -40,8 +48,16 @@ const listCampuses = `-- name: ListCampuses :many
 SELECT id FROM campus
 `
 
-func (q *Queries) ListCampuses(ctx context.Context) ([]string, error) {
-	rows, err := q.db.QueryContext(ctx, listCampuses)
+func (q *Queries) ListCampuses(ctx context.Context, aq ...AdditionalQuery) ([]string, error) {
+	query := listCampuses
+	queryParams := []interface{}{}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.QueryContext(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}
@@ -67,8 +83,16 @@ const listMetadata = `-- name: ListMetadata :many
 SELECT id FROM product_meta
 `
 
-func (q *Queries) ListMetadata(ctx context.Context) ([]string, error) {
-	rows, err := q.db.QueryContext(ctx, listMetadata)
+func (q *Queries) ListMetadata(ctx context.Context, aq ...AdditionalQuery) ([]string, error) {
+	query := listMetadata
+	queryParams := []interface{}{}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.QueryContext(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}
@@ -94,8 +118,16 @@ const listStudents = `-- name: ListStudents :many
 SELECT id FROM students
 `
 
-func (q *Queries) ListStudents(ctx context.Context) ([]string, error) {
-	rows, err := q.db.QueryContext(ctx, listStudents)
+func (q *Queries) ListStudents(ctx context.Context, aq ...AdditionalQuery) ([]string, error) {
+	query := listStudents
+	queryParams := []interface{}{}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.QueryContext(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/endtoend/testdata/inflection/postgresql/pgx/v4/go/db.go
+++ b/internal/endtoend/testdata/inflection/postgresql/pgx/v4/go/db.go
@@ -33,5 +33,5 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/inflection/postgresql/pgx/v4/go/db.go
+++ b/internal/endtoend/testdata/inflection/postgresql/pgx/v4/go/db.go
@@ -30,3 +30,8 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/inflection/postgresql/pgx/v4/go/query.sql.go
+++ b/internal/endtoend/testdata/inflection/postgresql/pgx/v4/go/query.sql.go
@@ -13,8 +13,16 @@ const listCalories = `-- name: ListCalories :many
 SELECT id FROM calories
 `
 
-func (q *Queries) ListCalories(ctx context.Context) ([]string, error) {
-	rows, err := q.db.Query(ctx, listCalories)
+func (q *Queries) ListCalories(ctx context.Context, aq ...AdditionalQuery) ([]string, error) {
+	query := listCalories
+	queryParams := []interface{}{}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.Query(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}
@@ -37,8 +45,16 @@ const listCampuses = `-- name: ListCampuses :many
 SELECT id FROM campus
 `
 
-func (q *Queries) ListCampuses(ctx context.Context) ([]string, error) {
-	rows, err := q.db.Query(ctx, listCampuses)
+func (q *Queries) ListCampuses(ctx context.Context, aq ...AdditionalQuery) ([]string, error) {
+	query := listCampuses
+	queryParams := []interface{}{}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.Query(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}
@@ -61,8 +77,16 @@ const listMetadata = `-- name: ListMetadata :many
 SELECT id FROM product_meta
 `
 
-func (q *Queries) ListMetadata(ctx context.Context) ([]string, error) {
-	rows, err := q.db.Query(ctx, listMetadata)
+func (q *Queries) ListMetadata(ctx context.Context, aq ...AdditionalQuery) ([]string, error) {
+	query := listMetadata
+	queryParams := []interface{}{}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.Query(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}
@@ -85,8 +109,16 @@ const listStudents = `-- name: ListStudents :many
 SELECT id FROM students
 `
 
-func (q *Queries) ListStudents(ctx context.Context) ([]string, error) {
-	rows, err := q.db.Query(ctx, listStudents)
+func (q *Queries) ListStudents(ctx context.Context, aq ...AdditionalQuery) ([]string, error) {
+	query := listStudents
+	queryParams := []interface{}{}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.Query(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/endtoend/testdata/inflection/postgresql/pgx/v5/go/db.go
+++ b/internal/endtoend/testdata/inflection/postgresql/pgx/v5/go/db.go
@@ -33,5 +33,5 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/inflection/postgresql/pgx/v5/go/db.go
+++ b/internal/endtoend/testdata/inflection/postgresql/pgx/v5/go/db.go
@@ -30,3 +30,8 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/inflection/postgresql/pgx/v5/go/query.sql.go
+++ b/internal/endtoend/testdata/inflection/postgresql/pgx/v5/go/query.sql.go
@@ -13,8 +13,16 @@ const listCalories = `-- name: ListCalories :many
 SELECT id FROM calories
 `
 
-func (q *Queries) ListCalories(ctx context.Context) ([]string, error) {
-	rows, err := q.db.Query(ctx, listCalories)
+func (q *Queries) ListCalories(ctx context.Context, aq ...AdditionalQuery) ([]string, error) {
+	query := listCalories
+	queryParams := []interface{}{}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.Query(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}
@@ -37,8 +45,16 @@ const listCampuses = `-- name: ListCampuses :many
 SELECT id FROM campus
 `
 
-func (q *Queries) ListCampuses(ctx context.Context) ([]string, error) {
-	rows, err := q.db.Query(ctx, listCampuses)
+func (q *Queries) ListCampuses(ctx context.Context, aq ...AdditionalQuery) ([]string, error) {
+	query := listCampuses
+	queryParams := []interface{}{}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.Query(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}
@@ -61,8 +77,16 @@ const listMetadata = `-- name: ListMetadata :many
 SELECT id FROM product_meta
 `
 
-func (q *Queries) ListMetadata(ctx context.Context) ([]string, error) {
-	rows, err := q.db.Query(ctx, listMetadata)
+func (q *Queries) ListMetadata(ctx context.Context, aq ...AdditionalQuery) ([]string, error) {
+	query := listMetadata
+	queryParams := []interface{}{}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.Query(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}
@@ -85,8 +109,16 @@ const listStudents = `-- name: ListStudents :many
 SELECT id FROM students
 `
 
-func (q *Queries) ListStudents(ctx context.Context) ([]string, error) {
-	rows, err := q.db.Query(ctx, listStudents)
+func (q *Queries) ListStudents(ctx context.Context, aq ...AdditionalQuery) ([]string, error) {
+	query := listStudents
+	queryParams := []interface{}{}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.Query(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/endtoend/testdata/inflection/postgresql/stdlib/go/db.go
+++ b/internal/endtoend/testdata/inflection/postgresql/stdlib/go/db.go
@@ -29,3 +29,8 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/inflection/postgresql/stdlib/go/db.go
+++ b/internal/endtoend/testdata/inflection/postgresql/stdlib/go/db.go
@@ -32,5 +32,5 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/inflection/postgresql/stdlib/go/query.sql.go
+++ b/internal/endtoend/testdata/inflection/postgresql/stdlib/go/query.sql.go
@@ -13,8 +13,16 @@ const listCalories = `-- name: ListCalories :many
 SELECT id FROM calories
 `
 
-func (q *Queries) ListCalories(ctx context.Context) ([]string, error) {
-	rows, err := q.db.QueryContext(ctx, listCalories)
+func (q *Queries) ListCalories(ctx context.Context, aq ...AdditionalQuery) ([]string, error) {
+	query := listCalories
+	queryParams := []interface{}{}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.QueryContext(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}
@@ -40,8 +48,16 @@ const listCampuses = `-- name: ListCampuses :many
 SELECT id FROM campus
 `
 
-func (q *Queries) ListCampuses(ctx context.Context) ([]string, error) {
-	rows, err := q.db.QueryContext(ctx, listCampuses)
+func (q *Queries) ListCampuses(ctx context.Context, aq ...AdditionalQuery) ([]string, error) {
+	query := listCampuses
+	queryParams := []interface{}{}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.QueryContext(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}
@@ -67,8 +83,16 @@ const listMetadata = `-- name: ListMetadata :many
 SELECT id FROM product_meta
 `
 
-func (q *Queries) ListMetadata(ctx context.Context) ([]string, error) {
-	rows, err := q.db.QueryContext(ctx, listMetadata)
+func (q *Queries) ListMetadata(ctx context.Context, aq ...AdditionalQuery) ([]string, error) {
+	query := listMetadata
+	queryParams := []interface{}{}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.QueryContext(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}
@@ -94,8 +118,16 @@ const listStudents = `-- name: ListStudents :many
 SELECT id FROM students
 `
 
-func (q *Queries) ListStudents(ctx context.Context) ([]string, error) {
-	rows, err := q.db.QueryContext(ctx, listStudents)
+func (q *Queries) ListStudents(ctx context.Context, aq ...AdditionalQuery) ([]string, error) {
+	query := listStudents
+	queryParams := []interface{}{}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.QueryContext(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/endtoend/testdata/inflection/sqlite/go/db.go
+++ b/internal/endtoend/testdata/inflection/sqlite/go/db.go
@@ -29,3 +29,8 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/inflection/sqlite/go/db.go
+++ b/internal/endtoend/testdata/inflection/sqlite/go/db.go
@@ -32,5 +32,5 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/inflection/sqlite/go/query.sql.go
+++ b/internal/endtoend/testdata/inflection/sqlite/go/query.sql.go
@@ -13,8 +13,16 @@ const listCalories = `-- name: ListCalories :many
 SELECT id FROM calories
 `
 
-func (q *Queries) ListCalories(ctx context.Context) ([]string, error) {
-	rows, err := q.db.QueryContext(ctx, listCalories)
+func (q *Queries) ListCalories(ctx context.Context, aq ...AdditionalQuery) ([]string, error) {
+	query := listCalories
+	queryParams := []interface{}{}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.QueryContext(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}
@@ -40,8 +48,16 @@ const listCampuses = `-- name: ListCampuses :many
 SELECT id FROM campus
 `
 
-func (q *Queries) ListCampuses(ctx context.Context) ([]string, error) {
-	rows, err := q.db.QueryContext(ctx, listCampuses)
+func (q *Queries) ListCampuses(ctx context.Context, aq ...AdditionalQuery) ([]string, error) {
+	query := listCampuses
+	queryParams := []interface{}{}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.QueryContext(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}
@@ -67,8 +83,16 @@ const listMetadata = `-- name: ListMetadata :many
 SELECT id FROM product_meta
 `
 
-func (q *Queries) ListMetadata(ctx context.Context) ([]string, error) {
-	rows, err := q.db.QueryContext(ctx, listMetadata)
+func (q *Queries) ListMetadata(ctx context.Context, aq ...AdditionalQuery) ([]string, error) {
+	query := listMetadata
+	queryParams := []interface{}{}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.QueryContext(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}
@@ -94,8 +118,16 @@ const listStudents = `-- name: ListStudents :many
 SELECT id FROM students
 `
 
-func (q *Queries) ListStudents(ctx context.Context) ([]string, error) {
-	rows, err := q.db.QueryContext(ctx, listStudents)
+func (q *Queries) ListStudents(ctx context.Context, aq ...AdditionalQuery) ([]string, error) {
+	query := listStudents
+	queryParams := []interface{}{}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.QueryContext(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/endtoend/testdata/inflection_exclude_table_names/postgresql/pgx/v4/go/db.go
+++ b/internal/endtoend/testdata/inflection_exclude_table_names/postgresql/pgx/v4/go/db.go
@@ -33,5 +33,5 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/inflection_exclude_table_names/postgresql/pgx/v4/go/db.go
+++ b/internal/endtoend/testdata/inflection_exclude_table_names/postgresql/pgx/v4/go/db.go
@@ -30,3 +30,8 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/inflection_exclude_table_names/postgresql/pgx/v4/go/query.sql.go
+++ b/internal/endtoend/testdata/inflection_exclude_table_names/postgresql/pgx/v4/go/query.sql.go
@@ -13,8 +13,10 @@ const deleteBarByID = `-- name: DeleteBarByID :one
 DELETE FROM bars WHERE id = $1 RETURNING id, name
 `
 
-func (q *Queries) DeleteBarByID(ctx context.Context, id int32) (Bar, error) {
-	row := q.db.QueryRow(ctx, deleteBarByID, id)
+func (q *Queries) DeleteBarByID(ctx context.Context, id int32, aq ...AdditionalQuery) (Bar, error) {
+	query := deleteBarByID
+	queryParams := []interface{}{id}
+	row := q.db.QueryRow(ctx, query, queryParams...)
 	var i Bar
 	err := row.Scan(&i.ID, &i.Name)
 	return i, err
@@ -24,8 +26,10 @@ const deleteExclusionByID = `-- name: DeleteExclusionByID :one
 DELETE FROM exclusions WHERE id = $1 RETURNING id, name
 `
 
-func (q *Queries) DeleteExclusionByID(ctx context.Context, id int32) (Exclusions, error) {
-	row := q.db.QueryRow(ctx, deleteExclusionByID, id)
+func (q *Queries) DeleteExclusionByID(ctx context.Context, id int32, aq ...AdditionalQuery) (Exclusions, error) {
+	query := deleteExclusionByID
+	queryParams := []interface{}{id}
+	row := q.db.QueryRow(ctx, query, queryParams...)
 	var i Exclusions
 	err := row.Scan(&i.ID, &i.Name)
 	return i, err
@@ -35,8 +39,10 @@ const deleteMyDataByID = `-- name: DeleteMyDataByID :one
 DELETE FROM my_data WHERE id = $1 RETURNING id, name
 `
 
-func (q *Queries) DeleteMyDataByID(ctx context.Context, id int32) (MyData, error) {
-	row := q.db.QueryRow(ctx, deleteMyDataByID, id)
+func (q *Queries) DeleteMyDataByID(ctx context.Context, id int32, aq ...AdditionalQuery) (MyData, error) {
+	query := deleteMyDataByID
+	queryParams := []interface{}{id}
+	row := q.db.QueryRow(ctx, query, queryParams...)
 	var i MyData
 	err := row.Scan(&i.ID, &i.Name)
 	return i, err

--- a/internal/endtoend/testdata/inflection_exclude_table_names/postgresql/pgx/v5/go/db.go
+++ b/internal/endtoend/testdata/inflection_exclude_table_names/postgresql/pgx/v5/go/db.go
@@ -33,5 +33,5 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/inflection_exclude_table_names/postgresql/pgx/v5/go/db.go
+++ b/internal/endtoend/testdata/inflection_exclude_table_names/postgresql/pgx/v5/go/db.go
@@ -30,3 +30,8 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/inflection_exclude_table_names/postgresql/pgx/v5/go/query.sql.go
+++ b/internal/endtoend/testdata/inflection_exclude_table_names/postgresql/pgx/v5/go/query.sql.go
@@ -13,8 +13,10 @@ const deleteBarByID = `-- name: DeleteBarByID :one
 DELETE FROM bars WHERE id = $1 RETURNING id, name
 `
 
-func (q *Queries) DeleteBarByID(ctx context.Context, id int32) (Bar, error) {
-	row := q.db.QueryRow(ctx, deleteBarByID, id)
+func (q *Queries) DeleteBarByID(ctx context.Context, id int32, aq ...AdditionalQuery) (Bar, error) {
+	query := deleteBarByID
+	queryParams := []interface{}{id}
+	row := q.db.QueryRow(ctx, query, queryParams...)
 	var i Bar
 	err := row.Scan(&i.ID, &i.Name)
 	return i, err
@@ -24,8 +26,10 @@ const deleteExclusionByID = `-- name: DeleteExclusionByID :one
 DELETE FROM exclusions WHERE id = $1 RETURNING id, name
 `
 
-func (q *Queries) DeleteExclusionByID(ctx context.Context, id int32) (Exclusions, error) {
-	row := q.db.QueryRow(ctx, deleteExclusionByID, id)
+func (q *Queries) DeleteExclusionByID(ctx context.Context, id int32, aq ...AdditionalQuery) (Exclusions, error) {
+	query := deleteExclusionByID
+	queryParams := []interface{}{id}
+	row := q.db.QueryRow(ctx, query, queryParams...)
 	var i Exclusions
 	err := row.Scan(&i.ID, &i.Name)
 	return i, err
@@ -35,8 +39,10 @@ const deleteMyDataByID = `-- name: DeleteMyDataByID :one
 DELETE FROM my_data WHERE id = $1 RETURNING id, name
 `
 
-func (q *Queries) DeleteMyDataByID(ctx context.Context, id int32) (MyData, error) {
-	row := q.db.QueryRow(ctx, deleteMyDataByID, id)
+func (q *Queries) DeleteMyDataByID(ctx context.Context, id int32, aq ...AdditionalQuery) (MyData, error) {
+	query := deleteMyDataByID
+	queryParams := []interface{}{id}
+	row := q.db.QueryRow(ctx, query, queryParams...)
 	var i MyData
 	err := row.Scan(&i.ID, &i.Name)
 	return i, err

--- a/internal/endtoend/testdata/insert_cte/pgx/v4/go/db.go
+++ b/internal/endtoend/testdata/insert_cte/pgx/v4/go/db.go
@@ -33,5 +33,5 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/insert_cte/pgx/v4/go/db.go
+++ b/internal/endtoend/testdata/insert_cte/pgx/v4/go/db.go
@@ -30,3 +30,8 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/insert_cte/pgx/v4/go/query.sql.go
+++ b/internal/endtoend/testdata/insert_cte/pgx/v4/go/query.sql.go
@@ -32,13 +32,15 @@ type InsertCodeParams struct {
 }
 
 // FILE: query.sql
-func (q *Queries) InsertCode(ctx context.Context, arg InsertCodeParams) (Td3TestCode, error) {
-	row := q.db.QueryRow(ctx, insertCode,
+func (q *Queries) InsertCode(ctx context.Context, arg InsertCodeParams, aq ...AdditionalQuery) (Td3TestCode, error) {
+	query := insertCode
+	queryParams := []interface{}{
 		arg.CreatedBy,
 		arg.Code,
 		arg.Hash,
 		arg.TestID,
-	)
+	}
+	row := q.db.QueryRow(ctx, query, queryParams...)
 	var i Td3TestCode
 	err := row.Scan(
 		&i.ID,

--- a/internal/endtoend/testdata/insert_cte/pgx/v5/go/db.go
+++ b/internal/endtoend/testdata/insert_cte/pgx/v5/go/db.go
@@ -33,5 +33,5 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/insert_cte/pgx/v5/go/db.go
+++ b/internal/endtoend/testdata/insert_cte/pgx/v5/go/db.go
@@ -30,3 +30,8 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/insert_cte/pgx/v5/go/query.sql.go
+++ b/internal/endtoend/testdata/insert_cte/pgx/v5/go/query.sql.go
@@ -33,13 +33,15 @@ type InsertCodeParams struct {
 }
 
 // FILE: query.sql
-func (q *Queries) InsertCode(ctx context.Context, arg InsertCodeParams) (Td3TestCode, error) {
-	row := q.db.QueryRow(ctx, insertCode,
+func (q *Queries) InsertCode(ctx context.Context, arg InsertCodeParams, aq ...AdditionalQuery) (Td3TestCode, error) {
+	query := insertCode
+	queryParams := []interface{}{
 		arg.CreatedBy,
 		arg.Code,
 		arg.Hash,
 		arg.TestID,
-	)
+	}
+	row := q.db.QueryRow(ctx, query, queryParams...)
 	var i Td3TestCode
 	err := row.Scan(
 		&i.ID,

--- a/internal/endtoend/testdata/insert_cte/stdlib/go/db.go
+++ b/internal/endtoend/testdata/insert_cte/stdlib/go/db.go
@@ -29,3 +29,8 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/insert_cte/stdlib/go/db.go
+++ b/internal/endtoend/testdata/insert_cte/stdlib/go/db.go
@@ -32,5 +32,5 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/insert_cte/stdlib/go/query.sql.go
+++ b/internal/endtoend/testdata/insert_cte/stdlib/go/query.sql.go
@@ -32,13 +32,21 @@ type InsertCodeParams struct {
 }
 
 // FILE: query.sql
-func (q *Queries) InsertCode(ctx context.Context, arg InsertCodeParams) (Td3TestCode, error) {
-	row := q.db.QueryRowContext(ctx, insertCode,
+func (q *Queries) InsertCode(ctx context.Context, arg InsertCodeParams, aq ...AdditionalQuery) (Td3TestCode, error) {
+	query := insertCode
+	queryParams := []interface{}{
 		arg.CreatedBy,
 		arg.Code,
 		arg.Hash,
 		arg.TestID,
-	)
+	}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	row := q.db.QueryRowContext(ctx, query, queryParams...)
 	var i Td3TestCode
 	err := row.Scan(
 		&i.ID,

--- a/internal/endtoend/testdata/insert_select/mysql/go/db.go
+++ b/internal/endtoend/testdata/insert_select/mysql/go/db.go
@@ -29,3 +29,8 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/insert_select/mysql/go/db.go
+++ b/internal/endtoend/testdata/insert_select/mysql/go/db.go
@@ -32,5 +32,5 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/insert_select/mysql/go/query.sql.go
+++ b/internal/endtoend/testdata/insert_select/mysql/go/query.sql.go
@@ -21,6 +21,9 @@ type InsertSelectParams struct {
 }
 
 func (q *Queries) InsertSelect(ctx context.Context, arg InsertSelectParams) error {
-	_, err := q.db.ExecContext(ctx, insertSelect, arg.Meta, arg.Ready)
+	query := insertSelect
+	queryParams := []interface{}{arg.Meta, arg.Ready}
+
+	_, err := q.db.ExecContext(ctx, query, queryParams...)
 	return err
 }

--- a/internal/endtoend/testdata/insert_select/postgresql/pgx/v4/go/db.go
+++ b/internal/endtoend/testdata/insert_select/postgresql/pgx/v4/go/db.go
@@ -33,5 +33,5 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/insert_select/postgresql/pgx/v4/go/db.go
+++ b/internal/endtoend/testdata/insert_select/postgresql/pgx/v4/go/db.go
@@ -30,3 +30,8 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/insert_select/postgresql/pgx/v5/go/db.go
+++ b/internal/endtoend/testdata/insert_select/postgresql/pgx/v5/go/db.go
@@ -33,5 +33,5 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/insert_select/postgresql/pgx/v5/go/db.go
+++ b/internal/endtoend/testdata/insert_select/postgresql/pgx/v5/go/db.go
@@ -30,3 +30,8 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/insert_select/postgresql/stdlib/go/db.go
+++ b/internal/endtoend/testdata/insert_select/postgresql/stdlib/go/db.go
@@ -29,3 +29,8 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/insert_select/postgresql/stdlib/go/db.go
+++ b/internal/endtoend/testdata/insert_select/postgresql/stdlib/go/db.go
@@ -32,5 +32,5 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/insert_select/postgresql/stdlib/go/query.sql.go
+++ b/internal/endtoend/testdata/insert_select/postgresql/stdlib/go/query.sql.go
@@ -21,6 +21,9 @@ type InsertSelectParams struct {
 }
 
 func (q *Queries) InsertSelect(ctx context.Context, arg InsertSelectParams) error {
-	_, err := q.db.ExecContext(ctx, insertSelect, arg.Meta, arg.Ready)
+	query := insertSelect
+	queryParams := []interface{}{arg.Meta, arg.Ready}
+
+	_, err := q.db.ExecContext(ctx, query, queryParams...)
 	return err
 }

--- a/internal/endtoend/testdata/insert_select/sqlite/go/db.go
+++ b/internal/endtoend/testdata/insert_select/sqlite/go/db.go
@@ -29,3 +29,8 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/insert_select/sqlite/go/db.go
+++ b/internal/endtoend/testdata/insert_select/sqlite/go/db.go
@@ -32,5 +32,5 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/insert_select/sqlite/go/query.sql.go
+++ b/internal/endtoend/testdata/insert_select/sqlite/go/query.sql.go
@@ -21,6 +21,9 @@ type InsertSelectParams struct {
 }
 
 func (q *Queries) InsertSelect(ctx context.Context, arg InsertSelectParams) error {
-	_, err := q.db.ExecContext(ctx, insertSelect, arg.Meta, arg.Ready)
+	query := insertSelect
+	queryParams := []interface{}{arg.Meta, arg.Ready}
+
+	_, err := q.db.ExecContext(ctx, query, queryParams...)
 	return err
 }

--- a/internal/endtoend/testdata/insert_values/mysql/go/db.go
+++ b/internal/endtoend/testdata/insert_values/mysql/go/db.go
@@ -29,3 +29,8 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/insert_values/mysql/go/db.go
+++ b/internal/endtoend/testdata/insert_values/mysql/go/db.go
@@ -32,5 +32,5 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/insert_values/mysql/go/query.sql.go
+++ b/internal/endtoend/testdata/insert_values/mysql/go/query.sql.go
@@ -20,6 +20,9 @@ type InsertValuesParams struct {
 }
 
 func (q *Queries) InsertValues(ctx context.Context, arg InsertValuesParams) error {
-	_, err := q.db.ExecContext(ctx, insertValues, arg.A, arg.B)
+	query := insertValues
+	queryParams := []interface{}{arg.A, arg.B}
+
+	_, err := q.db.ExecContext(ctx, query, queryParams...)
 	return err
 }

--- a/internal/endtoend/testdata/insert_values/postgresql/pgx/v4/go/db.go
+++ b/internal/endtoend/testdata/insert_values/postgresql/pgx/v4/go/db.go
@@ -33,5 +33,5 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/insert_values/postgresql/pgx/v4/go/db.go
+++ b/internal/endtoend/testdata/insert_values/postgresql/pgx/v4/go/db.go
@@ -30,3 +30,8 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/insert_values/postgresql/pgx/v5/go/db.go
+++ b/internal/endtoend/testdata/insert_values/postgresql/pgx/v5/go/db.go
@@ -33,5 +33,5 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/insert_values/postgresql/pgx/v5/go/db.go
+++ b/internal/endtoend/testdata/insert_values/postgresql/pgx/v5/go/db.go
@@ -30,3 +30,8 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/insert_values/postgresql/stdlib/go/db.go
+++ b/internal/endtoend/testdata/insert_values/postgresql/stdlib/go/db.go
@@ -29,3 +29,8 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/insert_values/postgresql/stdlib/go/db.go
+++ b/internal/endtoend/testdata/insert_values/postgresql/stdlib/go/db.go
@@ -32,5 +32,5 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/insert_values/postgresql/stdlib/go/query.sql.go
+++ b/internal/endtoend/testdata/insert_values/postgresql/stdlib/go/query.sql.go
@@ -20,6 +20,9 @@ type InsertValuesParams struct {
 }
 
 func (q *Queries) InsertValues(ctx context.Context, arg InsertValuesParams) error {
-	_, err := q.db.ExecContext(ctx, insertValues, arg.A, arg.B)
+	query := insertValues
+	queryParams := []interface{}{arg.A, arg.B}
+
+	_, err := q.db.ExecContext(ctx, query, queryParams...)
 	return err
 }

--- a/internal/endtoend/testdata/insert_values/sqlite/go/db.go
+++ b/internal/endtoend/testdata/insert_values/sqlite/go/db.go
@@ -29,3 +29,8 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/insert_values/sqlite/go/db.go
+++ b/internal/endtoend/testdata/insert_values/sqlite/go/db.go
@@ -32,5 +32,5 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/insert_values/sqlite/go/query.sql.go
+++ b/internal/endtoend/testdata/insert_values/sqlite/go/query.sql.go
@@ -20,6 +20,9 @@ type InsertValuesParams struct {
 }
 
 func (q *Queries) InsertValues(ctx context.Context, arg InsertValuesParams) error {
-	_, err := q.db.ExecContext(ctx, insertValues, arg.A, arg.B)
+	query := insertValues
+	queryParams := []interface{}{arg.A, arg.B}
+
+	_, err := q.db.ExecContext(ctx, query, queryParams...)
 	return err
 }

--- a/internal/endtoend/testdata/insert_values_public/mysql/go/db.go
+++ b/internal/endtoend/testdata/insert_values_public/mysql/go/db.go
@@ -29,3 +29,8 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/insert_values_public/mysql/go/db.go
+++ b/internal/endtoend/testdata/insert_values_public/mysql/go/db.go
@@ -32,5 +32,5 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/insert_values_public/mysql/go/query.sql.go
+++ b/internal/endtoend/testdata/insert_values_public/mysql/go/query.sql.go
@@ -20,6 +20,9 @@ type InsertValuesParams struct {
 }
 
 func (q *Queries) InsertValues(ctx context.Context, arg InsertValuesParams) error {
-	_, err := q.db.ExecContext(ctx, insertValues, arg.A, arg.B)
+	query := insertValues
+	queryParams := []interface{}{arg.A, arg.B}
+
+	_, err := q.db.ExecContext(ctx, query, queryParams...)
 	return err
 }

--- a/internal/endtoend/testdata/insert_values_public/postgresql/pgx/v4/go/db.go
+++ b/internal/endtoend/testdata/insert_values_public/postgresql/pgx/v4/go/db.go
@@ -33,5 +33,5 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/insert_values_public/postgresql/pgx/v4/go/db.go
+++ b/internal/endtoend/testdata/insert_values_public/postgresql/pgx/v4/go/db.go
@@ -30,3 +30,8 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/insert_values_public/postgresql/pgx/v5/go/db.go
+++ b/internal/endtoend/testdata/insert_values_public/postgresql/pgx/v5/go/db.go
@@ -33,5 +33,5 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/insert_values_public/postgresql/pgx/v5/go/db.go
+++ b/internal/endtoend/testdata/insert_values_public/postgresql/pgx/v5/go/db.go
@@ -30,3 +30,8 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/insert_values_public/postgresql/stdlib/go/db.go
+++ b/internal/endtoend/testdata/insert_values_public/postgresql/stdlib/go/db.go
@@ -29,3 +29,8 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/insert_values_public/postgresql/stdlib/go/db.go
+++ b/internal/endtoend/testdata/insert_values_public/postgresql/stdlib/go/db.go
@@ -32,5 +32,5 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/insert_values_public/postgresql/stdlib/go/query.sql.go
+++ b/internal/endtoend/testdata/insert_values_public/postgresql/stdlib/go/query.sql.go
@@ -20,6 +20,9 @@ type InsertValuesParams struct {
 }
 
 func (q *Queries) InsertValues(ctx context.Context, arg InsertValuesParams) error {
-	_, err := q.db.ExecContext(ctx, insertValues, arg.A, arg.B)
+	query := insertValues
+	queryParams := []interface{}{arg.A, arg.B}
+
+	_, err := q.db.ExecContext(ctx, query, queryParams...)
 	return err
 }

--- a/internal/endtoend/testdata/interval/pgx/v4/go/db.go
+++ b/internal/endtoend/testdata/interval/pgx/v4/go/db.go
@@ -33,5 +33,5 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/interval/pgx/v4/go/db.go
+++ b/internal/endtoend/testdata/interval/pgx/v4/go/db.go
@@ -30,3 +30,8 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/interval/pgx/v4/go/query.sql.go
+++ b/internal/endtoend/testdata/interval/pgx/v4/go/query.sql.go
@@ -13,8 +13,16 @@ const get = `-- name: Get :many
 SELECT bar, "interval" FROM foo LIMIT $1
 `
 
-func (q *Queries) Get(ctx context.Context, limit int32) ([]Foo, error) {
-	rows, err := q.db.Query(ctx, get, limit)
+func (q *Queries) Get(ctx context.Context, limit int32, aq ...AdditionalQuery) ([]Foo, error) {
+	query := get
+	queryParams := []interface{}{limit}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.Query(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/endtoend/testdata/interval/pgx/v5/go/db.go
+++ b/internal/endtoend/testdata/interval/pgx/v5/go/db.go
@@ -33,5 +33,5 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/interval/pgx/v5/go/db.go
+++ b/internal/endtoend/testdata/interval/pgx/v5/go/db.go
@@ -30,3 +30,8 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/interval/pgx/v5/go/query.sql.go
+++ b/internal/endtoend/testdata/interval/pgx/v5/go/query.sql.go
@@ -13,8 +13,16 @@ const get = `-- name: Get :many
 SELECT bar, "interval" FROM foo LIMIT $1
 `
 
-func (q *Queries) Get(ctx context.Context, limit int32) ([]Foo, error) {
-	rows, err := q.db.Query(ctx, get, limit)
+func (q *Queries) Get(ctx context.Context, limit int32, aq ...AdditionalQuery) ([]Foo, error) {
+	query := get
+	queryParams := []interface{}{limit}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.Query(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/endtoend/testdata/interval/stdlib/go/db.go
+++ b/internal/endtoend/testdata/interval/stdlib/go/db.go
@@ -29,3 +29,8 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/interval/stdlib/go/db.go
+++ b/internal/endtoend/testdata/interval/stdlib/go/db.go
@@ -32,5 +32,5 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/interval/stdlib/go/query.sql.go
+++ b/internal/endtoend/testdata/interval/stdlib/go/query.sql.go
@@ -13,8 +13,16 @@ const get = `-- name: Get :many
 SELECT bar, "interval" FROM foo LIMIT $1
 `
 
-func (q *Queries) Get(ctx context.Context, limit int32) ([]Foo, error) {
-	rows, err := q.db.QueryContext(ctx, get, limit)
+func (q *Queries) Get(ctx context.Context, limit int32, aq ...AdditionalQuery) ([]Foo, error) {
+	query := get
+	queryParams := []interface{}{limit}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.QueryContext(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/endtoend/testdata/join_alias/mysql/go/db.go
+++ b/internal/endtoend/testdata/join_alias/mysql/go/db.go
@@ -29,3 +29,8 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/join_alias/mysql/go/db.go
+++ b/internal/endtoend/testdata/join_alias/mysql/go/db.go
@@ -32,5 +32,5 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/join_alias/mysql/go/query.sql.go
+++ b/internal/endtoend/testdata/join_alias/mysql/go/query.sql.go
@@ -23,8 +23,16 @@ type AliasExpandRow struct {
 	Title sql.NullString
 }
 
-func (q *Queries) AliasExpand(ctx context.Context, id uint64) ([]AliasExpandRow, error) {
-	rows, err := q.db.QueryContext(ctx, aliasExpand, id)
+func (q *Queries) AliasExpand(ctx context.Context, id uint64, aq ...AdditionalQuery) ([]AliasExpandRow, error) {
+	query := aliasExpand
+	queryParams := []interface{}{id}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.QueryContext(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}
@@ -58,8 +66,16 @@ type AliasJoinRow struct {
 	Title sql.NullString
 }
 
-func (q *Queries) AliasJoin(ctx context.Context, id uint64) ([]AliasJoinRow, error) {
-	rows, err := q.db.QueryContext(ctx, aliasJoin, id)
+func (q *Queries) AliasJoin(ctx context.Context, id uint64, aq ...AdditionalQuery) ([]AliasJoinRow, error) {
+	query := aliasJoin
+	queryParams := []interface{}{id}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.QueryContext(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/endtoend/testdata/join_alias/postgresql/pgx/v4/go/db.go
+++ b/internal/endtoend/testdata/join_alias/postgresql/pgx/v4/go/db.go
@@ -33,5 +33,5 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/join_alias/postgresql/pgx/v4/go/db.go
+++ b/internal/endtoend/testdata/join_alias/postgresql/pgx/v4/go/db.go
@@ -30,3 +30,8 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/join_alias/postgresql/pgx/v4/go/query.sql.go
+++ b/internal/endtoend/testdata/join_alias/postgresql/pgx/v4/go/query.sql.go
@@ -23,8 +23,16 @@ type AliasExpandRow struct {
 	Title sql.NullString
 }
 
-func (q *Queries) AliasExpand(ctx context.Context, id int32) ([]AliasExpandRow, error) {
-	rows, err := q.db.Query(ctx, aliasExpand, id)
+func (q *Queries) AliasExpand(ctx context.Context, id int32, aq ...AdditionalQuery) ([]AliasExpandRow, error) {
+	query := aliasExpand
+	queryParams := []interface{}{id}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.Query(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}
@@ -55,8 +63,16 @@ type AliasJoinRow struct {
 	Title sql.NullString
 }
 
-func (q *Queries) AliasJoin(ctx context.Context, id int32) ([]AliasJoinRow, error) {
-	rows, err := q.db.Query(ctx, aliasJoin, id)
+func (q *Queries) AliasJoin(ctx context.Context, id int32, aq ...AdditionalQuery) ([]AliasJoinRow, error) {
+	query := aliasJoin
+	queryParams := []interface{}{id}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.Query(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/endtoend/testdata/join_alias/postgresql/pgx/v5/go/db.go
+++ b/internal/endtoend/testdata/join_alias/postgresql/pgx/v5/go/db.go
@@ -33,5 +33,5 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/join_alias/postgresql/pgx/v5/go/db.go
+++ b/internal/endtoend/testdata/join_alias/postgresql/pgx/v5/go/db.go
@@ -30,3 +30,8 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/join_alias/postgresql/pgx/v5/go/query.sql.go
+++ b/internal/endtoend/testdata/join_alias/postgresql/pgx/v5/go/query.sql.go
@@ -24,8 +24,16 @@ type AliasExpandRow struct {
 	Title pgtype.Text
 }
 
-func (q *Queries) AliasExpand(ctx context.Context, id int32) ([]AliasExpandRow, error) {
-	rows, err := q.db.Query(ctx, aliasExpand, id)
+func (q *Queries) AliasExpand(ctx context.Context, id int32, aq ...AdditionalQuery) ([]AliasExpandRow, error) {
+	query := aliasExpand
+	queryParams := []interface{}{id}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.Query(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}
@@ -56,8 +64,16 @@ type AliasJoinRow struct {
 	Title pgtype.Text
 }
 
-func (q *Queries) AliasJoin(ctx context.Context, id int32) ([]AliasJoinRow, error) {
-	rows, err := q.db.Query(ctx, aliasJoin, id)
+func (q *Queries) AliasJoin(ctx context.Context, id int32, aq ...AdditionalQuery) ([]AliasJoinRow, error) {
+	query := aliasJoin
+	queryParams := []interface{}{id}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.Query(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/endtoend/testdata/join_alias/postgresql/stdlib/go/db.go
+++ b/internal/endtoend/testdata/join_alias/postgresql/stdlib/go/db.go
@@ -29,3 +29,8 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/join_alias/postgresql/stdlib/go/db.go
+++ b/internal/endtoend/testdata/join_alias/postgresql/stdlib/go/db.go
@@ -32,5 +32,5 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/join_alias/postgresql/stdlib/go/query.sql.go
+++ b/internal/endtoend/testdata/join_alias/postgresql/stdlib/go/query.sql.go
@@ -23,8 +23,16 @@ type AliasExpandRow struct {
 	Title sql.NullString
 }
 
-func (q *Queries) AliasExpand(ctx context.Context, id int32) ([]AliasExpandRow, error) {
-	rows, err := q.db.QueryContext(ctx, aliasExpand, id)
+func (q *Queries) AliasExpand(ctx context.Context, id int32, aq ...AdditionalQuery) ([]AliasExpandRow, error) {
+	query := aliasExpand
+	queryParams := []interface{}{id}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.QueryContext(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}
@@ -58,8 +66,16 @@ type AliasJoinRow struct {
 	Title sql.NullString
 }
 
-func (q *Queries) AliasJoin(ctx context.Context, id int32) ([]AliasJoinRow, error) {
-	rows, err := q.db.QueryContext(ctx, aliasJoin, id)
+func (q *Queries) AliasJoin(ctx context.Context, id int32, aq ...AdditionalQuery) ([]AliasJoinRow, error) {
+	query := aliasJoin
+	queryParams := []interface{}{id}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.QueryContext(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/endtoend/testdata/join_alias/sqlite/go/db.go
+++ b/internal/endtoend/testdata/join_alias/sqlite/go/db.go
@@ -29,3 +29,8 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/join_alias/sqlite/go/db.go
+++ b/internal/endtoend/testdata/join_alias/sqlite/go/db.go
@@ -32,5 +32,5 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/join_alias/sqlite/go/query.sql.go
+++ b/internal/endtoend/testdata/join_alias/sqlite/go/query.sql.go
@@ -23,8 +23,16 @@ type AliasExpandRow struct {
 	Title sql.NullString
 }
 
-func (q *Queries) AliasExpand(ctx context.Context, id int64) ([]AliasExpandRow, error) {
-	rows, err := q.db.QueryContext(ctx, aliasExpand, id)
+func (q *Queries) AliasExpand(ctx context.Context, id int64, aq ...AdditionalQuery) ([]AliasExpandRow, error) {
+	query := aliasExpand
+	queryParams := []interface{}{id}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.QueryContext(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}
@@ -58,8 +66,16 @@ type AliasJoinRow struct {
 	Title sql.NullString
 }
 
-func (q *Queries) AliasJoin(ctx context.Context, id int64) ([]AliasJoinRow, error) {
-	rows, err := q.db.QueryContext(ctx, aliasJoin, id)
+func (q *Queries) AliasJoin(ctx context.Context, id int64, aq ...AdditionalQuery) ([]AliasJoinRow, error) {
+	query := aliasJoin
+	queryParams := []interface{}{id}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.QueryContext(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/endtoend/testdata/join_clauses_order/postgresql/go/db.go
+++ b/internal/endtoend/testdata/join_clauses_order/postgresql/go/db.go
@@ -29,3 +29,8 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/join_clauses_order/postgresql/go/db.go
+++ b/internal/endtoend/testdata/join_clauses_order/postgresql/go/db.go
@@ -32,5 +32,5 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/join_clauses_order/postgresql/go/query.sql.go
+++ b/internal/endtoend/testdata/join_clauses_order/postgresql/go/query.sql.go
@@ -23,8 +23,16 @@ type TestInnerLeftRow struct {
 	C sql.NullString
 }
 
-func (q *Queries) TestInnerLeft(ctx context.Context) ([]TestInnerLeftRow, error) {
-	rows, err := q.db.QueryContext(ctx, testInnerLeft)
+func (q *Queries) TestInnerLeft(ctx context.Context, aq ...AdditionalQuery) ([]TestInnerLeftRow, error) {
+	query := testInnerLeft
+	queryParams := []interface{}{}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.QueryContext(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}
@@ -63,8 +71,16 @@ type TestInnerLeftInnerLeftRow struct {
 	E sql.NullString
 }
 
-func (q *Queries) TestInnerLeftInnerLeft(ctx context.Context) ([]TestInnerLeftInnerLeftRow, error) {
-	rows, err := q.db.QueryContext(ctx, testInnerLeftInnerLeft)
+func (q *Queries) TestInnerLeftInnerLeft(ctx context.Context, aq ...AdditionalQuery) ([]TestInnerLeftInnerLeftRow, error) {
+	query := testInnerLeftInnerLeft
+	queryParams := []interface{}{}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.QueryContext(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}
@@ -105,8 +121,16 @@ type TestLeftInnerRow struct {
 	C string
 }
 
-func (q *Queries) TestLeftInner(ctx context.Context) ([]TestLeftInnerRow, error) {
-	rows, err := q.db.QueryContext(ctx, testLeftInner)
+func (q *Queries) TestLeftInner(ctx context.Context, aq ...AdditionalQuery) ([]TestLeftInnerRow, error) {
+	query := testLeftInner
+	queryParams := []interface{}{}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.QueryContext(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}
@@ -145,8 +169,16 @@ type TestLeftInnerLeftInnerRow struct {
 	E string
 }
 
-func (q *Queries) TestLeftInnerLeftInner(ctx context.Context) ([]TestLeftInnerLeftInnerRow, error) {
-	rows, err := q.db.QueryContext(ctx, testLeftInnerLeftInner)
+func (q *Queries) TestLeftInnerLeftInner(ctx context.Context, aq ...AdditionalQuery) ([]TestLeftInnerLeftInnerRow, error) {
+	query := testLeftInnerLeftInner
+	queryParams := []interface{}{}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.QueryContext(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/endtoend/testdata/join_from/mysql/go/db.go
+++ b/internal/endtoend/testdata/join_from/mysql/go/db.go
@@ -29,3 +29,8 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/join_from/mysql/go/db.go
+++ b/internal/endtoend/testdata/join_from/mysql/go/db.go
@@ -32,5 +32,5 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/join_from/mysql/go/query.sql.go
+++ b/internal/endtoend/testdata/join_from/mysql/go/query.sql.go
@@ -13,8 +13,16 @@ const multiFrom = `-- name: MultiFrom :many
 SELECT email FROM bar, foo WHERE login = ?
 `
 
-func (q *Queries) MultiFrom(ctx context.Context, login string) ([]string, error) {
-	rows, err := q.db.QueryContext(ctx, multiFrom, login)
+func (q *Queries) MultiFrom(ctx context.Context, login string, aq ...AdditionalQuery) ([]string, error) {
+	query := multiFrom
+	queryParams := []interface{}{login}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.QueryContext(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/endtoend/testdata/join_from/postgresql/pgx/v4/go/db.go
+++ b/internal/endtoend/testdata/join_from/postgresql/pgx/v4/go/db.go
@@ -33,5 +33,5 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/join_from/postgresql/pgx/v4/go/db.go
+++ b/internal/endtoend/testdata/join_from/postgresql/pgx/v4/go/db.go
@@ -30,3 +30,8 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/join_from/postgresql/pgx/v4/go/query.sql.go
+++ b/internal/endtoend/testdata/join_from/postgresql/pgx/v4/go/query.sql.go
@@ -13,8 +13,16 @@ const multiFrom = `-- name: MultiFrom :many
 SELECT email FROM bar, foo WHERE login = $1
 `
 
-func (q *Queries) MultiFrom(ctx context.Context, login string) ([]string, error) {
-	rows, err := q.db.Query(ctx, multiFrom, login)
+func (q *Queries) MultiFrom(ctx context.Context, login string, aq ...AdditionalQuery) ([]string, error) {
+	query := multiFrom
+	queryParams := []interface{}{login}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.Query(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/endtoend/testdata/join_from/postgresql/pgx/v5/go/db.go
+++ b/internal/endtoend/testdata/join_from/postgresql/pgx/v5/go/db.go
@@ -33,5 +33,5 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/join_from/postgresql/pgx/v5/go/db.go
+++ b/internal/endtoend/testdata/join_from/postgresql/pgx/v5/go/db.go
@@ -30,3 +30,8 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/join_from/postgresql/pgx/v5/go/query.sql.go
+++ b/internal/endtoend/testdata/join_from/postgresql/pgx/v5/go/query.sql.go
@@ -13,8 +13,16 @@ const multiFrom = `-- name: MultiFrom :many
 SELECT email FROM bar, foo WHERE login = $1
 `
 
-func (q *Queries) MultiFrom(ctx context.Context, login string) ([]string, error) {
-	rows, err := q.db.Query(ctx, multiFrom, login)
+func (q *Queries) MultiFrom(ctx context.Context, login string, aq ...AdditionalQuery) ([]string, error) {
+	query := multiFrom
+	queryParams := []interface{}{login}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.Query(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/endtoend/testdata/join_from/postgresql/stdlib/go/db.go
+++ b/internal/endtoend/testdata/join_from/postgresql/stdlib/go/db.go
@@ -29,3 +29,8 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/join_from/postgresql/stdlib/go/db.go
+++ b/internal/endtoend/testdata/join_from/postgresql/stdlib/go/db.go
@@ -32,5 +32,5 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/join_from/postgresql/stdlib/go/query.sql.go
+++ b/internal/endtoend/testdata/join_from/postgresql/stdlib/go/query.sql.go
@@ -13,8 +13,16 @@ const multiFrom = `-- name: MultiFrom :many
 SELECT email FROM bar, foo WHERE login = $1
 `
 
-func (q *Queries) MultiFrom(ctx context.Context, login string) ([]string, error) {
-	rows, err := q.db.QueryContext(ctx, multiFrom, login)
+func (q *Queries) MultiFrom(ctx context.Context, login string, aq ...AdditionalQuery) ([]string, error) {
+	query := multiFrom
+	queryParams := []interface{}{login}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.QueryContext(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/endtoend/testdata/join_from/sqlite/go/db.go
+++ b/internal/endtoend/testdata/join_from/sqlite/go/db.go
@@ -29,3 +29,8 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/join_from/sqlite/go/db.go
+++ b/internal/endtoend/testdata/join_from/sqlite/go/db.go
@@ -32,5 +32,5 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/join_from/sqlite/go/query.sql.go
+++ b/internal/endtoend/testdata/join_from/sqlite/go/query.sql.go
@@ -13,8 +13,16 @@ const multiFrom = `-- name: MultiFrom :many
 SELECT email FROM bar, foo WHERE login = ?
 `
 
-func (q *Queries) MultiFrom(ctx context.Context, login string) ([]string, error) {
-	rows, err := q.db.QueryContext(ctx, multiFrom, login)
+func (q *Queries) MultiFrom(ctx context.Context, login string, aq ...AdditionalQuery) ([]string, error) {
+	query := multiFrom
+	queryParams := []interface{}{login}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.QueryContext(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/endtoend/testdata/join_full/postgresql/go/db.go
+++ b/internal/endtoend/testdata/join_full/postgresql/go/db.go
@@ -29,3 +29,8 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/join_full/postgresql/go/db.go
+++ b/internal/endtoend/testdata/join_full/postgresql/go/db.go
@@ -32,5 +32,5 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/join_full/postgresql/go/query.sql.go
+++ b/internal/endtoend/testdata/join_full/postgresql/go/query.sql.go
@@ -23,8 +23,16 @@ type FullJoinRow struct {
 	ID_2  sql.NullInt32
 }
 
-func (q *Queries) FullJoin(ctx context.Context, id int32) ([]FullJoinRow, error) {
-	rows, err := q.db.QueryContext(ctx, fullJoin, id)
+func (q *Queries) FullJoin(ctx context.Context, id int32, aq ...AdditionalQuery) ([]FullJoinRow, error) {
+	query := fullJoin
+	queryParams := []interface{}{id}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.QueryContext(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/endtoend/testdata/join_group_by_alias/postgresql/stdlib/go/db.go
+++ b/internal/endtoend/testdata/join_group_by_alias/postgresql/stdlib/go/db.go
@@ -29,3 +29,8 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/join_group_by_alias/postgresql/stdlib/go/db.go
+++ b/internal/endtoend/testdata/join_group_by_alias/postgresql/stdlib/go/db.go
@@ -32,5 +32,5 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/join_group_by_alias/postgresql/stdlib/go/query.sql.go
+++ b/internal/endtoend/testdata/join_group_by_alias/postgresql/stdlib/go/query.sql.go
@@ -15,8 +15,16 @@ FROM foo a JOIN foo b ON a.email = b.email
 GROUP BY id
 `
 
-func (q *Queries) ColumnAsGroupBy(ctx context.Context) ([]string, error) {
-	rows, err := q.db.QueryContext(ctx, columnAsGroupBy)
+func (q *Queries) ColumnAsGroupBy(ctx context.Context, aq ...AdditionalQuery) ([]string, error) {
+	query := columnAsGroupBy
+	queryParams := []interface{}{}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.QueryContext(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/endtoend/testdata/join_inner/postgresql/go/db.go
+++ b/internal/endtoend/testdata/join_inner/postgresql/go/db.go
@@ -29,3 +29,8 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/join_inner/postgresql/go/db.go
+++ b/internal/endtoend/testdata/join_inner/postgresql/go/db.go
@@ -32,5 +32,5 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/join_inner/postgresql/go/query.sql.go
+++ b/internal/endtoend/testdata/join_inner/postgresql/go/query.sql.go
@@ -18,8 +18,16 @@ where handled_events.handler = $1
     for update of handled_events skip locked
 `
 
-func (q *Queries) SelectAllJoined(ctx context.Context, handler sql.NullString) ([]sql.NullInt32, error) {
-	rows, err := q.db.QueryContext(ctx, selectAllJoined, handler)
+func (q *Queries) SelectAllJoined(ctx context.Context, handler sql.NullString, aq ...AdditionalQuery) ([]sql.NullInt32, error) {
+	query := selectAllJoined
+	queryParams := []interface{}{handler}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.QueryContext(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}
@@ -49,8 +57,16 @@ where he.handler = $1
     for update of he skip locked
 `
 
-func (q *Queries) SelectAllJoinedAlias(ctx context.Context, handler sql.NullString) ([]sql.NullInt32, error) {
-	rows, err := q.db.QueryContext(ctx, selectAllJoinedAlias, handler)
+func (q *Queries) SelectAllJoinedAlias(ctx context.Context, handler sql.NullString, aq ...AdditionalQuery) ([]sql.NullInt32, error) {
+	query := selectAllJoinedAlias
+	queryParams := []interface{}{handler}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.QueryContext(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/endtoend/testdata/join_left/mysql/go/db.go
+++ b/internal/endtoend/testdata/join_left/mysql/go/db.go
@@ -29,3 +29,8 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/join_left/mysql/go/db.go
+++ b/internal/endtoend/testdata/join_left/mysql/go/db.go
@@ -32,5 +32,5 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/join_left/mysql/go/query.sql.go
+++ b/internal/endtoend/testdata/join_left/mysql/go/query.sql.go
@@ -27,8 +27,16 @@ type AllAuthorsRow struct {
 	ParentID_2 sql.NullInt32
 }
 
-func (q *Queries) AllAuthors(ctx context.Context) ([]AllAuthorsRow, error) {
-	rows, err := q.db.QueryContext(ctx, allAuthors)
+func (q *Queries) AllAuthors(ctx context.Context, aq ...AdditionalQuery) ([]AllAuthorsRow, error) {
+	query := allAuthors
+	queryParams := []interface{}{}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.QueryContext(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}
@@ -73,8 +81,16 @@ type AllAuthorsAliasesRow struct {
 	ParentID_2 sql.NullInt32
 }
 
-func (q *Queries) AllAuthorsAliases(ctx context.Context) ([]AllAuthorsAliasesRow, error) {
-	rows, err := q.db.QueryContext(ctx, allAuthorsAliases)
+func (q *Queries) AllAuthorsAliases(ctx context.Context, aq ...AdditionalQuery) ([]AllAuthorsAliasesRow, error) {
+	query := allAuthorsAliases
+	queryParams := []interface{}{}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.QueryContext(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}
@@ -119,8 +135,16 @@ type AllAuthorsAliases2Row struct {
 	ParentID_2 sql.NullInt32
 }
 
-func (q *Queries) AllAuthorsAliases2(ctx context.Context) ([]AllAuthorsAliases2Row, error) {
-	rows, err := q.db.QueryContext(ctx, allAuthorsAliases2)
+func (q *Queries) AllAuthorsAliases2(ctx context.Context, aq ...AdditionalQuery) ([]AllAuthorsAliases2Row, error) {
+	query := allAuthorsAliases2
+	queryParams := []interface{}{}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.QueryContext(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}
@@ -165,8 +189,16 @@ type AllSuperAuthorsRow struct {
 	SuperParentID sql.NullInt32
 }
 
-func (q *Queries) AllSuperAuthors(ctx context.Context) ([]AllSuperAuthorsRow, error) {
-	rows, err := q.db.QueryContext(ctx, allSuperAuthors)
+func (q *Queries) AllSuperAuthors(ctx context.Context, aq ...AdditionalQuery) ([]AllSuperAuthorsRow, error) {
+	query := allSuperAuthors
+	queryParams := []interface{}{}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.QueryContext(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}
@@ -211,8 +243,16 @@ type AllSuperAuthorsAliasesRow struct {
 	SuperParentID sql.NullInt32
 }
 
-func (q *Queries) AllSuperAuthorsAliases(ctx context.Context) ([]AllSuperAuthorsAliasesRow, error) {
-	rows, err := q.db.QueryContext(ctx, allSuperAuthorsAliases)
+func (q *Queries) AllSuperAuthorsAliases(ctx context.Context, aq ...AdditionalQuery) ([]AllSuperAuthorsAliasesRow, error) {
+	query := allSuperAuthorsAliases
+	queryParams := []interface{}{}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.QueryContext(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}
@@ -257,8 +297,16 @@ type AllSuperAuthorsAliases2Row struct {
 	SuperParentID sql.NullInt32
 }
 
-func (q *Queries) AllSuperAuthorsAliases2(ctx context.Context) ([]AllSuperAuthorsAliases2Row, error) {
-	rows, err := q.db.QueryContext(ctx, allSuperAuthorsAliases2)
+func (q *Queries) AllSuperAuthorsAliases2(ctx context.Context, aq ...AdditionalQuery) ([]AllSuperAuthorsAliases2Row, error) {
+	query := allSuperAuthorsAliases2
+	queryParams := []interface{}{}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.QueryContext(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}
@@ -301,8 +349,16 @@ type GetMayorsRow struct {
 	FullName string
 }
 
-func (q *Queries) GetMayors(ctx context.Context) ([]GetMayorsRow, error) {
-	rows, err := q.db.QueryContext(ctx, getMayors)
+func (q *Queries) GetMayors(ctx context.Context, aq ...AdditionalQuery) ([]GetMayorsRow, error) {
+	query := getMayors
+	queryParams := []interface{}{}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.QueryContext(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}
@@ -340,8 +396,16 @@ type GetMayorsOptionalRow struct {
 	FullName sql.NullString
 }
 
-func (q *Queries) GetMayorsOptional(ctx context.Context) ([]GetMayorsOptionalRow, error) {
-	rows, err := q.db.QueryContext(ctx, getMayorsOptional)
+func (q *Queries) GetMayorsOptional(ctx context.Context, aq ...AdditionalQuery) ([]GetMayorsOptionalRow, error) {
+	query := getMayorsOptional
+	queryParams := []interface{}{}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.QueryContext(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}
@@ -391,8 +455,16 @@ type GetSuggestedUsersByIDRow struct {
 	MediaHeight     sql.NullInt32
 }
 
-func (q *Queries) GetSuggestedUsersByID(ctx context.Context) ([]GetSuggestedUsersByIDRow, error) {
-	rows, err := q.db.QueryContext(ctx, getSuggestedUsersByID)
+func (q *Queries) GetSuggestedUsersByID(ctx context.Context, aq ...AdditionalQuery) ([]GetSuggestedUsersByIDRow, error) {
+	query := getSuggestedUsersByID
+	queryParams := []interface{}{}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.QueryContext(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/endtoend/testdata/join_left/postgresql/go/db.go
+++ b/internal/endtoend/testdata/join_left/postgresql/go/db.go
@@ -29,3 +29,8 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/join_left/postgresql/go/db.go
+++ b/internal/endtoend/testdata/join_left/postgresql/go/db.go
@@ -32,5 +32,5 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/join_left/postgresql/go/query.sql.go
+++ b/internal/endtoend/testdata/join_left/postgresql/go/query.sql.go
@@ -29,8 +29,16 @@ type AllAuthorsRow struct {
 	ParentID_2 sql.NullInt32
 }
 
-func (q *Queries) AllAuthors(ctx context.Context) ([]AllAuthorsRow, error) {
-	rows, err := q.db.QueryContext(ctx, allAuthors)
+func (q *Queries) AllAuthors(ctx context.Context, aq ...AdditionalQuery) ([]AllAuthorsRow, error) {
+	query := allAuthors
+	queryParams := []interface{}{}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.QueryContext(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}
@@ -75,8 +83,16 @@ type AllAuthorsAliasesRow struct {
 	ParentID_2 sql.NullInt32
 }
 
-func (q *Queries) AllAuthorsAliases(ctx context.Context) ([]AllAuthorsAliasesRow, error) {
-	rows, err := q.db.QueryContext(ctx, allAuthorsAliases)
+func (q *Queries) AllAuthorsAliases(ctx context.Context, aq ...AdditionalQuery) ([]AllAuthorsAliasesRow, error) {
+	query := allAuthorsAliases
+	queryParams := []interface{}{}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.QueryContext(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}
@@ -121,8 +137,16 @@ type AllAuthorsAliases2Row struct {
 	ParentID_2 sql.NullInt32
 }
 
-func (q *Queries) AllAuthorsAliases2(ctx context.Context) ([]AllAuthorsAliases2Row, error) {
-	rows, err := q.db.QueryContext(ctx, allAuthorsAliases2)
+func (q *Queries) AllAuthorsAliases2(ctx context.Context, aq ...AdditionalQuery) ([]AllAuthorsAliases2Row, error) {
+	query := allAuthorsAliases2
+	queryParams := []interface{}{}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.QueryContext(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}
@@ -167,8 +191,16 @@ type AllSuperAuthorsRow struct {
 	SuperParentID sql.NullInt32
 }
 
-func (q *Queries) AllSuperAuthors(ctx context.Context) ([]AllSuperAuthorsRow, error) {
-	rows, err := q.db.QueryContext(ctx, allSuperAuthors)
+func (q *Queries) AllSuperAuthors(ctx context.Context, aq ...AdditionalQuery) ([]AllSuperAuthorsRow, error) {
+	query := allSuperAuthors
+	queryParams := []interface{}{}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.QueryContext(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}
@@ -213,8 +245,16 @@ type AllSuperAuthorsAliasesRow struct {
 	SuperParentID sql.NullInt32
 }
 
-func (q *Queries) AllSuperAuthorsAliases(ctx context.Context) ([]AllSuperAuthorsAliasesRow, error) {
-	rows, err := q.db.QueryContext(ctx, allSuperAuthorsAliases)
+func (q *Queries) AllSuperAuthorsAliases(ctx context.Context, aq ...AdditionalQuery) ([]AllSuperAuthorsAliasesRow, error) {
+	query := allSuperAuthorsAliases
+	queryParams := []interface{}{}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.QueryContext(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}
@@ -259,8 +299,16 @@ type AllSuperAuthorsAliases2Row struct {
 	SuperParentID sql.NullInt32
 }
 
-func (q *Queries) AllSuperAuthorsAliases2(ctx context.Context) ([]AllSuperAuthorsAliases2Row, error) {
-	rows, err := q.db.QueryContext(ctx, allSuperAuthorsAliases2)
+func (q *Queries) AllSuperAuthorsAliases2(ctx context.Context, aq ...AdditionalQuery) ([]AllSuperAuthorsAliases2Row, error) {
+	query := allSuperAuthorsAliases2
+	queryParams := []interface{}{}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.QueryContext(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}
@@ -303,8 +351,16 @@ type GetMayorsRow struct {
 	FullName string
 }
 
-func (q *Queries) GetMayors(ctx context.Context) ([]GetMayorsRow, error) {
-	rows, err := q.db.QueryContext(ctx, getMayors)
+func (q *Queries) GetMayors(ctx context.Context, aq ...AdditionalQuery) ([]GetMayorsRow, error) {
+	query := getMayors
+	queryParams := []interface{}{}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.QueryContext(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}
@@ -340,8 +396,16 @@ type GetMayorsOptionalRow struct {
 	FullName sql.NullString
 }
 
-func (q *Queries) GetMayorsOptional(ctx context.Context) ([]GetMayorsOptionalRow, error) {
-	rows, err := q.db.QueryContext(ctx, getMayorsOptional)
+func (q *Queries) GetMayorsOptional(ctx context.Context, aq ...AdditionalQuery) ([]GetMayorsOptionalRow, error) {
+	query := getMayorsOptional
+	queryParams := []interface{}{}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.QueryContext(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}
@@ -397,8 +461,16 @@ type GetSuggestedUsersByIDRow struct {
 	MediaHeight     sql.NullInt32
 }
 
-func (q *Queries) GetSuggestedUsersByID(ctx context.Context, arg GetSuggestedUsersByIDParams) ([]GetSuggestedUsersByIDRow, error) {
-	rows, err := q.db.QueryContext(ctx, getSuggestedUsersByID, arg.UserID, arg.UserImit)
+func (q *Queries) GetSuggestedUsersByID(ctx context.Context, arg GetSuggestedUsersByIDParams, aq ...AdditionalQuery) ([]GetSuggestedUsersByIDRow, error) {
+	query := getSuggestedUsersByID
+	queryParams := []interface{}{arg.UserID, arg.UserImit}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.QueryContext(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/endtoend/testdata/join_left/sqlite/go/db.go
+++ b/internal/endtoend/testdata/join_left/sqlite/go/db.go
@@ -29,3 +29,8 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/join_left/sqlite/go/db.go
+++ b/internal/endtoend/testdata/join_left/sqlite/go/db.go
@@ -32,5 +32,5 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/join_left/sqlite/go/query.sql.go
+++ b/internal/endtoend/testdata/join_left/sqlite/go/query.sql.go
@@ -27,8 +27,16 @@ type AllAuthorsRow struct {
 	ParentID_2 sql.NullInt64
 }
 
-func (q *Queries) AllAuthors(ctx context.Context) ([]AllAuthorsRow, error) {
-	rows, err := q.db.QueryContext(ctx, allAuthors)
+func (q *Queries) AllAuthors(ctx context.Context, aq ...AdditionalQuery) ([]AllAuthorsRow, error) {
+	query := allAuthors
+	queryParams := []interface{}{}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.QueryContext(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}
@@ -73,8 +81,16 @@ type AllAuthorsAliasesRow struct {
 	ParentID_2 sql.NullInt64
 }
 
-func (q *Queries) AllAuthorsAliases(ctx context.Context) ([]AllAuthorsAliasesRow, error) {
-	rows, err := q.db.QueryContext(ctx, allAuthorsAliases)
+func (q *Queries) AllAuthorsAliases(ctx context.Context, aq ...AdditionalQuery) ([]AllAuthorsAliasesRow, error) {
+	query := allAuthorsAliases
+	queryParams := []interface{}{}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.QueryContext(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}
@@ -119,8 +135,16 @@ type AllAuthorsAliases2Row struct {
 	ParentID_2 sql.NullInt64
 }
 
-func (q *Queries) AllAuthorsAliases2(ctx context.Context) ([]AllAuthorsAliases2Row, error) {
-	rows, err := q.db.QueryContext(ctx, allAuthorsAliases2)
+func (q *Queries) AllAuthorsAliases2(ctx context.Context, aq ...AdditionalQuery) ([]AllAuthorsAliases2Row, error) {
+	query := allAuthorsAliases2
+	queryParams := []interface{}{}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.QueryContext(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}
@@ -165,8 +189,16 @@ type AllSuperAuthorsRow struct {
 	SuperParentID sql.NullInt64
 }
 
-func (q *Queries) AllSuperAuthors(ctx context.Context) ([]AllSuperAuthorsRow, error) {
-	rows, err := q.db.QueryContext(ctx, allSuperAuthors)
+func (q *Queries) AllSuperAuthors(ctx context.Context, aq ...AdditionalQuery) ([]AllSuperAuthorsRow, error) {
+	query := allSuperAuthors
+	queryParams := []interface{}{}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.QueryContext(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}
@@ -211,8 +243,16 @@ type AllSuperAuthorsAliasesRow struct {
 	SuperParentID sql.NullInt64
 }
 
-func (q *Queries) AllSuperAuthorsAliases(ctx context.Context) ([]AllSuperAuthorsAliasesRow, error) {
-	rows, err := q.db.QueryContext(ctx, allSuperAuthorsAliases)
+func (q *Queries) AllSuperAuthorsAliases(ctx context.Context, aq ...AdditionalQuery) ([]AllSuperAuthorsAliasesRow, error) {
+	query := allSuperAuthorsAliases
+	queryParams := []interface{}{}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.QueryContext(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}
@@ -257,8 +297,16 @@ type AllSuperAuthorsAliases2Row struct {
 	SuperParentID sql.NullInt64
 }
 
-func (q *Queries) AllSuperAuthorsAliases2(ctx context.Context) ([]AllSuperAuthorsAliases2Row, error) {
-	rows, err := q.db.QueryContext(ctx, allSuperAuthorsAliases2)
+func (q *Queries) AllSuperAuthorsAliases2(ctx context.Context, aq ...AdditionalQuery) ([]AllSuperAuthorsAliases2Row, error) {
+	query := allSuperAuthorsAliases2
+	queryParams := []interface{}{}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.QueryContext(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}
@@ -301,8 +349,16 @@ type GetMayorsRow struct {
 	FullName string
 }
 
-func (q *Queries) GetMayors(ctx context.Context) ([]GetMayorsRow, error) {
-	rows, err := q.db.QueryContext(ctx, getMayors)
+func (q *Queries) GetMayors(ctx context.Context, aq ...AdditionalQuery) ([]GetMayorsRow, error) {
+	query := getMayors
+	queryParams := []interface{}{}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.QueryContext(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}
@@ -340,8 +396,16 @@ type GetMayorsOptionalRow struct {
 	FullName string
 }
 
-func (q *Queries) GetMayorsOptional(ctx context.Context) ([]GetMayorsOptionalRow, error) {
-	rows, err := q.db.QueryContext(ctx, getMayorsOptional)
+func (q *Queries) GetMayorsOptional(ctx context.Context, aq ...AdditionalQuery) ([]GetMayorsOptionalRow, error) {
+	query := getMayorsOptional
+	queryParams := []interface{}{}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.QueryContext(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}
@@ -391,8 +455,16 @@ type GetSuggestedUsersByIDRow struct {
 	MediaHeight     int64
 }
 
-func (q *Queries) GetSuggestedUsersByID(ctx context.Context, userID int64) ([]GetSuggestedUsersByIDRow, error) {
-	rows, err := q.db.QueryContext(ctx, getSuggestedUsersByID, userID)
+func (q *Queries) GetSuggestedUsersByID(ctx context.Context, userID int64, aq ...AdditionalQuery) ([]GetSuggestedUsersByIDRow, error) {
+	query := getSuggestedUsersByID
+	queryParams := []interface{}{userID}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.QueryContext(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}
@@ -440,8 +512,16 @@ FROM    users_2
 WHERE   user_id != ?1
 `
 
-func (q *Queries) GetSuggestedUsersByID2(ctx context.Context, userID int64) ([]int64, error) {
-	rows, err := q.db.QueryContext(ctx, getSuggestedUsersByID2, userID)
+func (q *Queries) GetSuggestedUsersByID2(ctx context.Context, userID int64, aq ...AdditionalQuery) ([]int64, error) {
+	query := getSuggestedUsersByID2
+	queryParams := []interface{}{userID}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.QueryContext(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/endtoend/testdata/join_left_same_table/mysql/go/db.go
+++ b/internal/endtoend/testdata/join_left_same_table/mysql/go/db.go
@@ -29,3 +29,8 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/join_left_same_table/mysql/go/db.go
+++ b/internal/endtoend/testdata/join_left_same_table/mysql/go/db.go
@@ -32,5 +32,5 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/join_left_same_table/mysql/go/query.sql.go
+++ b/internal/endtoend/testdata/join_left_same_table/mysql/go/query.sql.go
@@ -27,8 +27,16 @@ type AllAuthorsRow struct {
 	AliasName sql.NullString
 }
 
-func (q *Queries) AllAuthors(ctx context.Context) ([]AllAuthorsRow, error) {
-	rows, err := q.db.QueryContext(ctx, allAuthors)
+func (q *Queries) AllAuthors(ctx context.Context, aq ...AdditionalQuery) ([]AllAuthorsRow, error) {
+	query := allAuthors
+	queryParams := []interface{}{}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.QueryContext(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/endtoend/testdata/join_left_same_table/postgres/go/db.go
+++ b/internal/endtoend/testdata/join_left_same_table/postgres/go/db.go
@@ -29,3 +29,8 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/join_left_same_table/postgres/go/db.go
+++ b/internal/endtoend/testdata/join_left_same_table/postgres/go/db.go
@@ -32,5 +32,5 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/join_left_same_table/postgres/go/query.sql.go
+++ b/internal/endtoend/testdata/join_left_same_table/postgres/go/query.sql.go
@@ -26,8 +26,16 @@ type AllAuthorsRow struct {
 	AliasName sql.NullString
 }
 
-func (q *Queries) AllAuthors(ctx context.Context) ([]AllAuthorsRow, error) {
-	rows, err := q.db.QueryContext(ctx, allAuthors)
+func (q *Queries) AllAuthors(ctx context.Context, aq ...AdditionalQuery) ([]AllAuthorsRow, error) {
+	query := allAuthors
+	queryParams := []interface{}{}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.QueryContext(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/endtoend/testdata/join_left_same_table/sqlite/go/db.go
+++ b/internal/endtoend/testdata/join_left_same_table/sqlite/go/db.go
@@ -29,3 +29,8 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/join_left_same_table/sqlite/go/db.go
+++ b/internal/endtoend/testdata/join_left_same_table/sqlite/go/db.go
@@ -32,5 +32,5 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/join_left_same_table/sqlite/go/query.sql.go
+++ b/internal/endtoend/testdata/join_left_same_table/sqlite/go/query.sql.go
@@ -26,8 +26,16 @@ type AllAuthorsRow struct {
 	AliasName string
 }
 
-func (q *Queries) AllAuthors(ctx context.Context) ([]AllAuthorsRow, error) {
-	rows, err := q.db.QueryContext(ctx, allAuthors)
+func (q *Queries) AllAuthors(ctx context.Context, aq ...AdditionalQuery) ([]AllAuthorsRow, error) {
+	query := allAuthors
+	queryParams := []interface{}{}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.QueryContext(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/endtoend/testdata/join_order_by_alias/postgresql/stdlib/go/db.go
+++ b/internal/endtoend/testdata/join_order_by_alias/postgresql/stdlib/go/db.go
@@ -29,3 +29,8 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/join_order_by_alias/postgresql/stdlib/go/db.go
+++ b/internal/endtoend/testdata/join_order_by_alias/postgresql/stdlib/go/db.go
@@ -32,5 +32,5 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/join_order_by_alias/postgresql/stdlib/go/query.sql.go
+++ b/internal/endtoend/testdata/join_order_by_alias/postgresql/stdlib/go/query.sql.go
@@ -15,8 +15,16 @@ FROM foo a JOIN foo b ON a.email = b.email
 ORDER BY id
 `
 
-func (q *Queries) ColumnAsOrderBy(ctx context.Context) ([]string, error) {
-	rows, err := q.db.QueryContext(ctx, columnAsOrderBy)
+func (q *Queries) ColumnAsOrderBy(ctx context.Context, aq ...AdditionalQuery) ([]string, error) {
+	query := columnAsOrderBy
+	queryParams := []interface{}{}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.QueryContext(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/endtoend/testdata/join_right/mysql/go/db.go
+++ b/internal/endtoend/testdata/join_right/mysql/go/db.go
@@ -29,3 +29,8 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/join_right/mysql/go/db.go
+++ b/internal/endtoend/testdata/join_right/mysql/go/db.go
@@ -32,5 +32,5 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/join_right/mysql/go/query.sql.go
+++ b/internal/endtoend/testdata/join_right/mysql/go/query.sql.go
@@ -23,8 +23,16 @@ type RightJoinRow struct {
 	ID_2  uint64
 }
 
-func (q *Queries) RightJoin(ctx context.Context, id uint64) ([]RightJoinRow, error) {
-	rows, err := q.db.QueryContext(ctx, rightJoin, id)
+func (q *Queries) RightJoin(ctx context.Context, id uint64, aq ...AdditionalQuery) ([]RightJoinRow, error) {
+	query := rightJoin
+	queryParams := []interface{}{id}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.QueryContext(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/endtoend/testdata/join_right/postgresql/go/db.go
+++ b/internal/endtoend/testdata/join_right/postgresql/go/db.go
@@ -29,3 +29,8 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/join_right/postgresql/go/db.go
+++ b/internal/endtoend/testdata/join_right/postgresql/go/db.go
@@ -32,5 +32,5 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/join_right/postgresql/go/query.sql.go
+++ b/internal/endtoend/testdata/join_right/postgresql/go/query.sql.go
@@ -23,8 +23,16 @@ type RightJoinRow struct {
 	ID_2  int32
 }
 
-func (q *Queries) RightJoin(ctx context.Context, id int32) ([]RightJoinRow, error) {
-	rows, err := q.db.QueryContext(ctx, rightJoin, id)
+func (q *Queries) RightJoin(ctx context.Context, id int32, aq ...AdditionalQuery) ([]RightJoinRow, error) {
+	query := rightJoin
+	queryParams := []interface{}{id}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.QueryContext(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/endtoend/testdata/join_table_name/mysql/go/db.go
+++ b/internal/endtoend/testdata/join_table_name/mysql/go/db.go
@@ -29,3 +29,8 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/join_table_name/mysql/go/db.go
+++ b/internal/endtoend/testdata/join_table_name/mysql/go/db.go
@@ -32,5 +32,5 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/join_table_name/mysql/go/query.sql.go
+++ b/internal/endtoend/testdata/join_table_name/mysql/go/query.sql.go
@@ -21,8 +21,16 @@ type TableNameParams struct {
 	ID_2 uint64
 }
 
-func (q *Queries) TableName(ctx context.Context, arg TableNameParams) (uint64, error) {
-	row := q.db.QueryRowContext(ctx, tableName, arg.ID, arg.ID_2)
+func (q *Queries) TableName(ctx context.Context, arg TableNameParams, aq ...AdditionalQuery) (uint64, error) {
+	query := tableName
+	queryParams := []interface{}{arg.ID, arg.ID_2}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	row := q.db.QueryRowContext(ctx, query, queryParams...)
 	var id uint64
 	err := row.Scan(&id)
 	return id, err

--- a/internal/endtoend/testdata/join_table_name/postgresql/pgx/v4/go/db.go
+++ b/internal/endtoend/testdata/join_table_name/postgresql/pgx/v4/go/db.go
@@ -33,5 +33,5 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/join_table_name/postgresql/pgx/v4/go/db.go
+++ b/internal/endtoend/testdata/join_table_name/postgresql/pgx/v4/go/db.go
@@ -30,3 +30,8 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/join_table_name/postgresql/pgx/v4/go/query.sql.go
+++ b/internal/endtoend/testdata/join_table_name/postgresql/pgx/v4/go/query.sql.go
@@ -21,8 +21,10 @@ type TableNameParams struct {
 	ID_2 int32
 }
 
-func (q *Queries) TableName(ctx context.Context, arg TableNameParams) (int32, error) {
-	row := q.db.QueryRow(ctx, tableName, arg.ID, arg.ID_2)
+func (q *Queries) TableName(ctx context.Context, arg TableNameParams, aq ...AdditionalQuery) (int32, error) {
+	query := tableName
+	queryParams := []interface{}{arg.ID, arg.ID_2}
+	row := q.db.QueryRow(ctx, query, queryParams...)
 	var id int32
 	err := row.Scan(&id)
 	return id, err

--- a/internal/endtoend/testdata/join_table_name/postgresql/pgx/v5/go/db.go
+++ b/internal/endtoend/testdata/join_table_name/postgresql/pgx/v5/go/db.go
@@ -33,5 +33,5 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/join_table_name/postgresql/pgx/v5/go/db.go
+++ b/internal/endtoend/testdata/join_table_name/postgresql/pgx/v5/go/db.go
@@ -30,3 +30,8 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/join_table_name/postgresql/pgx/v5/go/query.sql.go
+++ b/internal/endtoend/testdata/join_table_name/postgresql/pgx/v5/go/query.sql.go
@@ -21,8 +21,10 @@ type TableNameParams struct {
 	ID_2 int32
 }
 
-func (q *Queries) TableName(ctx context.Context, arg TableNameParams) (int32, error) {
-	row := q.db.QueryRow(ctx, tableName, arg.ID, arg.ID_2)
+func (q *Queries) TableName(ctx context.Context, arg TableNameParams, aq ...AdditionalQuery) (int32, error) {
+	query := tableName
+	queryParams := []interface{}{arg.ID, arg.ID_2}
+	row := q.db.QueryRow(ctx, query, queryParams...)
 	var id int32
 	err := row.Scan(&id)
 	return id, err

--- a/internal/endtoend/testdata/join_table_name/postgresql/stdlib/go/db.go
+++ b/internal/endtoend/testdata/join_table_name/postgresql/stdlib/go/db.go
@@ -29,3 +29,8 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/join_table_name/postgresql/stdlib/go/db.go
+++ b/internal/endtoend/testdata/join_table_name/postgresql/stdlib/go/db.go
@@ -32,5 +32,5 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/join_table_name/postgresql/stdlib/go/query.sql.go
+++ b/internal/endtoend/testdata/join_table_name/postgresql/stdlib/go/query.sql.go
@@ -21,8 +21,16 @@ type TableNameParams struct {
 	ID_2 int32
 }
 
-func (q *Queries) TableName(ctx context.Context, arg TableNameParams) (int32, error) {
-	row := q.db.QueryRowContext(ctx, tableName, arg.ID, arg.ID_2)
+func (q *Queries) TableName(ctx context.Context, arg TableNameParams, aq ...AdditionalQuery) (int32, error) {
+	query := tableName
+	queryParams := []interface{}{arg.ID, arg.ID_2}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	row := q.db.QueryRowContext(ctx, query, queryParams...)
 	var id int32
 	err := row.Scan(&id)
 	return id, err

--- a/internal/endtoend/testdata/join_table_name/sqlite/go/db.go
+++ b/internal/endtoend/testdata/join_table_name/sqlite/go/db.go
@@ -29,3 +29,8 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/join_table_name/sqlite/go/db.go
+++ b/internal/endtoend/testdata/join_table_name/sqlite/go/db.go
@@ -32,5 +32,5 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/join_table_name/sqlite/go/query.sql.go
+++ b/internal/endtoend/testdata/join_table_name/sqlite/go/query.sql.go
@@ -21,8 +21,16 @@ type TableNameParams struct {
 	ID_2 int64
 }
 
-func (q *Queries) TableName(ctx context.Context, arg TableNameParams) (int64, error) {
-	row := q.db.QueryRowContext(ctx, tableName, arg.ID, arg.ID_2)
+func (q *Queries) TableName(ctx context.Context, arg TableNameParams, aq ...AdditionalQuery) (int64, error) {
+	query := tableName
+	queryParams := []interface{}{arg.ID, arg.ID_2}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	row := q.db.QueryRowContext(ctx, query, queryParams...)
 	var id int64
 	err := row.Scan(&id)
 	return id, err

--- a/internal/endtoend/testdata/join_two_tables/mysql/go/db.go
+++ b/internal/endtoend/testdata/join_two_tables/mysql/go/db.go
@@ -29,3 +29,8 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/join_two_tables/mysql/go/db.go
+++ b/internal/endtoend/testdata/join_two_tables/mysql/go/db.go
@@ -32,5 +32,5 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/join_two_tables/mysql/go/query.sql.go
+++ b/internal/endtoend/testdata/join_two_tables/mysql/go/query.sql.go
@@ -16,8 +16,16 @@ JOIN bar ON bar.id = bar_id
 JOIN baz ON baz.id = baz_id
 `
 
-func (q *Queries) TwoJoins(ctx context.Context) ([]Foo, error) {
-	rows, err := q.db.QueryContext(ctx, twoJoins)
+func (q *Queries) TwoJoins(ctx context.Context, aq ...AdditionalQuery) ([]Foo, error) {
+	query := twoJoins
+	queryParams := []interface{}{}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.QueryContext(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/endtoend/testdata/join_two_tables/postgresql/pgx/v4/go/db.go
+++ b/internal/endtoend/testdata/join_two_tables/postgresql/pgx/v4/go/db.go
@@ -33,5 +33,5 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/join_two_tables/postgresql/pgx/v4/go/db.go
+++ b/internal/endtoend/testdata/join_two_tables/postgresql/pgx/v4/go/db.go
@@ -30,3 +30,8 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/join_two_tables/postgresql/pgx/v4/go/query.sql.go
+++ b/internal/endtoend/testdata/join_two_tables/postgresql/pgx/v4/go/query.sql.go
@@ -16,8 +16,16 @@ JOIN bar ON bar.id = bar_id
 JOIN baz ON baz.id = baz_id
 `
 
-func (q *Queries) TwoJoins(ctx context.Context) ([]Foo, error) {
-	rows, err := q.db.Query(ctx, twoJoins)
+func (q *Queries) TwoJoins(ctx context.Context, aq ...AdditionalQuery) ([]Foo, error) {
+	query := twoJoins
+	queryParams := []interface{}{}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.Query(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/endtoend/testdata/join_two_tables/postgresql/pgx/v5/go/db.go
+++ b/internal/endtoend/testdata/join_two_tables/postgresql/pgx/v5/go/db.go
@@ -33,5 +33,5 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/join_two_tables/postgresql/pgx/v5/go/db.go
+++ b/internal/endtoend/testdata/join_two_tables/postgresql/pgx/v5/go/db.go
@@ -30,3 +30,8 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/join_two_tables/postgresql/pgx/v5/go/query.sql.go
+++ b/internal/endtoend/testdata/join_two_tables/postgresql/pgx/v5/go/query.sql.go
@@ -16,8 +16,16 @@ JOIN bar ON bar.id = bar_id
 JOIN baz ON baz.id = baz_id
 `
 
-func (q *Queries) TwoJoins(ctx context.Context) ([]Foo, error) {
-	rows, err := q.db.Query(ctx, twoJoins)
+func (q *Queries) TwoJoins(ctx context.Context, aq ...AdditionalQuery) ([]Foo, error) {
+	query := twoJoins
+	queryParams := []interface{}{}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.Query(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/endtoend/testdata/join_two_tables/postgresql/stdlib/go/db.go
+++ b/internal/endtoend/testdata/join_two_tables/postgresql/stdlib/go/db.go
@@ -29,3 +29,8 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/join_two_tables/postgresql/stdlib/go/db.go
+++ b/internal/endtoend/testdata/join_two_tables/postgresql/stdlib/go/db.go
@@ -32,5 +32,5 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/join_two_tables/postgresql/stdlib/go/query.sql.go
+++ b/internal/endtoend/testdata/join_two_tables/postgresql/stdlib/go/query.sql.go
@@ -16,8 +16,16 @@ JOIN bar ON bar.id = bar_id
 JOIN baz ON baz.id = baz_id
 `
 
-func (q *Queries) TwoJoins(ctx context.Context) ([]Foo, error) {
-	rows, err := q.db.QueryContext(ctx, twoJoins)
+func (q *Queries) TwoJoins(ctx context.Context, aq ...AdditionalQuery) ([]Foo, error) {
+	query := twoJoins
+	queryParams := []interface{}{}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.QueryContext(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/endtoend/testdata/join_two_tables/sqlite/go/db.go
+++ b/internal/endtoend/testdata/join_two_tables/sqlite/go/db.go
@@ -29,3 +29,8 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/join_two_tables/sqlite/go/db.go
+++ b/internal/endtoend/testdata/join_two_tables/sqlite/go/db.go
@@ -32,5 +32,5 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/join_two_tables/sqlite/go/query.sql.go
+++ b/internal/endtoend/testdata/join_two_tables/sqlite/go/query.sql.go
@@ -16,8 +16,16 @@ JOIN bar ON bar.id = bar_id
 JOIN baz ON baz.id = baz_id
 `
 
-func (q *Queries) TwoJoins(ctx context.Context) ([]Foo, error) {
-	rows, err := q.db.QueryContext(ctx, twoJoins)
+func (q *Queries) TwoJoins(ctx context.Context, aq ...AdditionalQuery) ([]Foo, error) {
+	query := twoJoins
+	queryParams := []interface{}{}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.QueryContext(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/endtoend/testdata/join_where_clause/mysql/go/db.go
+++ b/internal/endtoend/testdata/join_where_clause/mysql/go/db.go
@@ -29,3 +29,8 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/join_where_clause/mysql/go/db.go
+++ b/internal/endtoend/testdata/join_where_clause/mysql/go/db.go
@@ -32,5 +32,5 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/join_where_clause/mysql/go/query.sql.go
+++ b/internal/endtoend/testdata/join_where_clause/mysql/go/query.sql.go
@@ -16,8 +16,16 @@ JOIN bar ON bar.id = barid
 WHERE owner = ?
 `
 
-func (q *Queries) JoinWhereClause(ctx context.Context, owner string) ([]uint64, error) {
-	rows, err := q.db.QueryContext(ctx, joinWhereClause, owner)
+func (q *Queries) JoinWhereClause(ctx context.Context, owner string, aq ...AdditionalQuery) ([]uint64, error) {
+	query := joinWhereClause
+	queryParams := []interface{}{owner}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.QueryContext(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/endtoend/testdata/join_where_clause/postgresql/pgx/v4/go/db.go
+++ b/internal/endtoend/testdata/join_where_clause/postgresql/pgx/v4/go/db.go
@@ -33,5 +33,5 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/join_where_clause/postgresql/pgx/v4/go/db.go
+++ b/internal/endtoend/testdata/join_where_clause/postgresql/pgx/v4/go/db.go
@@ -30,3 +30,8 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/join_where_clause/postgresql/pgx/v4/go/query.sql.go
+++ b/internal/endtoend/testdata/join_where_clause/postgresql/pgx/v4/go/query.sql.go
@@ -16,8 +16,16 @@ JOIN bar ON bar.id = barid
 WHERE owner = $1
 `
 
-func (q *Queries) JoinWhereClause(ctx context.Context, owner string) ([]int32, error) {
-	rows, err := q.db.Query(ctx, joinWhereClause, owner)
+func (q *Queries) JoinWhereClause(ctx context.Context, owner string, aq ...AdditionalQuery) ([]int32, error) {
+	query := joinWhereClause
+	queryParams := []interface{}{owner}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.Query(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/endtoend/testdata/join_where_clause/postgresql/pgx/v5/go/db.go
+++ b/internal/endtoend/testdata/join_where_clause/postgresql/pgx/v5/go/db.go
@@ -33,5 +33,5 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/join_where_clause/postgresql/pgx/v5/go/db.go
+++ b/internal/endtoend/testdata/join_where_clause/postgresql/pgx/v5/go/db.go
@@ -30,3 +30,8 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/join_where_clause/postgresql/pgx/v5/go/query.sql.go
+++ b/internal/endtoend/testdata/join_where_clause/postgresql/pgx/v5/go/query.sql.go
@@ -16,8 +16,16 @@ JOIN bar ON bar.id = barid
 WHERE owner = $1
 `
 
-func (q *Queries) JoinWhereClause(ctx context.Context, owner string) ([]int32, error) {
-	rows, err := q.db.Query(ctx, joinWhereClause, owner)
+func (q *Queries) JoinWhereClause(ctx context.Context, owner string, aq ...AdditionalQuery) ([]int32, error) {
+	query := joinWhereClause
+	queryParams := []interface{}{owner}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.Query(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/endtoend/testdata/join_where_clause/postgresql/stdlib/go/db.go
+++ b/internal/endtoend/testdata/join_where_clause/postgresql/stdlib/go/db.go
@@ -29,3 +29,8 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/join_where_clause/postgresql/stdlib/go/db.go
+++ b/internal/endtoend/testdata/join_where_clause/postgresql/stdlib/go/db.go
@@ -32,5 +32,5 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/join_where_clause/postgresql/stdlib/go/query.sql.go
+++ b/internal/endtoend/testdata/join_where_clause/postgresql/stdlib/go/query.sql.go
@@ -16,8 +16,16 @@ JOIN bar ON bar.id = barid
 WHERE owner = $1
 `
 
-func (q *Queries) JoinWhereClause(ctx context.Context, owner string) ([]int32, error) {
-	rows, err := q.db.QueryContext(ctx, joinWhereClause, owner)
+func (q *Queries) JoinWhereClause(ctx context.Context, owner string, aq ...AdditionalQuery) ([]int32, error) {
+	query := joinWhereClause
+	queryParams := []interface{}{owner}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.QueryContext(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/endtoend/testdata/join_where_clause/sqlite/go/db.go
+++ b/internal/endtoend/testdata/join_where_clause/sqlite/go/db.go
@@ -29,3 +29,8 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/join_where_clause/sqlite/go/db.go
+++ b/internal/endtoend/testdata/join_where_clause/sqlite/go/db.go
@@ -32,5 +32,5 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/join_where_clause/sqlite/go/query.sql.go
+++ b/internal/endtoend/testdata/join_where_clause/sqlite/go/query.sql.go
@@ -16,8 +16,16 @@ JOIN bar ON bar.id = barid
 WHERE owner = ?
 `
 
-func (q *Queries) JoinWhereClause(ctx context.Context, owner string) ([]int64, error) {
-	rows, err := q.db.QueryContext(ctx, joinWhereClause, owner)
+func (q *Queries) JoinWhereClause(ctx context.Context, owner string, aq ...AdditionalQuery) ([]int64, error) {
+	query := joinWhereClause
+	queryParams := []interface{}{owner}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.QueryContext(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/endtoend/testdata/json/mysql/go/db.go
+++ b/internal/endtoend/testdata/json/mysql/go/db.go
@@ -29,3 +29,8 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/json/mysql/go/db.go
+++ b/internal/endtoend/testdata/json/mysql/go/db.go
@@ -32,5 +32,5 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/json/mysql/go/query.sql.go
+++ b/internal/endtoend/testdata/json/mysql/go/query.sql.go
@@ -14,6 +14,9 @@ SELECT a, b FROM foo
 `
 
 func (q *Queries) SelectFoo(ctx context.Context) error {
-	_, err := q.db.ExecContext(ctx, selectFoo)
+	query := selectFoo
+	queryParams := []interface{}{}
+
+	_, err := q.db.ExecContext(ctx, query, queryParams...)
 	return err
 }

--- a/internal/endtoend/testdata/json/postgresql/pgx/v4/go/db.go
+++ b/internal/endtoend/testdata/json/postgresql/pgx/v4/go/db.go
@@ -33,5 +33,5 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/json/postgresql/pgx/v4/go/db.go
+++ b/internal/endtoend/testdata/json/postgresql/pgx/v4/go/db.go
@@ -30,3 +30,8 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/json/postgresql/pgx/v5/go/db.go
+++ b/internal/endtoend/testdata/json/postgresql/pgx/v5/go/db.go
@@ -33,5 +33,5 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/json/postgresql/pgx/v5/go/db.go
+++ b/internal/endtoend/testdata/json/postgresql/pgx/v5/go/db.go
@@ -30,3 +30,8 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/json/postgresql/stdlib/go/db.go
+++ b/internal/endtoend/testdata/json/postgresql/stdlib/go/db.go
@@ -29,3 +29,8 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/json/postgresql/stdlib/go/db.go
+++ b/internal/endtoend/testdata/json/postgresql/stdlib/go/db.go
@@ -32,5 +32,5 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/json/postgresql/stdlib/go/query.sql.go
+++ b/internal/endtoend/testdata/json/postgresql/stdlib/go/query.sql.go
@@ -14,6 +14,9 @@ SELECT a, b, c, d FROM foo
 `
 
 func (q *Queries) SelectFoo(ctx context.Context) error {
-	_, err := q.db.ExecContext(ctx, selectFoo)
+	query := selectFoo
+	queryParams := []interface{}{}
+
+	_, err := q.db.ExecContext(ctx, query, queryParams...)
 	return err
 }

--- a/internal/endtoend/testdata/json_build/postgresql/pgx/v4/go/db.go
+++ b/internal/endtoend/testdata/json_build/postgresql/pgx/v4/go/db.go
@@ -33,5 +33,5 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/json_build/postgresql/pgx/v4/go/db.go
+++ b/internal/endtoend/testdata/json_build/postgresql/pgx/v4/go/db.go
@@ -30,3 +30,8 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/json_build/postgresql/pgx/v4/go/query.sql.go
+++ b/internal/endtoend/testdata/json_build/postgresql/pgx/v4/go/query.sql.go
@@ -28,8 +28,10 @@ type SelectJSONBBuildArrayRow struct {
 	JsonbBuildArray_5 pgtype.JSONB
 }
 
-func (q *Queries) SelectJSONBBuildArray(ctx context.Context) (SelectJSONBBuildArrayRow, error) {
-	row := q.db.QueryRow(ctx, selectJSONBBuildArray)
+func (q *Queries) SelectJSONBBuildArray(ctx context.Context, aq ...AdditionalQuery) (SelectJSONBBuildArrayRow, error) {
+	query := selectJSONBBuildArray
+	queryParams := []interface{}{}
+	row := q.db.QueryRow(ctx, query, queryParams...)
 	var i SelectJSONBBuildArrayRow
 	err := row.Scan(
 		&i.JsonbBuildArray,
@@ -58,8 +60,10 @@ type SelectJSONBBuildObjectRow struct {
 	JsonbBuildObject_5 pgtype.JSONB
 }
 
-func (q *Queries) SelectJSONBBuildObject(ctx context.Context) (SelectJSONBBuildObjectRow, error) {
-	row := q.db.QueryRow(ctx, selectJSONBBuildObject)
+func (q *Queries) SelectJSONBBuildObject(ctx context.Context, aq ...AdditionalQuery) (SelectJSONBBuildObjectRow, error) {
+	query := selectJSONBBuildObject
+	queryParams := []interface{}{}
+	row := q.db.QueryRow(ctx, query, queryParams...)
 	var i SelectJSONBBuildObjectRow
 	err := row.Scan(
 		&i.JsonbBuildObject,
@@ -88,8 +92,10 @@ type SelectJSONBuildArrayRow struct {
 	JsonBuildArray_5 pgtype.JSON
 }
 
-func (q *Queries) SelectJSONBuildArray(ctx context.Context) (SelectJSONBuildArrayRow, error) {
-	row := q.db.QueryRow(ctx, selectJSONBuildArray)
+func (q *Queries) SelectJSONBuildArray(ctx context.Context, aq ...AdditionalQuery) (SelectJSONBuildArrayRow, error) {
+	query := selectJSONBuildArray
+	queryParams := []interface{}{}
+	row := q.db.QueryRow(ctx, query, queryParams...)
 	var i SelectJSONBuildArrayRow
 	err := row.Scan(
 		&i.JsonBuildArray,
@@ -118,8 +124,10 @@ type SelectJSONBuildObjectRow struct {
 	JsonBuildObject_5 pgtype.JSON
 }
 
-func (q *Queries) SelectJSONBuildObject(ctx context.Context) (SelectJSONBuildObjectRow, error) {
-	row := q.db.QueryRow(ctx, selectJSONBuildObject)
+func (q *Queries) SelectJSONBuildObject(ctx context.Context, aq ...AdditionalQuery) (SelectJSONBuildObjectRow, error) {
+	query := selectJSONBuildObject
+	queryParams := []interface{}{}
+	row := q.db.QueryRow(ctx, query, queryParams...)
 	var i SelectJSONBuildObjectRow
 	err := row.Scan(
 		&i.JsonBuildObject,

--- a/internal/endtoend/testdata/json_build/postgresql/pgx/v5/go/db.go
+++ b/internal/endtoend/testdata/json_build/postgresql/pgx/v5/go/db.go
@@ -33,5 +33,5 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/json_build/postgresql/pgx/v5/go/db.go
+++ b/internal/endtoend/testdata/json_build/postgresql/pgx/v5/go/db.go
@@ -30,3 +30,8 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/json_build/postgresql/pgx/v5/go/query.sql.go
+++ b/internal/endtoend/testdata/json_build/postgresql/pgx/v5/go/query.sql.go
@@ -26,8 +26,10 @@ type SelectJSONBBuildArrayRow struct {
 	JsonbBuildArray_5 []byte
 }
 
-func (q *Queries) SelectJSONBBuildArray(ctx context.Context) (SelectJSONBBuildArrayRow, error) {
-	row := q.db.QueryRow(ctx, selectJSONBBuildArray)
+func (q *Queries) SelectJSONBBuildArray(ctx context.Context, aq ...AdditionalQuery) (SelectJSONBBuildArrayRow, error) {
+	query := selectJSONBBuildArray
+	queryParams := []interface{}{}
+	row := q.db.QueryRow(ctx, query, queryParams...)
 	var i SelectJSONBBuildArrayRow
 	err := row.Scan(
 		&i.JsonbBuildArray,
@@ -56,8 +58,10 @@ type SelectJSONBBuildObjectRow struct {
 	JsonbBuildObject_5 []byte
 }
 
-func (q *Queries) SelectJSONBBuildObject(ctx context.Context) (SelectJSONBBuildObjectRow, error) {
-	row := q.db.QueryRow(ctx, selectJSONBBuildObject)
+func (q *Queries) SelectJSONBBuildObject(ctx context.Context, aq ...AdditionalQuery) (SelectJSONBBuildObjectRow, error) {
+	query := selectJSONBBuildObject
+	queryParams := []interface{}{}
+	row := q.db.QueryRow(ctx, query, queryParams...)
 	var i SelectJSONBBuildObjectRow
 	err := row.Scan(
 		&i.JsonbBuildObject,
@@ -86,8 +90,10 @@ type SelectJSONBuildArrayRow struct {
 	JsonBuildArray_5 []byte
 }
 
-func (q *Queries) SelectJSONBuildArray(ctx context.Context) (SelectJSONBuildArrayRow, error) {
-	row := q.db.QueryRow(ctx, selectJSONBuildArray)
+func (q *Queries) SelectJSONBuildArray(ctx context.Context, aq ...AdditionalQuery) (SelectJSONBuildArrayRow, error) {
+	query := selectJSONBuildArray
+	queryParams := []interface{}{}
+	row := q.db.QueryRow(ctx, query, queryParams...)
 	var i SelectJSONBuildArrayRow
 	err := row.Scan(
 		&i.JsonBuildArray,
@@ -116,8 +122,10 @@ type SelectJSONBuildObjectRow struct {
 	JsonBuildObject_5 []byte
 }
 
-func (q *Queries) SelectJSONBuildObject(ctx context.Context) (SelectJSONBuildObjectRow, error) {
-	row := q.db.QueryRow(ctx, selectJSONBuildObject)
+func (q *Queries) SelectJSONBuildObject(ctx context.Context, aq ...AdditionalQuery) (SelectJSONBuildObjectRow, error) {
+	query := selectJSONBuildObject
+	queryParams := []interface{}{}
+	row := q.db.QueryRow(ctx, query, queryParams...)
 	var i SelectJSONBuildObjectRow
 	err := row.Scan(
 		&i.JsonBuildObject,

--- a/internal/endtoend/testdata/json_build/postgresql/stdlib/go/db.go
+++ b/internal/endtoend/testdata/json_build/postgresql/stdlib/go/db.go
@@ -29,3 +29,8 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/json_build/postgresql/stdlib/go/db.go
+++ b/internal/endtoend/testdata/json_build/postgresql/stdlib/go/db.go
@@ -32,5 +32,5 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/json_build/postgresql/stdlib/go/query.sql.go
+++ b/internal/endtoend/testdata/json_build/postgresql/stdlib/go/query.sql.go
@@ -27,8 +27,16 @@ type SelectJSONBBuildArrayRow struct {
 	JsonbBuildArray_5 json.RawMessage
 }
 
-func (q *Queries) SelectJSONBBuildArray(ctx context.Context) (SelectJSONBBuildArrayRow, error) {
-	row := q.db.QueryRowContext(ctx, selectJSONBBuildArray)
+func (q *Queries) SelectJSONBBuildArray(ctx context.Context, aq ...AdditionalQuery) (SelectJSONBBuildArrayRow, error) {
+	query := selectJSONBBuildArray
+	queryParams := []interface{}{}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	row := q.db.QueryRowContext(ctx, query, queryParams...)
 	var i SelectJSONBBuildArrayRow
 	err := row.Scan(
 		&i.JsonbBuildArray,
@@ -57,8 +65,16 @@ type SelectJSONBBuildObjectRow struct {
 	JsonbBuildObject_5 json.RawMessage
 }
 
-func (q *Queries) SelectJSONBBuildObject(ctx context.Context) (SelectJSONBBuildObjectRow, error) {
-	row := q.db.QueryRowContext(ctx, selectJSONBBuildObject)
+func (q *Queries) SelectJSONBBuildObject(ctx context.Context, aq ...AdditionalQuery) (SelectJSONBBuildObjectRow, error) {
+	query := selectJSONBBuildObject
+	queryParams := []interface{}{}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	row := q.db.QueryRowContext(ctx, query, queryParams...)
 	var i SelectJSONBBuildObjectRow
 	err := row.Scan(
 		&i.JsonbBuildObject,
@@ -87,8 +103,16 @@ type SelectJSONBuildArrayRow struct {
 	JsonBuildArray_5 json.RawMessage
 }
 
-func (q *Queries) SelectJSONBuildArray(ctx context.Context) (SelectJSONBuildArrayRow, error) {
-	row := q.db.QueryRowContext(ctx, selectJSONBuildArray)
+func (q *Queries) SelectJSONBuildArray(ctx context.Context, aq ...AdditionalQuery) (SelectJSONBuildArrayRow, error) {
+	query := selectJSONBuildArray
+	queryParams := []interface{}{}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	row := q.db.QueryRowContext(ctx, query, queryParams...)
 	var i SelectJSONBuildArrayRow
 	err := row.Scan(
 		&i.JsonBuildArray,
@@ -117,8 +141,16 @@ type SelectJSONBuildObjectRow struct {
 	JsonBuildObject_5 json.RawMessage
 }
 
-func (q *Queries) SelectJSONBuildObject(ctx context.Context) (SelectJSONBuildObjectRow, error) {
-	row := q.db.QueryRowContext(ctx, selectJSONBuildObject)
+func (q *Queries) SelectJSONBuildObject(ctx context.Context, aq ...AdditionalQuery) (SelectJSONBuildObjectRow, error) {
+	query := selectJSONBuildObject
+	queryParams := []interface{}{}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	row := q.db.QueryRowContext(ctx, query, queryParams...)
 	var i SelectJSONBuildObjectRow
 	err := row.Scan(
 		&i.JsonBuildObject,

--- a/internal/endtoend/testdata/json_tags/camel_case/postgresql/pgx/v4/go/db.go
+++ b/internal/endtoend/testdata/json_tags/camel_case/postgresql/pgx/v4/go/db.go
@@ -33,5 +33,5 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/json_tags/camel_case/postgresql/pgx/v4/go/db.go
+++ b/internal/endtoend/testdata/json_tags/camel_case/postgresql/pgx/v4/go/db.go
@@ -30,3 +30,8 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/json_tags/camel_case/postgresql/pgx/v4/go/query.sql.go
+++ b/internal/endtoend/testdata/json_tags/camel_case/postgresql/pgx/v4/go/query.sql.go
@@ -13,8 +13,16 @@ const getAll = `-- name: GetAll :many
 SELECT first_name, last_name, age FROM users
 `
 
-func (q *Queries) GetAll(ctx context.Context) ([]User, error) {
-	rows, err := q.db.Query(ctx, getAll)
+func (q *Queries) GetAll(ctx context.Context, aq ...AdditionalQuery) ([]User, error) {
+	query := getAll
+	queryParams := []interface{}{}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.Query(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/endtoend/testdata/json_tags/camel_case/postgresql/pgx/v5/go/db.go
+++ b/internal/endtoend/testdata/json_tags/camel_case/postgresql/pgx/v5/go/db.go
@@ -33,5 +33,5 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/json_tags/camel_case/postgresql/pgx/v5/go/db.go
+++ b/internal/endtoend/testdata/json_tags/camel_case/postgresql/pgx/v5/go/db.go
@@ -30,3 +30,8 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/json_tags/camel_case/postgresql/pgx/v5/go/query.sql.go
+++ b/internal/endtoend/testdata/json_tags/camel_case/postgresql/pgx/v5/go/query.sql.go
@@ -13,8 +13,16 @@ const getAll = `-- name: GetAll :many
 SELECT first_name, last_name, age FROM users
 `
 
-func (q *Queries) GetAll(ctx context.Context) ([]User, error) {
-	rows, err := q.db.Query(ctx, getAll)
+func (q *Queries) GetAll(ctx context.Context, aq ...AdditionalQuery) ([]User, error) {
+	query := getAll
+	queryParams := []interface{}{}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.Query(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/endtoend/testdata/json_tags/camel_case/postgresql/stdlib/go/db.go
+++ b/internal/endtoend/testdata/json_tags/camel_case/postgresql/stdlib/go/db.go
@@ -29,3 +29,8 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/json_tags/camel_case/postgresql/stdlib/go/db.go
+++ b/internal/endtoend/testdata/json_tags/camel_case/postgresql/stdlib/go/db.go
@@ -32,5 +32,5 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/json_tags/camel_case/postgresql/stdlib/go/query.sql.go
+++ b/internal/endtoend/testdata/json_tags/camel_case/postgresql/stdlib/go/query.sql.go
@@ -13,8 +13,16 @@ const getAll = `-- name: GetAll :many
 SELECT first_name, last_name, age FROM users
 `
 
-func (q *Queries) GetAll(ctx context.Context) ([]User, error) {
-	rows, err := q.db.QueryContext(ctx, getAll)
+func (q *Queries) GetAll(ctx context.Context, aq ...AdditionalQuery) ([]User, error) {
+	query := getAll
+	queryParams := []interface{}{}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.QueryContext(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/endtoend/testdata/json_tags/pascal_case/postgresql/pgx/v4/go/db.go
+++ b/internal/endtoend/testdata/json_tags/pascal_case/postgresql/pgx/v4/go/db.go
@@ -33,5 +33,5 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/json_tags/pascal_case/postgresql/pgx/v4/go/db.go
+++ b/internal/endtoend/testdata/json_tags/pascal_case/postgresql/pgx/v4/go/db.go
@@ -30,3 +30,8 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/json_tags/pascal_case/postgresql/pgx/v4/go/query.sql.go
+++ b/internal/endtoend/testdata/json_tags/pascal_case/postgresql/pgx/v4/go/query.sql.go
@@ -13,8 +13,16 @@ const getAll = `-- name: GetAll :many
 SELECT first_name, last_name, age FROM users
 `
 
-func (q *Queries) GetAll(ctx context.Context) ([]User, error) {
-	rows, err := q.db.Query(ctx, getAll)
+func (q *Queries) GetAll(ctx context.Context, aq ...AdditionalQuery) ([]User, error) {
+	query := getAll
+	queryParams := []interface{}{}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.Query(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/endtoend/testdata/json_tags/pascal_case/postgresql/pgx/v5/go/db.go
+++ b/internal/endtoend/testdata/json_tags/pascal_case/postgresql/pgx/v5/go/db.go
@@ -33,5 +33,5 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/json_tags/pascal_case/postgresql/pgx/v5/go/db.go
+++ b/internal/endtoend/testdata/json_tags/pascal_case/postgresql/pgx/v5/go/db.go
@@ -30,3 +30,8 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/json_tags/pascal_case/postgresql/pgx/v5/go/query.sql.go
+++ b/internal/endtoend/testdata/json_tags/pascal_case/postgresql/pgx/v5/go/query.sql.go
@@ -13,8 +13,16 @@ const getAll = `-- name: GetAll :many
 SELECT first_name, last_name, age FROM users
 `
 
-func (q *Queries) GetAll(ctx context.Context) ([]User, error) {
-	rows, err := q.db.Query(ctx, getAll)
+func (q *Queries) GetAll(ctx context.Context, aq ...AdditionalQuery) ([]User, error) {
+	query := getAll
+	queryParams := []interface{}{}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.Query(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/endtoend/testdata/json_tags/pascal_case/postgresql/stdlib/go/db.go
+++ b/internal/endtoend/testdata/json_tags/pascal_case/postgresql/stdlib/go/db.go
@@ -29,3 +29,8 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/json_tags/pascal_case/postgresql/stdlib/go/db.go
+++ b/internal/endtoend/testdata/json_tags/pascal_case/postgresql/stdlib/go/db.go
@@ -32,5 +32,5 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/json_tags/pascal_case/postgresql/stdlib/go/query.sql.go
+++ b/internal/endtoend/testdata/json_tags/pascal_case/postgresql/stdlib/go/query.sql.go
@@ -13,8 +13,16 @@ const getAll = `-- name: GetAll :many
 SELECT first_name, last_name, age FROM users
 `
 
-func (q *Queries) GetAll(ctx context.Context) ([]User, error) {
-	rows, err := q.db.QueryContext(ctx, getAll)
+func (q *Queries) GetAll(ctx context.Context, aq ...AdditionalQuery) ([]User, error) {
+	query := getAll
+	queryParams := []interface{}{}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.QueryContext(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/endtoend/testdata/json_tags/snake_case/postgresql/pgx/v4/go/db.go
+++ b/internal/endtoend/testdata/json_tags/snake_case/postgresql/pgx/v4/go/db.go
@@ -33,5 +33,5 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/json_tags/snake_case/postgresql/pgx/v4/go/db.go
+++ b/internal/endtoend/testdata/json_tags/snake_case/postgresql/pgx/v4/go/db.go
@@ -30,3 +30,8 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/json_tags/snake_case/postgresql/pgx/v4/go/query.sql.go
+++ b/internal/endtoend/testdata/json_tags/snake_case/postgresql/pgx/v4/go/query.sql.go
@@ -13,8 +13,16 @@ const getAll = `-- name: GetAll :many
 SELECT first_name, last_name, age FROM users
 `
 
-func (q *Queries) GetAll(ctx context.Context) ([]User, error) {
-	rows, err := q.db.Query(ctx, getAll)
+func (q *Queries) GetAll(ctx context.Context, aq ...AdditionalQuery) ([]User, error) {
+	query := getAll
+	queryParams := []interface{}{}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.Query(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/endtoend/testdata/json_tags/snake_case/postgresql/pgx/v5/go/db.go
+++ b/internal/endtoend/testdata/json_tags/snake_case/postgresql/pgx/v5/go/db.go
@@ -33,5 +33,5 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/json_tags/snake_case/postgresql/pgx/v5/go/db.go
+++ b/internal/endtoend/testdata/json_tags/snake_case/postgresql/pgx/v5/go/db.go
@@ -30,3 +30,8 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/json_tags/snake_case/postgresql/pgx/v5/go/query.sql.go
+++ b/internal/endtoend/testdata/json_tags/snake_case/postgresql/pgx/v5/go/query.sql.go
@@ -13,8 +13,16 @@ const getAll = `-- name: GetAll :many
 SELECT first_name, last_name, age FROM users
 `
 
-func (q *Queries) GetAll(ctx context.Context) ([]User, error) {
-	rows, err := q.db.Query(ctx, getAll)
+func (q *Queries) GetAll(ctx context.Context, aq ...AdditionalQuery) ([]User, error) {
+	query := getAll
+	queryParams := []interface{}{}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.Query(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/endtoend/testdata/json_tags/snake_case/postgresql/stdlib/go/db.go
+++ b/internal/endtoend/testdata/json_tags/snake_case/postgresql/stdlib/go/db.go
@@ -29,3 +29,8 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/json_tags/snake_case/postgresql/stdlib/go/db.go
+++ b/internal/endtoend/testdata/json_tags/snake_case/postgresql/stdlib/go/db.go
@@ -32,5 +32,5 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/json_tags/snake_case/postgresql/stdlib/go/query.sql.go
+++ b/internal/endtoend/testdata/json_tags/snake_case/postgresql/stdlib/go/query.sql.go
@@ -13,8 +13,16 @@ const getAll = `-- name: GetAll :many
 SELECT first_name, last_name, age FROM users
 `
 
-func (q *Queries) GetAll(ctx context.Context) ([]User, error) {
-	rows, err := q.db.QueryContext(ctx, getAll)
+func (q *Queries) GetAll(ctx context.Context, aq ...AdditionalQuery) ([]User, error) {
+	query := getAll
+	queryParams := []interface{}{}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.QueryContext(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/endtoend/testdata/json_tags_null_enum/camel_case/postgresql/stdlib/go/db.go
+++ b/internal/endtoend/testdata/json_tags_null_enum/camel_case/postgresql/stdlib/go/db.go
@@ -29,3 +29,8 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/json_tags_null_enum/camel_case/postgresql/stdlib/go/db.go
+++ b/internal/endtoend/testdata/json_tags_null_enum/camel_case/postgresql/stdlib/go/db.go
@@ -32,5 +32,5 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/json_tags_null_enum/camel_case/postgresql/stdlib/go/query.sql.go
+++ b/internal/endtoend/testdata/json_tags_null_enum/camel_case/postgresql/stdlib/go/query.sql.go
@@ -14,8 +14,16 @@ SELECT id, type, name, bio FROM authors
 WHERE id = $1 LIMIT 1
 `
 
-func (q *Queries) GetAuthor(ctx context.Context, id int64) (Author, error) {
-	row := q.db.QueryRowContext(ctx, getAuthor, id)
+func (q *Queries) GetAuthor(ctx context.Context, id int64, aq ...AdditionalQuery) (Author, error) {
+	query := getAuthor
+	queryParams := []interface{}{id}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	row := q.db.QueryRowContext(ctx, query, queryParams...)
 	var i Author
 	err := row.Scan(
 		&i.ID,

--- a/internal/endtoend/testdata/json_tags_null_enum/none/postgresql/stdlib/go/db.go
+++ b/internal/endtoend/testdata/json_tags_null_enum/none/postgresql/stdlib/go/db.go
@@ -29,3 +29,8 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/json_tags_null_enum/none/postgresql/stdlib/go/db.go
+++ b/internal/endtoend/testdata/json_tags_null_enum/none/postgresql/stdlib/go/db.go
@@ -32,5 +32,5 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/json_tags_null_enum/none/postgresql/stdlib/go/query.sql.go
+++ b/internal/endtoend/testdata/json_tags_null_enum/none/postgresql/stdlib/go/query.sql.go
@@ -14,8 +14,16 @@ SELECT id, type, name, bio FROM authors
 WHERE id = $1 LIMIT 1
 `
 
-func (q *Queries) GetAuthor(ctx context.Context, id int64) (Author, error) {
-	row := q.db.QueryRowContext(ctx, getAuthor, id)
+func (q *Queries) GetAuthor(ctx context.Context, id int64, aq ...AdditionalQuery) (Author, error) {
+	query := getAuthor
+	queryParams := []interface{}{id}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	row := q.db.QueryRowContext(ctx, query, queryParams...)
 	var i Author
 	err := row.Scan(
 		&i.ID,

--- a/internal/endtoend/testdata/json_tags_null_enum/pascal_case/postgresql/stdlib/go/db.go
+++ b/internal/endtoend/testdata/json_tags_null_enum/pascal_case/postgresql/stdlib/go/db.go
@@ -29,3 +29,8 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/json_tags_null_enum/pascal_case/postgresql/stdlib/go/db.go
+++ b/internal/endtoend/testdata/json_tags_null_enum/pascal_case/postgresql/stdlib/go/db.go
@@ -32,5 +32,5 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/json_tags_null_enum/pascal_case/postgresql/stdlib/go/query.sql.go
+++ b/internal/endtoend/testdata/json_tags_null_enum/pascal_case/postgresql/stdlib/go/query.sql.go
@@ -14,8 +14,16 @@ SELECT id, type, name, bio FROM authors
 WHERE id = $1 LIMIT 1
 `
 
-func (q *Queries) GetAuthor(ctx context.Context, id int64) (Author, error) {
-	row := q.db.QueryRowContext(ctx, getAuthor, id)
+func (q *Queries) GetAuthor(ctx context.Context, id int64, aq ...AdditionalQuery) (Author, error) {
+	query := getAuthor
+	queryParams := []interface{}{id}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	row := q.db.QueryRowContext(ctx, query, queryParams...)
 	var i Author
 	err := row.Scan(
 		&i.ID,

--- a/internal/endtoend/testdata/json_tags_null_enum/snake_case/postgresql/stdlib/go/db.go
+++ b/internal/endtoend/testdata/json_tags_null_enum/snake_case/postgresql/stdlib/go/db.go
@@ -29,3 +29,8 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/json_tags_null_enum/snake_case/postgresql/stdlib/go/db.go
+++ b/internal/endtoend/testdata/json_tags_null_enum/snake_case/postgresql/stdlib/go/db.go
@@ -32,5 +32,5 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/json_tags_null_enum/snake_case/postgresql/stdlib/go/query.sql.go
+++ b/internal/endtoend/testdata/json_tags_null_enum/snake_case/postgresql/stdlib/go/query.sql.go
@@ -14,8 +14,16 @@ SELECT id, type, name, bio FROM authors
 WHERE id = $1 LIMIT 1
 `
 
-func (q *Queries) GetAuthor(ctx context.Context, id int64) (Author, error) {
-	row := q.db.QueryRowContext(ctx, getAuthor, id)
+func (q *Queries) GetAuthor(ctx context.Context, id int64, aq ...AdditionalQuery) (Author, error) {
+	query := getAuthor
+	queryParams := []interface{}{id}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	row := q.db.QueryRowContext(ctx, query, queryParams...)
 	var i Author
 	err := row.Scan(
 		&i.ID,

--- a/internal/endtoend/testdata/json_tags_null_enum/v2_config/postgresql/stdlib/go/db.go
+++ b/internal/endtoend/testdata/json_tags_null_enum/v2_config/postgresql/stdlib/go/db.go
@@ -29,3 +29,8 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/json_tags_null_enum/v2_config/postgresql/stdlib/go/db.go
+++ b/internal/endtoend/testdata/json_tags_null_enum/v2_config/postgresql/stdlib/go/db.go
@@ -32,5 +32,5 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/json_tags_null_enum/v2_config/postgresql/stdlib/go/query.sql.go
+++ b/internal/endtoend/testdata/json_tags_null_enum/v2_config/postgresql/stdlib/go/query.sql.go
@@ -14,8 +14,16 @@ SELECT id, type, name, bio FROM authors
 WHERE id = $1 LIMIT 1
 `
 
-func (q *Queries) GetAuthor(ctx context.Context, id int64) (Author, error) {
-	row := q.db.QueryRowContext(ctx, getAuthor, id)
+func (q *Queries) GetAuthor(ctx context.Context, id int64, aq ...AdditionalQuery) (Author, error) {
+	query := getAuthor
+	queryParams := []interface{}{id}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	row := q.db.QueryRowContext(ctx, query, queryParams...)
 	var i Author
 	err := row.Scan(
 		&i.ID,

--- a/internal/endtoend/testdata/limit/mysql/go/db.go
+++ b/internal/endtoend/testdata/limit/mysql/go/db.go
@@ -29,3 +29,8 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/limit/mysql/go/db.go
+++ b/internal/endtoend/testdata/limit/mysql/go/db.go
@@ -32,5 +32,5 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/limit/mysql/go/query.sql.go
+++ b/internal/endtoend/testdata/limit/mysql/go/query.sql.go
@@ -14,7 +14,10 @@ UPDATE foo SET bar='baz' LIMIT ?
 `
 
 func (q *Queries) LimitMe(ctx context.Context, limit int32) error {
-	_, err := q.db.ExecContext(ctx, limitMe, limit)
+	query := limitMe
+	queryParams := []interface{}{limit}
+
+	_, err := q.db.ExecContext(ctx, query, queryParams...)
 	return err
 }
 
@@ -23,6 +26,9 @@ DELETE FROM foo LIMIT ?
 `
 
 func (q *Queries) LimitMeToo(ctx context.Context, limit int32) error {
-	_, err := q.db.ExecContext(ctx, limitMeToo, limit)
+	query := limitMeToo
+	queryParams := []interface{}{limit}
+
+	_, err := q.db.ExecContext(ctx, query, queryParams...)
 	return err
 }

--- a/internal/endtoend/testdata/limit/pgx/v4/go/db.go
+++ b/internal/endtoend/testdata/limit/pgx/v4/go/db.go
@@ -33,5 +33,5 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/limit/pgx/v4/go/db.go
+++ b/internal/endtoend/testdata/limit/pgx/v4/go/db.go
@@ -30,3 +30,8 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/limit/pgx/v4/go/query.sql.go
+++ b/internal/endtoend/testdata/limit/pgx/v4/go/query.sql.go
@@ -13,8 +13,16 @@ const limitMe = `-- name: LimitMe :many
 SELECT bar FROM foo LIMIT $1
 `
 
-func (q *Queries) LimitMe(ctx context.Context, limit int32) ([]bool, error) {
-	rows, err := q.db.Query(ctx, limitMe, limit)
+func (q *Queries) LimitMe(ctx context.Context, limit int32, aq ...AdditionalQuery) ([]bool, error) {
+	query := limitMe
+	queryParams := []interface{}{limit}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.Query(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/endtoend/testdata/limit/pgx/v5/go/db.go
+++ b/internal/endtoend/testdata/limit/pgx/v5/go/db.go
@@ -33,5 +33,5 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/limit/pgx/v5/go/db.go
+++ b/internal/endtoend/testdata/limit/pgx/v5/go/db.go
@@ -30,3 +30,8 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/limit/pgx/v5/go/query.sql.go
+++ b/internal/endtoend/testdata/limit/pgx/v5/go/query.sql.go
@@ -13,8 +13,16 @@ const limitMe = `-- name: LimitMe :many
 SELECT bar FROM foo LIMIT $1
 `
 
-func (q *Queries) LimitMe(ctx context.Context, limit int32) ([]bool, error) {
-	rows, err := q.db.Query(ctx, limitMe, limit)
+func (q *Queries) LimitMe(ctx context.Context, limit int32, aq ...AdditionalQuery) ([]bool, error) {
+	query := limitMe
+	queryParams := []interface{}{limit}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.Query(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/endtoend/testdata/limit/sqlite/go/db.go
+++ b/internal/endtoend/testdata/limit/sqlite/go/db.go
@@ -29,3 +29,8 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/limit/sqlite/go/db.go
+++ b/internal/endtoend/testdata/limit/sqlite/go/db.go
@@ -32,5 +32,5 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/limit/sqlite/go/query.sql.go
+++ b/internal/endtoend/testdata/limit/sqlite/go/query.sql.go
@@ -14,7 +14,10 @@ DELETE FROM foo LIMIT ?
 `
 
 func (q *Queries) DeleteLimit(ctx context.Context, limit int64) error {
-	_, err := q.db.ExecContext(ctx, deleteLimit, limit)
+	query := deleteLimit
+	queryParams := []interface{}{limit}
+
+	_, err := q.db.ExecContext(ctx, query, queryParams...)
 	return err
 }
 
@@ -22,8 +25,16 @@ const limitMe = `-- name: LimitMe :many
 SELECT bar FROM foo LIMIT ?
 `
 
-func (q *Queries) LimitMe(ctx context.Context, limit int64) ([]bool, error) {
-	rows, err := q.db.QueryContext(ctx, limitMe, limit)
+func (q *Queries) LimitMe(ctx context.Context, limit int64, aq ...AdditionalQuery) ([]bool, error) {
+	query := limitMe
+	queryParams := []interface{}{limit}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.QueryContext(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}
@@ -50,6 +61,9 @@ UPDATE foo SET bar='baz' LIMIT ?
 `
 
 func (q *Queries) UpdateLimit(ctx context.Context, limit int64) error {
-	_, err := q.db.ExecContext(ctx, updateLimit, limit)
+	query := updateLimit
+	queryParams := []interface{}{limit}
+
+	_, err := q.db.ExecContext(ctx, query, queryParams...)
 	return err
 }

--- a/internal/endtoend/testdata/limit/stdlib/go/db.go
+++ b/internal/endtoend/testdata/limit/stdlib/go/db.go
@@ -29,3 +29,8 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/limit/stdlib/go/db.go
+++ b/internal/endtoend/testdata/limit/stdlib/go/db.go
@@ -32,5 +32,5 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/limit/stdlib/go/query.sql.go
+++ b/internal/endtoend/testdata/limit/stdlib/go/query.sql.go
@@ -13,8 +13,16 @@ const limitMe = `-- name: LimitMe :many
 SELECT bar FROM foo LIMIT $1
 `
 
-func (q *Queries) LimitMe(ctx context.Context, limit int32) ([]bool, error) {
-	rows, err := q.db.QueryContext(ctx, limitMe, limit)
+func (q *Queries) LimitMe(ctx context.Context, limit int32, aq ...AdditionalQuery) ([]bool, error) {
+	query := limitMe
+	queryParams := []interface{}{limit}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.QueryContext(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/endtoend/testdata/lower/pgx/v4/go/db.go
+++ b/internal/endtoend/testdata/lower/pgx/v4/go/db.go
@@ -33,5 +33,5 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/lower/pgx/v4/go/db.go
+++ b/internal/endtoend/testdata/lower/pgx/v4/go/db.go
@@ -30,3 +30,8 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/lower/pgx/v4/go/query.sql.go
+++ b/internal/endtoend/testdata/lower/pgx/v4/go/query.sql.go
@@ -18,8 +18,16 @@ type LowerParams struct {
 	Bat string
 }
 
-func (q *Queries) Lower(ctx context.Context, arg LowerParams) ([]string, error) {
-	rows, err := q.db.Query(ctx, lower, arg.Bar, arg.Bat)
+func (q *Queries) Lower(ctx context.Context, arg LowerParams, aq ...AdditionalQuery) ([]string, error) {
+	query := lower
+	queryParams := []interface{}{arg.Bar, arg.Bat}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.Query(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/endtoend/testdata/lower/pgx/v5/go/db.go
+++ b/internal/endtoend/testdata/lower/pgx/v5/go/db.go
@@ -33,5 +33,5 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/lower/pgx/v5/go/db.go
+++ b/internal/endtoend/testdata/lower/pgx/v5/go/db.go
@@ -30,3 +30,8 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/lower/pgx/v5/go/query.sql.go
+++ b/internal/endtoend/testdata/lower/pgx/v5/go/query.sql.go
@@ -18,8 +18,16 @@ type LowerParams struct {
 	Bat string
 }
 
-func (q *Queries) Lower(ctx context.Context, arg LowerParams) ([]string, error) {
-	rows, err := q.db.Query(ctx, lower, arg.Bar, arg.Bat)
+func (q *Queries) Lower(ctx context.Context, arg LowerParams, aq ...AdditionalQuery) ([]string, error) {
+	query := lower
+	queryParams := []interface{}{arg.Bar, arg.Bat}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.Query(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/endtoend/testdata/lower/stdlib/go/db.go
+++ b/internal/endtoend/testdata/lower/stdlib/go/db.go
@@ -29,3 +29,8 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/lower/stdlib/go/db.go
+++ b/internal/endtoend/testdata/lower/stdlib/go/db.go
@@ -32,5 +32,5 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/lower/stdlib/go/query.sql.go
+++ b/internal/endtoend/testdata/lower/stdlib/go/query.sql.go
@@ -18,8 +18,16 @@ type LowerParams struct {
 	Bat string
 }
 
-func (q *Queries) Lower(ctx context.Context, arg LowerParams) ([]string, error) {
-	rows, err := q.db.QueryContext(ctx, lower, arg.Bar, arg.Bat)
+func (q *Queries) Lower(ctx context.Context, arg LowerParams, aq ...AdditionalQuery) ([]string, error) {
+	query := lower
+	queryParams := []interface{}{arg.Bar, arg.Bat}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.QueryContext(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/endtoend/testdata/lower_switched_order/pgx/v4/go/db.go
+++ b/internal/endtoend/testdata/lower_switched_order/pgx/v4/go/db.go
@@ -33,5 +33,5 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/lower_switched_order/pgx/v4/go/db.go
+++ b/internal/endtoend/testdata/lower_switched_order/pgx/v4/go/db.go
@@ -30,3 +30,8 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/lower_switched_order/pgx/v4/go/query.sql.go
+++ b/internal/endtoend/testdata/lower_switched_order/pgx/v4/go/query.sql.go
@@ -18,8 +18,16 @@ type LowerSwitchedOrderParams struct {
 	Lower string
 }
 
-func (q *Queries) LowerSwitchedOrder(ctx context.Context, arg LowerSwitchedOrderParams) ([]string, error) {
-	rows, err := q.db.Query(ctx, lowerSwitchedOrder, arg.Bar, arg.Lower)
+func (q *Queries) LowerSwitchedOrder(ctx context.Context, arg LowerSwitchedOrderParams, aq ...AdditionalQuery) ([]string, error) {
+	query := lowerSwitchedOrder
+	queryParams := []interface{}{arg.Bar, arg.Lower}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.Query(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/endtoend/testdata/lower_switched_order/pgx/v5/go/db.go
+++ b/internal/endtoend/testdata/lower_switched_order/pgx/v5/go/db.go
@@ -33,5 +33,5 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/lower_switched_order/pgx/v5/go/db.go
+++ b/internal/endtoend/testdata/lower_switched_order/pgx/v5/go/db.go
@@ -30,3 +30,8 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/lower_switched_order/pgx/v5/go/query.sql.go
+++ b/internal/endtoend/testdata/lower_switched_order/pgx/v5/go/query.sql.go
@@ -18,8 +18,16 @@ type LowerSwitchedOrderParams struct {
 	Lower string
 }
 
-func (q *Queries) LowerSwitchedOrder(ctx context.Context, arg LowerSwitchedOrderParams) ([]string, error) {
-	rows, err := q.db.Query(ctx, lowerSwitchedOrder, arg.Bar, arg.Lower)
+func (q *Queries) LowerSwitchedOrder(ctx context.Context, arg LowerSwitchedOrderParams, aq ...AdditionalQuery) ([]string, error) {
+	query := lowerSwitchedOrder
+	queryParams := []interface{}{arg.Bar, arg.Lower}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.Query(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/endtoend/testdata/lower_switched_order/stdlib/go/db.go
+++ b/internal/endtoend/testdata/lower_switched_order/stdlib/go/db.go
@@ -29,3 +29,8 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/lower_switched_order/stdlib/go/db.go
+++ b/internal/endtoend/testdata/lower_switched_order/stdlib/go/db.go
@@ -32,5 +32,5 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/lower_switched_order/stdlib/go/query.sql.go
+++ b/internal/endtoend/testdata/lower_switched_order/stdlib/go/query.sql.go
@@ -18,8 +18,16 @@ type LowerSwitchedOrderParams struct {
 	Lower string
 }
 
-func (q *Queries) LowerSwitchedOrder(ctx context.Context, arg LowerSwitchedOrderParams) ([]string, error) {
-	rows, err := q.db.QueryContext(ctx, lowerSwitchedOrder, arg.Bar, arg.Lower)
+func (q *Queries) LowerSwitchedOrder(ctx context.Context, arg LowerSwitchedOrderParams, aq ...AdditionalQuery) ([]string, error) {
+	query := lowerSwitchedOrder
+	queryParams := []interface{}{arg.Bar, arg.Lower}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.QueryContext(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/endtoend/testdata/materialized_views/postgresql/pgx/v4/go/db.go
+++ b/internal/endtoend/testdata/materialized_views/postgresql/pgx/v4/go/db.go
@@ -33,5 +33,5 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/materialized_views/postgresql/pgx/v4/go/db.go
+++ b/internal/endtoend/testdata/materialized_views/postgresql/pgx/v4/go/db.go
@@ -30,3 +30,8 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/materialized_views/postgresql/pgx/v5/go/db.go
+++ b/internal/endtoend/testdata/materialized_views/postgresql/pgx/v5/go/db.go
@@ -33,5 +33,5 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/materialized_views/postgresql/pgx/v5/go/db.go
+++ b/internal/endtoend/testdata/materialized_views/postgresql/pgx/v5/go/db.go
@@ -30,3 +30,8 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/materialized_views/postgresql/stdlib/go/db.go
+++ b/internal/endtoend/testdata/materialized_views/postgresql/stdlib/go/db.go
@@ -29,3 +29,8 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/materialized_views/postgresql/stdlib/go/db.go
+++ b/internal/endtoend/testdata/materialized_views/postgresql/stdlib/go/db.go
@@ -32,5 +32,5 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/mathmatical_operator/pgx/v4/go/db.go
+++ b/internal/endtoend/testdata/mathmatical_operator/pgx/v4/go/db.go
@@ -33,5 +33,5 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/mathmatical_operator/pgx/v4/go/db.go
+++ b/internal/endtoend/testdata/mathmatical_operator/pgx/v4/go/db.go
@@ -30,3 +30,8 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/mathmatical_operator/pgx/v4/go/query.sql.go
+++ b/internal/endtoend/testdata/mathmatical_operator/pgx/v4/go/query.sql.go
@@ -18,8 +18,16 @@ type MathRow struct {
 	Division int32
 }
 
-func (q *Queries) Math(ctx context.Context) ([]MathRow, error) {
-	rows, err := q.db.Query(ctx, math)
+func (q *Queries) Math(ctx context.Context, aq ...AdditionalQuery) ([]MathRow, error) {
+	query := math
+	queryParams := []interface{}{}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.Query(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/endtoend/testdata/mathmatical_operator/pgx/v5/go/db.go
+++ b/internal/endtoend/testdata/mathmatical_operator/pgx/v5/go/db.go
@@ -33,5 +33,5 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/mathmatical_operator/pgx/v5/go/db.go
+++ b/internal/endtoend/testdata/mathmatical_operator/pgx/v5/go/db.go
@@ -30,3 +30,8 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/mathmatical_operator/pgx/v5/go/query.sql.go
+++ b/internal/endtoend/testdata/mathmatical_operator/pgx/v5/go/query.sql.go
@@ -18,8 +18,16 @@ type MathRow struct {
 	Division int32
 }
 
-func (q *Queries) Math(ctx context.Context) ([]MathRow, error) {
-	rows, err := q.db.Query(ctx, math)
+func (q *Queries) Math(ctx context.Context, aq ...AdditionalQuery) ([]MathRow, error) {
+	query := math
+	queryParams := []interface{}{}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.Query(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/endtoend/testdata/mathmatical_operator/stdlib/go/db.go
+++ b/internal/endtoend/testdata/mathmatical_operator/stdlib/go/db.go
@@ -29,3 +29,8 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/mathmatical_operator/stdlib/go/db.go
+++ b/internal/endtoend/testdata/mathmatical_operator/stdlib/go/db.go
@@ -32,5 +32,5 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/mathmatical_operator/stdlib/go/query.sql.go
+++ b/internal/endtoend/testdata/mathmatical_operator/stdlib/go/query.sql.go
@@ -18,8 +18,16 @@ type MathRow struct {
 	Division int32
 }
 
-func (q *Queries) Math(ctx context.Context) ([]MathRow, error) {
-	rows, err := q.db.QueryContext(ctx, math)
+func (q *Queries) Math(ctx context.Context, aq ...AdditionalQuery) ([]MathRow, error) {
+	query := math
+	queryParams := []interface{}{}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.QueryContext(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/endtoend/testdata/missing_semicolon/mysql/go/db.go
+++ b/internal/endtoend/testdata/missing_semicolon/mysql/go/db.go
@@ -29,3 +29,8 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/missing_semicolon/mysql/go/db.go
+++ b/internal/endtoend/testdata/missing_semicolon/mysql/go/db.go
@@ -32,5 +32,5 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/missing_semicolon/mysql/go/query.sql.go
+++ b/internal/endtoend/testdata/missing_semicolon/mysql/go/query.sql.go
@@ -21,6 +21,9 @@ type SetAuthorParams struct {
 }
 
 func (q *Queries) SetAuthor(ctx context.Context, arg SetAuthorParams) error {
-	_, err := q.db.ExecContext(ctx, setAuthor, arg.Name, arg.ID)
+	query := setAuthor
+	queryParams := []interface{}{arg.Name, arg.ID}
+
+	_, err := q.db.ExecContext(ctx, query, queryParams...)
 	return err
 }

--- a/internal/endtoend/testdata/mix_param_types/mysql/go/db.go
+++ b/internal/endtoend/testdata/mix_param_types/mysql/go/db.go
@@ -29,3 +29,8 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/mix_param_types/mysql/go/db.go
+++ b/internal/endtoend/testdata/mix_param_types/mysql/go/db.go
@@ -32,5 +32,5 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/mix_param_types/mysql/go/test.sql.go
+++ b/internal/endtoend/testdata/mix_param_types/mysql/go/test.sql.go
@@ -18,8 +18,16 @@ type CountOneParams struct {
 	Name string
 }
 
-func (q *Queries) CountOne(ctx context.Context, arg CountOneParams) (int64, error) {
-	row := q.db.QueryRowContext(ctx, countOne, arg.ID, arg.Name)
+func (q *Queries) CountOne(ctx context.Context, arg CountOneParams, aq ...AdditionalQuery) (int64, error) {
+	query := countOne
+	queryParams := []interface{}{arg.ID, arg.Name}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	row := q.db.QueryRowContext(ctx, query, queryParams...)
 	var count int64
 	err := row.Scan(&count)
 	return count, err
@@ -35,8 +43,16 @@ type CountThreeParams struct {
 	Name  string
 }
 
-func (q *Queries) CountThree(ctx context.Context, arg CountThreeParams) (int64, error) {
-	row := q.db.QueryRowContext(ctx, countThree, arg.ID, arg.Phone, arg.Name)
+func (q *Queries) CountThree(ctx context.Context, arg CountThreeParams, aq ...AdditionalQuery) (int64, error) {
+	query := countThree
+	queryParams := []interface{}{arg.ID, arg.Phone, arg.Name}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	row := q.db.QueryRowContext(ctx, query, queryParams...)
 	var count int64
 	err := row.Scan(&count)
 	return count, err
@@ -51,8 +67,16 @@ type CountTwoParams struct {
 	Name string
 }
 
-func (q *Queries) CountTwo(ctx context.Context, arg CountTwoParams) (int64, error) {
-	row := q.db.QueryRowContext(ctx, countTwo, arg.ID, arg.Name)
+func (q *Queries) CountTwo(ctx context.Context, arg CountTwoParams, aq ...AdditionalQuery) (int64, error) {
+	query := countTwo
+	queryParams := []interface{}{arg.ID, arg.Name}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	row := q.db.QueryRowContext(ctx, query, queryParams...)
 	var count int64
 	err := row.Scan(&count)
 	return count, err

--- a/internal/endtoend/testdata/mix_param_types/postgresql/go/db.go
+++ b/internal/endtoend/testdata/mix_param_types/postgresql/go/db.go
@@ -29,3 +29,8 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/mix_param_types/postgresql/go/db.go
+++ b/internal/endtoend/testdata/mix_param_types/postgresql/go/db.go
@@ -32,5 +32,5 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/mix_param_types/postgresql/go/test.sql.go
+++ b/internal/endtoend/testdata/mix_param_types/postgresql/go/test.sql.go
@@ -19,8 +19,16 @@ type CountOneParams struct {
 	Limit int32
 }
 
-func (q *Queries) CountOne(ctx context.Context, arg CountOneParams) (int64, error) {
-	row := q.db.QueryRowContext(ctx, countOne, arg.Name, arg.ID, arg.Limit)
+func (q *Queries) CountOne(ctx context.Context, arg CountOneParams, aq ...AdditionalQuery) (int64, error) {
+	query := countOne
+	queryParams := []interface{}{arg.Name, arg.ID, arg.Limit}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	row := q.db.QueryRowContext(ctx, query, queryParams...)
 	var count int64
 	err := row.Scan(&count)
 	return count, err
@@ -36,8 +44,16 @@ type CountThreeParams struct {
 	Phone string
 }
 
-func (q *Queries) CountThree(ctx context.Context, arg CountThreeParams) (int64, error) {
-	row := q.db.QueryRowContext(ctx, countThree, arg.Name, arg.ID, arg.Phone)
+func (q *Queries) CountThree(ctx context.Context, arg CountThreeParams, aq ...AdditionalQuery) (int64, error) {
+	query := countThree
+	queryParams := []interface{}{arg.Name, arg.ID, arg.Phone}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	row := q.db.QueryRowContext(ctx, query, queryParams...)
 	var count int64
 	err := row.Scan(&count)
 	return count, err
@@ -52,8 +68,16 @@ type CountTwoParams struct {
 	Name string
 }
 
-func (q *Queries) CountTwo(ctx context.Context, arg CountTwoParams) (int64, error) {
-	row := q.db.QueryRowContext(ctx, countTwo, arg.ID, arg.Name)
+func (q *Queries) CountTwo(ctx context.Context, arg CountTwoParams, aq ...AdditionalQuery) (int64, error) {
+	query := countTwo
+	queryParams := []interface{}{arg.ID, arg.Name}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	row := q.db.QueryRowContext(ctx, query, queryParams...)
 	var count int64
 	err := row.Scan(&count)
 	return count, err

--- a/internal/endtoend/testdata/multidimension_array/pgx/v4/go/db.go
+++ b/internal/endtoend/testdata/multidimension_array/pgx/v4/go/db.go
@@ -33,5 +33,5 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/multidimension_array/pgx/v4/go/db.go
+++ b/internal/endtoend/testdata/multidimension_array/pgx/v4/go/db.go
@@ -30,3 +30,8 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/multidimension_array/pgx/v4/go/query.sql.go
+++ b/internal/endtoend/testdata/multidimension_array/pgx/v4/go/query.sql.go
@@ -13,8 +13,16 @@ const textArray = `-- name: TextArray :many
 SELECT tags FROM bar
 `
 
-func (q *Queries) TextArray(ctx context.Context) ([][][]string, error) {
-	rows, err := q.db.Query(ctx, textArray)
+func (q *Queries) TextArray(ctx context.Context, aq ...AdditionalQuery) ([][][]string, error) {
+	query := textArray
+	queryParams := []interface{}{}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.Query(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/endtoend/testdata/multidimension_array/pgx/v5/go/db.go
+++ b/internal/endtoend/testdata/multidimension_array/pgx/v5/go/db.go
@@ -33,5 +33,5 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/multidimension_array/pgx/v5/go/db.go
+++ b/internal/endtoend/testdata/multidimension_array/pgx/v5/go/db.go
@@ -30,3 +30,8 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/multidimension_array/pgx/v5/go/query.sql.go
+++ b/internal/endtoend/testdata/multidimension_array/pgx/v5/go/query.sql.go
@@ -13,8 +13,16 @@ const textArray = `-- name: TextArray :many
 SELECT tags FROM bar
 `
 
-func (q *Queries) TextArray(ctx context.Context) ([][][]string, error) {
-	rows, err := q.db.Query(ctx, textArray)
+func (q *Queries) TextArray(ctx context.Context, aq ...AdditionalQuery) ([][][]string, error) {
+	query := textArray
+	queryParams := []interface{}{}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.Query(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/endtoend/testdata/multidimension_array/stdlib/go/db.go
+++ b/internal/endtoend/testdata/multidimension_array/stdlib/go/db.go
@@ -29,3 +29,8 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/multidimension_array/stdlib/go/db.go
+++ b/internal/endtoend/testdata/multidimension_array/stdlib/go/db.go
@@ -32,5 +32,5 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/multidimension_array/stdlib/go/query.sql.go
+++ b/internal/endtoend/testdata/multidimension_array/stdlib/go/query.sql.go
@@ -15,8 +15,16 @@ const textArray = `-- name: TextArray :many
 SELECT tags FROM bar
 `
 
-func (q *Queries) TextArray(ctx context.Context) ([][][]string, error) {
-	rows, err := q.db.QueryContext(ctx, textArray)
+func (q *Queries) TextArray(ctx context.Context, aq ...AdditionalQuery) ([][][]string, error) {
+	query := textArray
+	queryParams := []interface{}{}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.QueryContext(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/endtoend/testdata/multischema/pgx/v4/go/db.go
+++ b/internal/endtoend/testdata/multischema/pgx/v4/go/db.go
@@ -33,5 +33,5 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/multischema/pgx/v4/go/db.go
+++ b/internal/endtoend/testdata/multischema/pgx/v4/go/db.go
@@ -30,3 +30,8 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/multischema/pgx/v4/go/query.sql.go
+++ b/internal/endtoend/testdata/multischema/pgx/v4/go/query.sql.go
@@ -13,8 +13,16 @@ const listBar = `-- name: ListBar :many
 SELECT id FROM bar
 `
 
-func (q *Queries) ListBar(ctx context.Context) ([]int32, error) {
-	rows, err := q.db.Query(ctx, listBar)
+func (q *Queries) ListBar(ctx context.Context, aq ...AdditionalQuery) ([]int32, error) {
+	query := listBar
+	queryParams := []interface{}{}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.Query(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}
@@ -37,8 +45,16 @@ const listFoo = `-- name: ListFoo :many
 SELECT id, bar FROM foo
 `
 
-func (q *Queries) ListFoo(ctx context.Context) ([]Foo, error) {
-	rows, err := q.db.Query(ctx, listFoo)
+func (q *Queries) ListFoo(ctx context.Context, aq ...AdditionalQuery) ([]Foo, error) {
+	query := listFoo
+	queryParams := []interface{}{}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.Query(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/endtoend/testdata/multischema/pgx/v5/go/db.go
+++ b/internal/endtoend/testdata/multischema/pgx/v5/go/db.go
@@ -33,5 +33,5 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/multischema/pgx/v5/go/db.go
+++ b/internal/endtoend/testdata/multischema/pgx/v5/go/db.go
@@ -30,3 +30,8 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/multischema/pgx/v5/go/query.sql.go
+++ b/internal/endtoend/testdata/multischema/pgx/v5/go/query.sql.go
@@ -13,8 +13,16 @@ const listBar = `-- name: ListBar :many
 SELECT id FROM bar
 `
 
-func (q *Queries) ListBar(ctx context.Context) ([]int32, error) {
-	rows, err := q.db.Query(ctx, listBar)
+func (q *Queries) ListBar(ctx context.Context, aq ...AdditionalQuery) ([]int32, error) {
+	query := listBar
+	queryParams := []interface{}{}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.Query(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}
@@ -37,8 +45,16 @@ const listFoo = `-- name: ListFoo :many
 SELECT id, bar FROM foo
 `
 
-func (q *Queries) ListFoo(ctx context.Context) ([]Foo, error) {
-	rows, err := q.db.Query(ctx, listFoo)
+func (q *Queries) ListFoo(ctx context.Context, aq ...AdditionalQuery) ([]Foo, error) {
+	query := listFoo
+	queryParams := []interface{}{}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.Query(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/endtoend/testdata/multischema/stdlib/go/db.go
+++ b/internal/endtoend/testdata/multischema/stdlib/go/db.go
@@ -29,3 +29,8 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/multischema/stdlib/go/db.go
+++ b/internal/endtoend/testdata/multischema/stdlib/go/db.go
@@ -32,5 +32,5 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/multischema/stdlib/go/query.sql.go
+++ b/internal/endtoend/testdata/multischema/stdlib/go/query.sql.go
@@ -13,8 +13,16 @@ const listBar = `-- name: ListBar :many
 SELECT id FROM bar
 `
 
-func (q *Queries) ListBar(ctx context.Context) ([]int32, error) {
-	rows, err := q.db.QueryContext(ctx, listBar)
+func (q *Queries) ListBar(ctx context.Context, aq ...AdditionalQuery) ([]int32, error) {
+	query := listBar
+	queryParams := []interface{}{}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.QueryContext(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}
@@ -40,8 +48,16 @@ const listFoo = `-- name: ListFoo :many
 SELECT id, bar FROM foo
 `
 
-func (q *Queries) ListFoo(ctx context.Context) ([]Foo, error) {
-	rows, err := q.db.QueryContext(ctx, listFoo)
+func (q *Queries) ListFoo(ctx context.Context, aq ...AdditionalQuery) ([]Foo, error) {
+	query := listFoo
+	queryParams := []interface{}{}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.QueryContext(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/endtoend/testdata/mysql_reference_manual/aggregate_functions/go/db.go
+++ b/internal/endtoend/testdata/mysql_reference_manual/aggregate_functions/go/db.go
@@ -29,3 +29,8 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/mysql_reference_manual/aggregate_functions/go/db.go
+++ b/internal/endtoend/testdata/mysql_reference_manual/aggregate_functions/go/db.go
@@ -32,5 +32,5 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/mysql_reference_manual/aggregate_functions/go/group_concat.sql.go
+++ b/internal/endtoend/testdata/mysql_reference_manual/aggregate_functions/go/group_concat.sql.go
@@ -21,8 +21,16 @@ type GroupConcatRow struct {
 	GroupConcat sql.NullString
 }
 
-func (q *Queries) GroupConcat(ctx context.Context) ([]GroupConcatRow, error) {
-	rows, err := q.db.QueryContext(ctx, groupConcat)
+func (q *Queries) GroupConcat(ctx context.Context, aq ...AdditionalQuery) ([]GroupConcatRow, error) {
+	query := groupConcat
+	queryParams := []interface{}{}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.QueryContext(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}
@@ -56,8 +64,16 @@ type GroupConcatOrderByRow struct {
 	GroupConcat sql.NullString
 }
 
-func (q *Queries) GroupConcatOrderBy(ctx context.Context) ([]GroupConcatOrderByRow, error) {
-	rows, err := q.db.QueryContext(ctx, groupConcatOrderBy)
+func (q *Queries) GroupConcatOrderBy(ctx context.Context, aq ...AdditionalQuery) ([]GroupConcatOrderByRow, error) {
+	query := groupConcatOrderBy
+	queryParams := []interface{}{}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.QueryContext(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/endtoend/testdata/mysql_reference_manual/date_and_time_functions/go/date_add.sql.go
+++ b/internal/endtoend/testdata/mysql_reference_manual/date_and_time_functions/go/date_add.sql.go
@@ -15,8 +15,16 @@ SELECT DATE_ADD('1900-01-01 00:00:00',
                 INTERVAL '-1 10' DAY_HOUR)
 `
 
-func (q *Queries) DateAddDayHour(ctx context.Context) (time.Time, error) {
-	row := q.db.QueryRowContext(ctx, dateAddDayHour)
+func (q *Queries) DateAddDayHour(ctx context.Context, aq ...AdditionalQuery) (time.Time, error) {
+	query := dateAddDayHour
+	queryParams := []interface{}{}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	row := q.db.QueryRowContext(ctx, query, queryParams...)
 	var date_add time.Time
 	err := row.Scan(&date_add)
 	return date_add, err
@@ -27,8 +35,16 @@ SELECT DATE_ADD('2100-12-31 23:59:59',
                 INTERVAL '1:1' MINUTE_SECOND)
 `
 
-func (q *Queries) DateAddMinuteSecond(ctx context.Context) (time.Time, error) {
-	row := q.db.QueryRowContext(ctx, dateAddMinuteSecond)
+func (q *Queries) DateAddMinuteSecond(ctx context.Context, aq ...AdditionalQuery) (time.Time, error) {
+	query := dateAddMinuteSecond
+	queryParams := []interface{}{}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	row := q.db.QueryRowContext(ctx, query, queryParams...)
 	var date_add time.Time
 	err := row.Scan(&date_add)
 	return date_add, err
@@ -40,8 +56,16 @@ SELECT DATE_ADD('2018-05-01',INTERVAL 1 DAY)
 `
 
 // https://dev.mysql.com/doc/refman/8.0/en/date-and-time-functions.html#function_date-add
-func (q *Queries) DateAddOneDay(ctx context.Context) (time.Time, error) {
-	row := q.db.QueryRowContext(ctx, dateAddOneDay)
+func (q *Queries) DateAddOneDay(ctx context.Context, aq ...AdditionalQuery) (time.Time, error) {
+	query := dateAddOneDay
+	queryParams := []interface{}{}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	row := q.db.QueryRowContext(ctx, query, queryParams...)
 	var date_add time.Time
 	err := row.Scan(&date_add)
 	return date_add, err
@@ -52,8 +76,16 @@ SELECT DATE_ADD('2020-12-31 23:59:59',
                 INTERVAL 1 SECOND)
 `
 
-func (q *Queries) DateAddOneSecond(ctx context.Context) (time.Time, error) {
-	row := q.db.QueryRowContext(ctx, dateAddOneSecond)
+func (q *Queries) DateAddOneSecond(ctx context.Context, aq ...AdditionalQuery) (time.Time, error) {
+	query := dateAddOneSecond
+	queryParams := []interface{}{}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	row := q.db.QueryRowContext(ctx, query, queryParams...)
 	var date_add time.Time
 	err := row.Scan(&date_add)
 	return date_add, err
@@ -64,8 +96,16 @@ SELECT DATE_ADD('1992-12-31 23:59:59.000002',
            INTERVAL '1.999999' SECOND_MICROSECOND)
 `
 
-func (q *Queries) DateAddSecondMicrosecond(ctx context.Context) (time.Time, error) {
-	row := q.db.QueryRowContext(ctx, dateAddSecondMicrosecond)
+func (q *Queries) DateAddSecondMicrosecond(ctx context.Context, aq ...AdditionalQuery) (time.Time, error) {
+	query := dateAddSecondMicrosecond
+	queryParams := []interface{}{}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	row := q.db.QueryRowContext(ctx, query, queryParams...)
 	var date_add time.Time
 	err := row.Scan(&date_add)
 	return date_add, err
@@ -76,8 +116,16 @@ SELECT DATE_ADD('2018-12-31 23:59:59',
                 INTERVAL 1 DAY)
 `
 
-func (q *Queries) DateAddTimestampOneSecond(ctx context.Context) (time.Time, error) {
-	row := q.db.QueryRowContext(ctx, dateAddTimestampOneSecond)
+func (q *Queries) DateAddTimestampOneSecond(ctx context.Context, aq ...AdditionalQuery) (time.Time, error) {
+	query := dateAddTimestampOneSecond
+	queryParams := []interface{}{}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	row := q.db.QueryRowContext(ctx, query, queryParams...)
 	var date_add time.Time
 	err := row.Scan(&date_add)
 	return date_add, err

--- a/internal/endtoend/testdata/mysql_reference_manual/date_and_time_functions/go/date_sub.sql.go
+++ b/internal/endtoend/testdata/mysql_reference_manual/date_and_time_functions/go/date_sub.sql.go
@@ -14,8 +14,16 @@ const dateSub31Days = `-- name: DateSub31Days :one
 SELECT DATE_SUB('1998-01-02', INTERVAL 31 DAY)
 `
 
-func (q *Queries) DateSub31Days(ctx context.Context) (time.Time, error) {
-	row := q.db.QueryRowContext(ctx, dateSub31Days)
+func (q *Queries) DateSub31Days(ctx context.Context, aq ...AdditionalQuery) (time.Time, error) {
+	query := dateSub31Days
+	queryParams := []interface{}{}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	row := q.db.QueryRowContext(ctx, query, queryParams...)
 	var date_sub time.Time
 	err := row.Scan(&date_sub)
 	return date_sub, err
@@ -26,8 +34,16 @@ SELECT DATE_SUB('2025-01-01 00:00:00',
                 INTERVAL '1 1:1:1' DAY_SECOND)
 `
 
-func (q *Queries) DateSubDaySecond(ctx context.Context) (time.Time, error) {
-	row := q.db.QueryRowContext(ctx, dateSubDaySecond)
+func (q *Queries) DateSubDaySecond(ctx context.Context, aq ...AdditionalQuery) (time.Time, error) {
+	query := dateSubDaySecond
+	queryParams := []interface{}{}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	row := q.db.QueryRowContext(ctx, query, queryParams...)
 	var date_sub time.Time
 	err := row.Scan(&date_sub)
 	return date_sub, err
@@ -37,8 +53,16 @@ const dateSubOneYear = `-- name: DateSubOneYear :one
 SELECT DATE_SUB('2018-05-01',INTERVAL 1 YEAR)
 `
 
-func (q *Queries) DateSubOneYear(ctx context.Context) (time.Time, error) {
-	row := q.db.QueryRowContext(ctx, dateSubOneYear)
+func (q *Queries) DateSubOneYear(ctx context.Context, aq ...AdditionalQuery) (time.Time, error) {
+	query := dateSubOneYear
+	queryParams := []interface{}{}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	row := q.db.QueryRowContext(ctx, query, queryParams...)
 	var date_sub time.Time
 	err := row.Scan(&date_sub)
 	return date_sub, err

--- a/internal/endtoend/testdata/mysql_reference_manual/date_and_time_functions/go/db.go
+++ b/internal/endtoend/testdata/mysql_reference_manual/date_and_time_functions/go/db.go
@@ -29,3 +29,8 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/mysql_reference_manual/date_and_time_functions/go/db.go
+++ b/internal/endtoend/testdata/mysql_reference_manual/date_and_time_functions/go/db.go
@@ -32,5 +32,5 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/named_param/pgx/v4/go/db.go
+++ b/internal/endtoend/testdata/named_param/pgx/v4/go/db.go
@@ -33,5 +33,5 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/named_param/pgx/v4/go/db.go
+++ b/internal/endtoend/testdata/named_param/pgx/v4/go/db.go
@@ -30,3 +30,8 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/named_param/pgx/v4/go/query.sql.go
+++ b/internal/endtoend/testdata/named_param/pgx/v4/go/query.sql.go
@@ -18,8 +18,16 @@ type AtParamsParams struct {
 	Filter bool
 }
 
-func (q *Queries) AtParams(ctx context.Context, arg AtParamsParams) ([]string, error) {
-	rows, err := q.db.Query(ctx, atParams, arg.Slug, arg.Filter)
+func (q *Queries) AtParams(ctx context.Context, arg AtParamsParams, aq ...AdditionalQuery) ([]string, error) {
+	query := atParams
+	queryParams := []interface{}{arg.Slug, arg.Filter}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.Query(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}
@@ -47,8 +55,16 @@ type FuncParamsParams struct {
 	Filter bool
 }
 
-func (q *Queries) FuncParams(ctx context.Context, arg FuncParamsParams) ([]string, error) {
-	rows, err := q.db.Query(ctx, funcParams, arg.Slug, arg.Filter)
+func (q *Queries) FuncParams(ctx context.Context, arg FuncParamsParams, aq ...AdditionalQuery) ([]string, error) {
+	query := funcParams
+	queryParams := []interface{}{arg.Slug, arg.Filter}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.Query(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}
@@ -76,8 +92,10 @@ type InsertAtParamsParams struct {
 	Bio  string
 }
 
-func (q *Queries) InsertAtParams(ctx context.Context, arg InsertAtParamsParams) (string, error) {
-	row := q.db.QueryRow(ctx, insertAtParams, arg.Name, arg.Bio)
+func (q *Queries) InsertAtParams(ctx context.Context, arg InsertAtParamsParams, aq ...AdditionalQuery) (string, error) {
+	query := insertAtParams
+	queryParams := []interface{}{arg.Name, arg.Bio}
+	row := q.db.QueryRow(ctx, query, queryParams...)
 	var name string
 	err := row.Scan(&name)
 	return name, err
@@ -92,8 +110,10 @@ type InsertFuncParamsParams struct {
 	Bio  string
 }
 
-func (q *Queries) InsertFuncParams(ctx context.Context, arg InsertFuncParamsParams) (string, error) {
-	row := q.db.QueryRow(ctx, insertFuncParams, arg.Name, arg.Bio)
+func (q *Queries) InsertFuncParams(ctx context.Context, arg InsertFuncParamsParams, aq ...AdditionalQuery) (string, error) {
+	query := insertFuncParams
+	queryParams := []interface{}{arg.Name, arg.Bio}
+	row := q.db.QueryRow(ctx, query, queryParams...)
 	var name string
 	err := row.Scan(&name)
 	return name, err
@@ -114,8 +134,10 @@ type UpdateParams struct {
 	Name    string
 }
 
-func (q *Queries) Update(ctx context.Context, arg UpdateParams) (Foo, error) {
-	row := q.db.QueryRow(ctx, update, arg.SetName, arg.Name)
+func (q *Queries) Update(ctx context.Context, arg UpdateParams, aq ...AdditionalQuery) (Foo, error) {
+	query := update
+	queryParams := []interface{}{arg.SetName, arg.Name}
+	row := q.db.QueryRow(ctx, query, queryParams...)
 	var i Foo
 	err := row.Scan(&i.Name, &i.Bio)
 	return i, err

--- a/internal/endtoend/testdata/named_param/pgx/v5/go/db.go
+++ b/internal/endtoend/testdata/named_param/pgx/v5/go/db.go
@@ -33,5 +33,5 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/named_param/pgx/v5/go/db.go
+++ b/internal/endtoend/testdata/named_param/pgx/v5/go/db.go
@@ -30,3 +30,8 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/named_param/pgx/v5/go/query.sql.go
+++ b/internal/endtoend/testdata/named_param/pgx/v5/go/query.sql.go
@@ -18,8 +18,16 @@ type AtParamsParams struct {
 	Filter bool
 }
 
-func (q *Queries) AtParams(ctx context.Context, arg AtParamsParams) ([]string, error) {
-	rows, err := q.db.Query(ctx, atParams, arg.Slug, arg.Filter)
+func (q *Queries) AtParams(ctx context.Context, arg AtParamsParams, aq ...AdditionalQuery) ([]string, error) {
+	query := atParams
+	queryParams := []interface{}{arg.Slug, arg.Filter}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.Query(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}
@@ -47,8 +55,16 @@ type FuncParamsParams struct {
 	Filter bool
 }
 
-func (q *Queries) FuncParams(ctx context.Context, arg FuncParamsParams) ([]string, error) {
-	rows, err := q.db.Query(ctx, funcParams, arg.Slug, arg.Filter)
+func (q *Queries) FuncParams(ctx context.Context, arg FuncParamsParams, aq ...AdditionalQuery) ([]string, error) {
+	query := funcParams
+	queryParams := []interface{}{arg.Slug, arg.Filter}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.Query(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}
@@ -76,8 +92,10 @@ type InsertAtParamsParams struct {
 	Bio  string
 }
 
-func (q *Queries) InsertAtParams(ctx context.Context, arg InsertAtParamsParams) (string, error) {
-	row := q.db.QueryRow(ctx, insertAtParams, arg.Name, arg.Bio)
+func (q *Queries) InsertAtParams(ctx context.Context, arg InsertAtParamsParams, aq ...AdditionalQuery) (string, error) {
+	query := insertAtParams
+	queryParams := []interface{}{arg.Name, arg.Bio}
+	row := q.db.QueryRow(ctx, query, queryParams...)
 	var name string
 	err := row.Scan(&name)
 	return name, err
@@ -92,8 +110,10 @@ type InsertFuncParamsParams struct {
 	Bio  string
 }
 
-func (q *Queries) InsertFuncParams(ctx context.Context, arg InsertFuncParamsParams) (string, error) {
-	row := q.db.QueryRow(ctx, insertFuncParams, arg.Name, arg.Bio)
+func (q *Queries) InsertFuncParams(ctx context.Context, arg InsertFuncParamsParams, aq ...AdditionalQuery) (string, error) {
+	query := insertFuncParams
+	queryParams := []interface{}{arg.Name, arg.Bio}
+	row := q.db.QueryRow(ctx, query, queryParams...)
 	var name string
 	err := row.Scan(&name)
 	return name, err
@@ -114,8 +134,10 @@ type UpdateParams struct {
 	Name    string
 }
 
-func (q *Queries) Update(ctx context.Context, arg UpdateParams) (Foo, error) {
-	row := q.db.QueryRow(ctx, update, arg.SetName, arg.Name)
+func (q *Queries) Update(ctx context.Context, arg UpdateParams, aq ...AdditionalQuery) (Foo, error) {
+	query := update
+	queryParams := []interface{}{arg.SetName, arg.Name}
+	row := q.db.QueryRow(ctx, query, queryParams...)
 	var i Foo
 	err := row.Scan(&i.Name, &i.Bio)
 	return i, err

--- a/internal/endtoend/testdata/named_param/sqlite/go/db.go
+++ b/internal/endtoend/testdata/named_param/sqlite/go/db.go
@@ -29,3 +29,8 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/named_param/sqlite/go/db.go
+++ b/internal/endtoend/testdata/named_param/sqlite/go/db.go
@@ -32,5 +32,5 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/named_param/sqlite/go/query.sql.go
+++ b/internal/endtoend/testdata/named_param/sqlite/go/query.sql.go
@@ -13,8 +13,16 @@ const atParams = `-- name: AtParams :many
 SELECT name FROM foo WHERE name = ?1
 `
 
-func (q *Queries) AtParams(ctx context.Context, slug string) ([]string, error) {
-	rows, err := q.db.QueryContext(ctx, atParams, slug)
+func (q *Queries) AtParams(ctx context.Context, slug string, aq ...AdditionalQuery) ([]string, error) {
+	query := atParams
+	queryParams := []interface{}{slug}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.QueryContext(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}
@@ -40,8 +48,16 @@ const funcParams = `-- name: FuncParams :many
 SELECT name FROM foo WHERE name = ?1
 `
 
-func (q *Queries) FuncParams(ctx context.Context, slug string) ([]string, error) {
-	rows, err := q.db.QueryContext(ctx, funcParams, slug)
+func (q *Queries) FuncParams(ctx context.Context, slug string, aq ...AdditionalQuery) ([]string, error) {
+	query := funcParams
+	queryParams := []interface{}{slug}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.QueryContext(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}
@@ -72,8 +88,16 @@ type InsertAtParamsParams struct {
 	Bio  string
 }
 
-func (q *Queries) InsertAtParams(ctx context.Context, arg InsertAtParamsParams) (string, error) {
-	row := q.db.QueryRowContext(ctx, insertAtParams, arg.Name, arg.Bio)
+func (q *Queries) InsertAtParams(ctx context.Context, arg InsertAtParamsParams, aq ...AdditionalQuery) (string, error) {
+	query := insertAtParams
+	queryParams := []interface{}{arg.Name, arg.Bio}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	row := q.db.QueryRowContext(ctx, query, queryParams...)
 	var name string
 	err := row.Scan(&name)
 	return name, err
@@ -88,8 +112,16 @@ type InsertFuncParamsParams struct {
 	Bio  string
 }
 
-func (q *Queries) InsertFuncParams(ctx context.Context, arg InsertFuncParamsParams) (string, error) {
-	row := q.db.QueryRowContext(ctx, insertFuncParams, arg.Name, arg.Bio)
+func (q *Queries) InsertFuncParams(ctx context.Context, arg InsertFuncParamsParams, aq ...AdditionalQuery) (string, error) {
+	query := insertFuncParams
+	queryParams := []interface{}{arg.Name, arg.Bio}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	row := q.db.QueryRowContext(ctx, query, queryParams...)
 	var name string
 	err := row.Scan(&name)
 	return name, err

--- a/internal/endtoend/testdata/named_param/stdlib/go/db.go
+++ b/internal/endtoend/testdata/named_param/stdlib/go/db.go
@@ -29,3 +29,8 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/named_param/stdlib/go/db.go
+++ b/internal/endtoend/testdata/named_param/stdlib/go/db.go
@@ -32,5 +32,5 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/named_param/stdlib/go/query.sql.go
+++ b/internal/endtoend/testdata/named_param/stdlib/go/query.sql.go
@@ -18,8 +18,16 @@ type AtParamsParams struct {
 	Filter bool
 }
 
-func (q *Queries) AtParams(ctx context.Context, arg AtParamsParams) ([]string, error) {
-	rows, err := q.db.QueryContext(ctx, atParams, arg.Slug, arg.Filter)
+func (q *Queries) AtParams(ctx context.Context, arg AtParamsParams, aq ...AdditionalQuery) ([]string, error) {
+	query := atParams
+	queryParams := []interface{}{arg.Slug, arg.Filter}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.QueryContext(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}
@@ -50,8 +58,16 @@ type FuncParamsParams struct {
 	Filter bool
 }
 
-func (q *Queries) FuncParams(ctx context.Context, arg FuncParamsParams) ([]string, error) {
-	rows, err := q.db.QueryContext(ctx, funcParams, arg.Slug, arg.Filter)
+func (q *Queries) FuncParams(ctx context.Context, arg FuncParamsParams, aq ...AdditionalQuery) ([]string, error) {
+	query := funcParams
+	queryParams := []interface{}{arg.Slug, arg.Filter}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.QueryContext(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}
@@ -82,8 +98,16 @@ type InsertAtParamsParams struct {
 	Bio  string
 }
 
-func (q *Queries) InsertAtParams(ctx context.Context, arg InsertAtParamsParams) (string, error) {
-	row := q.db.QueryRowContext(ctx, insertAtParams, arg.Name, arg.Bio)
+func (q *Queries) InsertAtParams(ctx context.Context, arg InsertAtParamsParams, aq ...AdditionalQuery) (string, error) {
+	query := insertAtParams
+	queryParams := []interface{}{arg.Name, arg.Bio}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	row := q.db.QueryRowContext(ctx, query, queryParams...)
 	var name string
 	err := row.Scan(&name)
 	return name, err
@@ -98,8 +122,16 @@ type InsertFuncParamsParams struct {
 	Bio  string
 }
 
-func (q *Queries) InsertFuncParams(ctx context.Context, arg InsertFuncParamsParams) (string, error) {
-	row := q.db.QueryRowContext(ctx, insertFuncParams, arg.Name, arg.Bio)
+func (q *Queries) InsertFuncParams(ctx context.Context, arg InsertFuncParamsParams, aq ...AdditionalQuery) (string, error) {
+	query := insertFuncParams
+	queryParams := []interface{}{arg.Name, arg.Bio}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	row := q.db.QueryRowContext(ctx, query, queryParams...)
 	var name string
 	err := row.Scan(&name)
 	return name, err
@@ -120,8 +152,16 @@ type UpdateParams struct {
 	Name    string
 }
 
-func (q *Queries) Update(ctx context.Context, arg UpdateParams) (Foo, error) {
-	row := q.db.QueryRowContext(ctx, update, arg.SetName, arg.Name)
+func (q *Queries) Update(ctx context.Context, arg UpdateParams, aq ...AdditionalQuery) (Foo, error) {
+	query := update
+	queryParams := []interface{}{arg.SetName, arg.Name}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	row := q.db.QueryRowContext(ctx, query, queryParams...)
 	var i Foo
 	err := row.Scan(&i.Name, &i.Bio)
 	return i, err

--- a/internal/endtoend/testdata/nextval/postgresql/go/db.go
+++ b/internal/endtoend/testdata/nextval/postgresql/go/db.go
@@ -29,3 +29,8 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/nextval/postgresql/go/db.go
+++ b/internal/endtoend/testdata/nextval/postgresql/go/db.go
@@ -32,5 +32,5 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/nextval/postgresql/go/query.sql.go
+++ b/internal/endtoend/testdata/nextval/postgresql/go/query.sql.go
@@ -19,8 +19,16 @@ type GetNextIDRow struct {
 	Pk_2 int64
 }
 
-func (q *Queries) GetNextID(ctx context.Context) (GetNextIDRow, error) {
-	row := q.db.QueryRowContext(ctx, getNextID)
+func (q *Queries) GetNextID(ctx context.Context, aq ...AdditionalQuery) (GetNextIDRow, error) {
+	query := getNextID
+	queryParams := []interface{}{}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	row := q.db.QueryRowContext(ctx, query, queryParams...)
 	var i GetNextIDRow
 	err := row.Scan(&i.Pk, &i.Pk_2)
 	return i, err

--- a/internal/endtoend/testdata/notifylisten/postgresql/pgx/v5/go/db.go
+++ b/internal/endtoend/testdata/notifylisten/postgresql/pgx/v5/go/db.go
@@ -33,5 +33,5 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/notifylisten/postgresql/pgx/v5/go/db.go
+++ b/internal/endtoend/testdata/notifylisten/postgresql/pgx/v5/go/db.go
@@ -30,3 +30,8 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/omit_unused_structs/postgresql/stdlib/go/db.go
+++ b/internal/endtoend/testdata/omit_unused_structs/postgresql/stdlib/go/db.go
@@ -29,3 +29,8 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/omit_unused_structs/postgresql/stdlib/go/db.go
+++ b/internal/endtoend/testdata/omit_unused_structs/postgresql/stdlib/go/db.go
@@ -32,5 +32,5 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/omit_unused_structs/postgresql/stdlib/go/query.sql.go
+++ b/internal/endtoend/testdata/omit_unused_structs/postgresql/stdlib/go/query.sql.go
@@ -14,8 +14,16 @@ const query_param_enum_table = `-- name: query_param_enum_table :one
 SELECT id, other, value FROM query_param_enum_table WHERE value = $1
 `
 
-func (q *Queries) query_param_enum_table(ctx context.Context, value NullQueryParamEnumTableEnum) (QueryParamEnumTable, error) {
-	row := q.db.QueryRowContext(ctx, query_param_enum_table, value)
+func (q *Queries) query_param_enum_table(ctx context.Context, value NullQueryParamEnumTableEnum, aq ...AdditionalQuery) (QueryParamEnumTable, error) {
+	query := query_param_enum_table
+	queryParams := []interface{}{value}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	row := q.db.QueryRowContext(ctx, query, queryParams...)
 	var i QueryParamEnumTable
 	err := row.Scan(&i.ID, &i.Other, &i.Value)
 	return i, err
@@ -30,8 +38,16 @@ type query_param_struct_enum_tableParams struct {
 	Value NullQueryParamStructEnumTableEnum
 }
 
-func (q *Queries) query_param_struct_enum_table(ctx context.Context, arg query_param_struct_enum_tableParams) (int32, error) {
-	row := q.db.QueryRowContext(ctx, query_param_struct_enum_table, arg.ID, arg.Value)
+func (q *Queries) query_param_struct_enum_table(ctx context.Context, arg query_param_struct_enum_tableParams, aq ...AdditionalQuery) (int32, error) {
+	query := query_param_struct_enum_table
+	queryParams := []interface{}{arg.ID, arg.Value}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	row := q.db.QueryRowContext(ctx, query, queryParams...)
 	var id int32
 	err := row.Scan(&id)
 	return id, err
@@ -41,8 +57,16 @@ const query_return_enum_table = `-- name: query_return_enum_table :one
 SELECT value FROM query_return_enum_table WHERE id = $1
 `
 
-func (q *Queries) query_return_enum_table(ctx context.Context, id int32) (NullQueryReturnEnumTableEnum, error) {
-	row := q.db.QueryRowContext(ctx, query_return_enum_table, id)
+func (q *Queries) query_return_enum_table(ctx context.Context, id int32, aq ...AdditionalQuery) (NullQueryReturnEnumTableEnum, error) {
+	query := query_return_enum_table
+	queryParams := []interface{}{id}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	row := q.db.QueryRowContext(ctx, query, queryParams...)
 	var value NullQueryReturnEnumTableEnum
 	err := row.Scan(&value)
 	return value, err
@@ -52,8 +76,16 @@ const query_return_full_table = `-- name: query_return_full_table :many
 SELECT id, value FROM query_return_full_table
 `
 
-func (q *Queries) query_return_full_table(ctx context.Context) ([]QueryReturnFullTable, error) {
-	rows, err := q.db.QueryContext(ctx, query_return_full_table)
+func (q *Queries) query_return_full_table(ctx context.Context, aq ...AdditionalQuery) ([]QueryReturnFullTable, error) {
+	query := query_return_full_table
+	queryParams := []interface{}{}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.QueryContext(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}
@@ -84,8 +116,16 @@ type query_return_struct_enum_tableRow struct {
 	Another sql.NullInt32
 }
 
-func (q *Queries) query_return_struct_enum_table(ctx context.Context, id int32) (query_return_struct_enum_tableRow, error) {
-	row := q.db.QueryRowContext(ctx, query_return_struct_enum_table, id)
+func (q *Queries) query_return_struct_enum_table(ctx context.Context, id int32, aq ...AdditionalQuery) (query_return_struct_enum_tableRow, error) {
+	query := query_return_struct_enum_table
+	queryParams := []interface{}{id}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	row := q.db.QueryRowContext(ctx, query, queryParams...)
 	var i query_return_struct_enum_tableRow
 	err := row.Scan(&i.Value, &i.Another)
 	return i, err

--- a/internal/endtoend/testdata/on_duplicate_key_update/mysql/db/db.go
+++ b/internal/endtoend/testdata/on_duplicate_key_update/mysql/db/db.go
@@ -29,3 +29,8 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/on_duplicate_key_update/mysql/db/db.go
+++ b/internal/endtoend/testdata/on_duplicate_key_update/mysql/db/db.go
@@ -32,5 +32,5 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/on_duplicate_key_update/mysql/db/query.sql.go
+++ b/internal/endtoend/testdata/on_duplicate_key_update/mysql/db/query.sql.go
@@ -24,7 +24,10 @@ type UpsertAuthorParams struct {
 }
 
 func (q *Queries) UpsertAuthor(ctx context.Context, arg UpsertAuthorParams) error {
-	_, err := q.db.ExecContext(ctx, upsertAuthor, arg.Name, arg.Bio, arg.Bio_2)
+	query := upsertAuthor
+	queryParams := []interface{}{arg.Name, arg.Bio, arg.Bio_2}
+
+	_, err := q.db.ExecContext(ctx, query, queryParams...)
 	return err
 }
 
@@ -41,6 +44,9 @@ type UpsertAuthorNamedParams struct {
 }
 
 func (q *Queries) UpsertAuthorNamed(ctx context.Context, arg UpsertAuthorNamedParams) error {
-	_, err := q.db.ExecContext(ctx, upsertAuthorNamed, arg.Name, arg.Bio, arg.Bio)
+	query := upsertAuthorNamed
+	queryParams := []interface{}{arg.Name, arg.Bio, arg.Bio}
+
+	_, err := q.db.ExecContext(ctx, query, queryParams...)
 	return err
 }

--- a/internal/endtoend/testdata/on_duplicate_key_update/postgresql/db/db.go
+++ b/internal/endtoend/testdata/on_duplicate_key_update/postgresql/db/db.go
@@ -29,3 +29,8 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/on_duplicate_key_update/postgresql/db/db.go
+++ b/internal/endtoend/testdata/on_duplicate_key_update/postgresql/db/db.go
@@ -32,5 +32,5 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/on_duplicate_key_update/postgresql/db/query.sql.go
+++ b/internal/endtoend/testdata/on_duplicate_key_update/postgresql/db/query.sql.go
@@ -23,7 +23,10 @@ type UpsertAuthorParams struct {
 }
 
 func (q *Queries) UpsertAuthor(ctx context.Context, arg UpsertAuthorParams) error {
-	_, err := q.db.ExecContext(ctx, upsertAuthor, arg.Name, arg.Bio)
+	query := upsertAuthor
+	queryParams := []interface{}{arg.Name, arg.Bio}
+
+	_, err := q.db.ExecContext(ctx, query, queryParams...)
 	return err
 }
 
@@ -40,6 +43,9 @@ type UpsertAuthorNamedParams struct {
 }
 
 func (q *Queries) UpsertAuthorNamed(ctx context.Context, arg UpsertAuthorNamedParams) error {
-	_, err := q.db.ExecContext(ctx, upsertAuthorNamed, arg.Name, arg.Bio)
+	query := upsertAuthorNamed
+	queryParams := []interface{}{arg.Name, arg.Bio}
+
+	_, err := q.db.ExecContext(ctx, query, queryParams...)
 	return err
 }

--- a/internal/endtoend/testdata/operator_string_concat/postgresql/pgx/v4/go/db.go
+++ b/internal/endtoend/testdata/operator_string_concat/postgresql/pgx/v4/go/db.go
@@ -33,5 +33,5 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/operator_string_concat/postgresql/pgx/v4/go/db.go
+++ b/internal/endtoend/testdata/operator_string_concat/postgresql/pgx/v4/go/db.go
@@ -30,3 +30,8 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/operator_string_concat/postgresql/pgx/v4/go/query.sql.go
+++ b/internal/endtoend/testdata/operator_string_concat/postgresql/pgx/v4/go/query.sql.go
@@ -15,8 +15,10 @@ select txt from Demo
 where txt ~~ '%' || $1 || '%'
 `
 
-func (q *Queries) Test(ctx context.Context, val string) (string, error) {
-	row := q.db.QueryRow(ctx, test, val)
+func (q *Queries) Test(ctx context.Context, val string, aq ...AdditionalQuery) (string, error) {
+	query := test
+	queryParams := []interface{}{val}
+	row := q.db.QueryRow(ctx, query, queryParams...)
 	var txt string
 	err := row.Scan(&txt)
 	return txt, err
@@ -27,8 +29,10 @@ select txt from Demo
 where txt like '%' || $1 || '%'
 `
 
-func (q *Queries) Test2(ctx context.Context, val sql.NullString) (string, error) {
-	row := q.db.QueryRow(ctx, test2, val)
+func (q *Queries) Test2(ctx context.Context, val sql.NullString, aq ...AdditionalQuery) (string, error) {
+	query := test2
+	queryParams := []interface{}{val}
+	row := q.db.QueryRow(ctx, query, queryParams...)
 	var txt string
 	err := row.Scan(&txt)
 	return txt, err
@@ -39,8 +43,10 @@ select txt from Demo
 where txt like concat('%', $1, '%')
 `
 
-func (q *Queries) Test3(ctx context.Context, val interface{}) (string, error) {
-	row := q.db.QueryRow(ctx, test3, val)
+func (q *Queries) Test3(ctx context.Context, val interface{}, aq ...AdditionalQuery) (string, error) {
+	query := test3
+	queryParams := []interface{}{val}
+	row := q.db.QueryRow(ctx, query, queryParams...)
 	var txt string
 	err := row.Scan(&txt)
 	return txt, err

--- a/internal/endtoend/testdata/operator_string_concat/postgresql/pgx/v5/go/db.go
+++ b/internal/endtoend/testdata/operator_string_concat/postgresql/pgx/v5/go/db.go
@@ -33,5 +33,5 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/operator_string_concat/postgresql/pgx/v5/go/db.go
+++ b/internal/endtoend/testdata/operator_string_concat/postgresql/pgx/v5/go/db.go
@@ -30,3 +30,8 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/operator_string_concat/postgresql/pgx/v5/go/query.sql.go
+++ b/internal/endtoend/testdata/operator_string_concat/postgresql/pgx/v5/go/query.sql.go
@@ -16,8 +16,10 @@ select txt from Demo
 where txt ~~ '%' || $1 || '%'
 `
 
-func (q *Queries) Test(ctx context.Context, val string) (string, error) {
-	row := q.db.QueryRow(ctx, test, val)
+func (q *Queries) Test(ctx context.Context, val string, aq ...AdditionalQuery) (string, error) {
+	query := test
+	queryParams := []interface{}{val}
+	row := q.db.QueryRow(ctx, query, queryParams...)
 	var txt string
 	err := row.Scan(&txt)
 	return txt, err
@@ -28,8 +30,10 @@ select txt from Demo
 where txt like '%' || $1 || '%'
 `
 
-func (q *Queries) Test2(ctx context.Context, val pgtype.Text) (string, error) {
-	row := q.db.QueryRow(ctx, test2, val)
+func (q *Queries) Test2(ctx context.Context, val pgtype.Text, aq ...AdditionalQuery) (string, error) {
+	query := test2
+	queryParams := []interface{}{val}
+	row := q.db.QueryRow(ctx, query, queryParams...)
 	var txt string
 	err := row.Scan(&txt)
 	return txt, err
@@ -40,8 +44,10 @@ select txt from Demo
 where txt like concat('%', $1, '%')
 `
 
-func (q *Queries) Test3(ctx context.Context, val interface{}) (string, error) {
-	row := q.db.QueryRow(ctx, test3, val)
+func (q *Queries) Test3(ctx context.Context, val interface{}, aq ...AdditionalQuery) (string, error) {
+	query := test3
+	queryParams := []interface{}{val}
+	row := q.db.QueryRow(ctx, query, queryParams...)
 	var txt string
 	err := row.Scan(&txt)
 	return txt, err

--- a/internal/endtoend/testdata/operator_string_concat/postgresql/stdlib/go/db.go
+++ b/internal/endtoend/testdata/operator_string_concat/postgresql/stdlib/go/db.go
@@ -29,3 +29,8 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/operator_string_concat/postgresql/stdlib/go/db.go
+++ b/internal/endtoend/testdata/operator_string_concat/postgresql/stdlib/go/db.go
@@ -32,5 +32,5 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/operator_string_concat/postgresql/stdlib/go/query.sql.go
+++ b/internal/endtoend/testdata/operator_string_concat/postgresql/stdlib/go/query.sql.go
@@ -15,8 +15,16 @@ select txt from Demo
 where txt ~~ '%' || $1 || '%'
 `
 
-func (q *Queries) Test(ctx context.Context, val string) (string, error) {
-	row := q.db.QueryRowContext(ctx, test, val)
+func (q *Queries) Test(ctx context.Context, val string, aq ...AdditionalQuery) (string, error) {
+	query := test
+	queryParams := []interface{}{val}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	row := q.db.QueryRowContext(ctx, query, queryParams...)
 	var txt string
 	err := row.Scan(&txt)
 	return txt, err
@@ -27,8 +35,16 @@ select txt from Demo
 where txt like '%' || $1 || '%'
 `
 
-func (q *Queries) Test2(ctx context.Context, val sql.NullString) (string, error) {
-	row := q.db.QueryRowContext(ctx, test2, val)
+func (q *Queries) Test2(ctx context.Context, val sql.NullString, aq ...AdditionalQuery) (string, error) {
+	query := test2
+	queryParams := []interface{}{val}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	row := q.db.QueryRowContext(ctx, query, queryParams...)
 	var txt string
 	err := row.Scan(&txt)
 	return txt, err
@@ -39,8 +55,16 @@ select txt from Demo
 where txt like concat('%', $1, '%')
 `
 
-func (q *Queries) Test3(ctx context.Context, val interface{}) (string, error) {
-	row := q.db.QueryRowContext(ctx, test3, val)
+func (q *Queries) Test3(ctx context.Context, val interface{}, aq ...AdditionalQuery) (string, error) {
+	query := test3
+	queryParams := []interface{}{val}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	row := q.db.QueryRowContext(ctx, query, queryParams...)
 	var txt string
 	err := row.Scan(&txt)
 	return txt, err

--- a/internal/endtoend/testdata/order_by_binds/mysql/go/db.go
+++ b/internal/endtoend/testdata/order_by_binds/mysql/go/db.go
@@ -29,3 +29,8 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/order_by_binds/mysql/go/db.go
+++ b/internal/endtoend/testdata/order_by_binds/mysql/go/db.go
@@ -32,5 +32,5 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/order_by_binds/mysql/go/query.sql.go
+++ b/internal/endtoend/testdata/order_by_binds/mysql/go/query.sql.go
@@ -20,8 +20,16 @@ type ListAuthorsColumnSortParams struct {
 	SortColumn interface{}
 }
 
-func (q *Queries) ListAuthorsColumnSort(ctx context.Context, arg ListAuthorsColumnSortParams) ([]Author, error) {
-	rows, err := q.db.QueryContext(ctx, listAuthorsColumnSort, arg.MinID, arg.SortColumn)
+func (q *Queries) ListAuthorsColumnSort(ctx context.Context, arg ListAuthorsColumnSortParams, aq ...AdditionalQuery) ([]Author, error) {
+	query := listAuthorsColumnSort
+	queryParams := []interface{}{arg.MinID, arg.SortColumn}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.QueryContext(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}
@@ -49,8 +57,16 @@ WHERE   id > ?
 ORDER   BY name ASC
 `
 
-func (q *Queries) ListAuthorsNameSort(ctx context.Context, minID int64) ([]Author, error) {
-	rows, err := q.db.QueryContext(ctx, listAuthorsNameSort, minID)
+func (q *Queries) ListAuthorsNameSort(ctx context.Context, minID int64, aq ...AdditionalQuery) ([]Author, error) {
+	query := listAuthorsNameSort
+	queryParams := []interface{}{minID}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.QueryContext(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/endtoend/testdata/order_by_binds/postgresql/go/db.go
+++ b/internal/endtoend/testdata/order_by_binds/postgresql/go/db.go
@@ -29,3 +29,8 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/order_by_binds/postgresql/go/db.go
+++ b/internal/endtoend/testdata/order_by_binds/postgresql/go/db.go
@@ -32,5 +32,5 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/order_by_binds/postgresql/go/query.sql.go
+++ b/internal/endtoend/testdata/order_by_binds/postgresql/go/query.sql.go
@@ -20,8 +20,16 @@ type ListAuthorsColumnSortParams struct {
 	SortColumn interface{}
 }
 
-func (q *Queries) ListAuthorsColumnSort(ctx context.Context, arg ListAuthorsColumnSortParams) ([]Author, error) {
-	rows, err := q.db.QueryContext(ctx, listAuthorsColumnSort, arg.MinID, arg.SortColumn)
+func (q *Queries) ListAuthorsColumnSort(ctx context.Context, arg ListAuthorsColumnSortParams, aq ...AdditionalQuery) ([]Author, error) {
+	query := listAuthorsColumnSort
+	queryParams := []interface{}{arg.MinID, arg.SortColumn}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.QueryContext(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}
@@ -49,8 +57,16 @@ WHERE   id > $1
 ORDER   BY name ASC
 `
 
-func (q *Queries) ListAuthorsNameSort(ctx context.Context, minID int64) ([]Author, error) {
-	rows, err := q.db.QueryContext(ctx, listAuthorsNameSort, minID)
+func (q *Queries) ListAuthorsNameSort(ctx context.Context, minID int64, aq ...AdditionalQuery) ([]Author, error) {
+	query := listAuthorsNameSort
+	queryParams := []interface{}{minID}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.QueryContext(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/endtoend/testdata/order_by_union/mysql/go/db.go
+++ b/internal/endtoend/testdata/order_by_union/mysql/go/db.go
@@ -29,3 +29,8 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/order_by_union/mysql/go/db.go
+++ b/internal/endtoend/testdata/order_by_union/mysql/go/db.go
@@ -32,5 +32,5 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/order_by_union/mysql/go/query.sql.go
+++ b/internal/endtoend/testdata/order_by_union/mysql/go/query.sql.go
@@ -16,8 +16,16 @@ SELECT first_name as foo FROM people
 ORDER BY foo
 `
 
-func (q *Queries) ListAuthorsUnion(ctx context.Context) ([]string, error) {
-	rows, err := q.db.QueryContext(ctx, listAuthorsUnion)
+func (q *Queries) ListAuthorsUnion(ctx context.Context, aq ...AdditionalQuery) ([]string, error) {
+	query := listAuthorsUnion
+	queryParams := []interface{}{}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.QueryContext(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/endtoend/testdata/order_by_union/postgresql/go/db.go
+++ b/internal/endtoend/testdata/order_by_union/postgresql/go/db.go
@@ -29,3 +29,8 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/order_by_union/postgresql/go/db.go
+++ b/internal/endtoend/testdata/order_by_union/postgresql/go/db.go
@@ -32,5 +32,5 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/order_by_union/postgresql/go/query.sql.go
+++ b/internal/endtoend/testdata/order_by_union/postgresql/go/query.sql.go
@@ -16,8 +16,16 @@ SELECT first_name as foo FROM people
 ORDER BY foo
 `
 
-func (q *Queries) ListAuthorsUnion(ctx context.Context) ([]string, error) {
-	rows, err := q.db.QueryContext(ctx, listAuthorsUnion)
+func (q *Queries) ListAuthorsUnion(ctx context.Context, aq ...AdditionalQuery) ([]string, error) {
+	query := listAuthorsUnion
+	queryParams := []interface{}{}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.QueryContext(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/endtoend/testdata/output_file_names/pgx/v4/go/db_gen.go
+++ b/internal/endtoend/testdata/output_file_names/pgx/v4/go/db_gen.go
@@ -31,3 +31,8 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/output_file_names/pgx/v4/go/db_gen.go
+++ b/internal/endtoend/testdata/output_file_names/pgx/v4/go/db_gen.go
@@ -34,5 +34,5 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/output_file_names/pgx/v4/go/querier_gen.go
+++ b/internal/endtoend/testdata/output_file_names/pgx/v4/go/querier_gen.go
@@ -9,7 +9,7 @@ import (
 )
 
 type Querier interface {
-	User(ctx context.Context) ([]int64, error)
+	User(ctx context.Context, aq ...AdditionalQuery) ([]int64, error)
 	UsersB(ctx context.Context, id []int64) *UsersBBatchResults
 }
 

--- a/internal/endtoend/testdata/output_file_names/pgx/v4/go/query.sql.go
+++ b/internal/endtoend/testdata/output_file_names/pgx/v4/go/query.sql.go
@@ -13,8 +13,16 @@ const user = `-- name: User :many
 SELECT "user".id FROM "user"
 `
 
-func (q *Queries) User(ctx context.Context) ([]int64, error) {
-	rows, err := q.db.Query(ctx, user)
+func (q *Queries) User(ctx context.Context, aq ...AdditionalQuery) ([]int64, error) {
+	query := user
+	queryParams := []interface{}{}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.Query(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/endtoend/testdata/output_file_names/pgx/v5/go/db_gen.go
+++ b/internal/endtoend/testdata/output_file_names/pgx/v5/go/db_gen.go
@@ -31,3 +31,8 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/output_file_names/pgx/v5/go/db_gen.go
+++ b/internal/endtoend/testdata/output_file_names/pgx/v5/go/db_gen.go
@@ -34,5 +34,5 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/output_file_names/pgx/v5/go/querier_gen.go
+++ b/internal/endtoend/testdata/output_file_names/pgx/v5/go/querier_gen.go
@@ -9,7 +9,7 @@ import (
 )
 
 type Querier interface {
-	User(ctx context.Context) ([]int64, error)
+	User(ctx context.Context, aq ...AdditionalQuery) ([]int64, error)
 	UsersB(ctx context.Context, id []int64) *UsersBBatchResults
 }
 

--- a/internal/endtoend/testdata/output_file_names/pgx/v5/go/query.sql.go
+++ b/internal/endtoend/testdata/output_file_names/pgx/v5/go/query.sql.go
@@ -13,8 +13,16 @@ const user = `-- name: User :many
 SELECT "user".id FROM "user"
 `
 
-func (q *Queries) User(ctx context.Context) ([]int64, error) {
-	rows, err := q.db.Query(ctx, user)
+func (q *Queries) User(ctx context.Context, aq ...AdditionalQuery) ([]int64, error) {
+	query := user
+	queryParams := []interface{}{}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.Query(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/endtoend/testdata/output_file_names/stdlib/go/db_gen.go
+++ b/internal/endtoend/testdata/output_file_names/stdlib/go/db_gen.go
@@ -29,3 +29,8 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/output_file_names/stdlib/go/db_gen.go
+++ b/internal/endtoend/testdata/output_file_names/stdlib/go/db_gen.go
@@ -32,5 +32,5 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/output_file_names/stdlib/go/querier_gen.go
+++ b/internal/endtoend/testdata/output_file_names/stdlib/go/querier_gen.go
@@ -9,7 +9,7 @@ import (
 )
 
 type Querier interface {
-	User(ctx context.Context) ([]int64, error)
+	User(ctx context.Context, aq ...AdditionalQuery) ([]int64, error)
 }
 
 var _ Querier = (*Queries)(nil)

--- a/internal/endtoend/testdata/output_file_names/stdlib/go/query.sql.go
+++ b/internal/endtoend/testdata/output_file_names/stdlib/go/query.sql.go
@@ -13,8 +13,16 @@ const user = `-- name: User :many
 SELECT "user".id FROM "user"
 `
 
-func (q *Queries) User(ctx context.Context) ([]int64, error) {
-	rows, err := q.db.QueryContext(ctx, user)
+func (q *Queries) User(ctx context.Context, aq ...AdditionalQuery) ([]int64, error) {
+	query := user
+	queryParams := []interface{}{}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.QueryContext(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/endtoend/testdata/output_files_suffix/pgx/v4/go/db.go
+++ b/internal/endtoend/testdata/output_files_suffix/pgx/v4/go/db.go
@@ -33,5 +33,5 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/output_files_suffix/pgx/v4/go/db.go
+++ b/internal/endtoend/testdata/output_files_suffix/pgx/v4/go/db.go
@@ -30,3 +30,8 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/output_files_suffix/pgx/v4/go/query.sql_gen.go
+++ b/internal/endtoend/testdata/output_files_suffix/pgx/v4/go/query.sql_gen.go
@@ -13,8 +13,16 @@ const user = `-- name: User :many
 SELECT "user".id FROM "user"
 `
 
-func (q *Queries) User(ctx context.Context) ([]int64, error) {
-	rows, err := q.db.Query(ctx, user)
+func (q *Queries) User(ctx context.Context, aq ...AdditionalQuery) ([]int64, error) {
+	query := user
+	queryParams := []interface{}{}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.Query(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/endtoend/testdata/output_files_suffix/pgx/v5/go/db.go
+++ b/internal/endtoend/testdata/output_files_suffix/pgx/v5/go/db.go
@@ -33,5 +33,5 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/output_files_suffix/pgx/v5/go/db.go
+++ b/internal/endtoend/testdata/output_files_suffix/pgx/v5/go/db.go
@@ -30,3 +30,8 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/output_files_suffix/pgx/v5/go/query.sql_gen.go
+++ b/internal/endtoend/testdata/output_files_suffix/pgx/v5/go/query.sql_gen.go
@@ -13,8 +13,16 @@ const user = `-- name: User :many
 SELECT "user".id FROM "user"
 `
 
-func (q *Queries) User(ctx context.Context) ([]int64, error) {
-	rows, err := q.db.Query(ctx, user)
+func (q *Queries) User(ctx context.Context, aq ...AdditionalQuery) ([]int64, error) {
+	query := user
+	queryParams := []interface{}{}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.Query(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/endtoend/testdata/output_files_suffix/stdlib/go/db.go
+++ b/internal/endtoend/testdata/output_files_suffix/stdlib/go/db.go
@@ -29,3 +29,8 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/output_files_suffix/stdlib/go/db.go
+++ b/internal/endtoend/testdata/output_files_suffix/stdlib/go/db.go
@@ -32,5 +32,5 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/output_files_suffix/stdlib/go/query.sql_gen.go
+++ b/internal/endtoend/testdata/output_files_suffix/stdlib/go/query.sql_gen.go
@@ -13,8 +13,16 @@ const user = `-- name: User :many
 SELECT "user".id FROM "user"
 `
 
-func (q *Queries) User(ctx context.Context) ([]int64, error) {
-	rows, err := q.db.QueryContext(ctx, user)
+func (q *Queries) User(ctx context.Context, aq ...AdditionalQuery) ([]int64, error) {
+	query := user
+	queryParams := []interface{}{}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.QueryContext(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/endtoend/testdata/overrides/mysql/go/db.go
+++ b/internal/endtoend/testdata/overrides/mysql/go/db.go
@@ -29,3 +29,8 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/overrides/mysql/go/db.go
+++ b/internal/endtoend/testdata/overrides/mysql/go/db.go
@@ -32,5 +32,5 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/overrides/postgresql/pgx/v4/go/db.go
+++ b/internal/endtoend/testdata/overrides/postgresql/pgx/v4/go/db.go
@@ -33,5 +33,5 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/overrides/postgresql/pgx/v4/go/db.go
+++ b/internal/endtoend/testdata/overrides/postgresql/pgx/v4/go/db.go
@@ -30,3 +30,8 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/overrides/postgresql/pgx/v5/go/db.go
+++ b/internal/endtoend/testdata/overrides/postgresql/pgx/v5/go/db.go
@@ -33,5 +33,5 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/overrides/postgresql/pgx/v5/go/db.go
+++ b/internal/endtoend/testdata/overrides/postgresql/pgx/v5/go/db.go
@@ -30,3 +30,8 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/overrides/postgresql/stdlib/go/db.go
+++ b/internal/endtoend/testdata/overrides/postgresql/stdlib/go/db.go
@@ -29,3 +29,8 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/overrides/postgresql/stdlib/go/db.go
+++ b/internal/endtoend/testdata/overrides/postgresql/stdlib/go/db.go
@@ -32,5 +32,5 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/overrides/sqlite/go/db.go
+++ b/internal/endtoend/testdata/overrides/sqlite/go/db.go
@@ -29,3 +29,8 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/overrides/sqlite/go/db.go
+++ b/internal/endtoend/testdata/overrides/sqlite/go/db.go
@@ -32,5 +32,5 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/overrides_array/postgresql/pgx/v4/query/db.go
+++ b/internal/endtoend/testdata/overrides_array/postgresql/pgx/v4/query/db.go
@@ -33,5 +33,5 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/overrides_array/postgresql/pgx/v4/query/db.go
+++ b/internal/endtoend/testdata/overrides_array/postgresql/pgx/v4/query/db.go
@@ -30,3 +30,8 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/overrides_array/postgresql/pgx/v4/query/query.sql.go
+++ b/internal/endtoend/testdata/overrides_array/postgresql/pgx/v4/query/query.sql.go
@@ -14,8 +14,10 @@ SELECT id, name, bio, tags FROM authors
 WHERE id = $1 LIMIT 1
 `
 
-func (q *Queries) GetAuthor(ctx context.Context, id int64) (Author, error) {
-	row := q.db.QueryRow(ctx, getAuthor, id)
+func (q *Queries) GetAuthor(ctx context.Context, id int64, aq ...AdditionalQuery) (Author, error) {
+	query := getAuthor
+	queryParams := []interface{}{id}
+	row := q.db.QueryRow(ctx, query, queryParams...)
 	var i Author
 	err := row.Scan(
 		&i.ID,

--- a/internal/endtoend/testdata/overrides_array/postgresql/pgx/v5/query/db.go
+++ b/internal/endtoend/testdata/overrides_array/postgresql/pgx/v5/query/db.go
@@ -33,5 +33,5 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/overrides_array/postgresql/pgx/v5/query/db.go
+++ b/internal/endtoend/testdata/overrides_array/postgresql/pgx/v5/query/db.go
@@ -30,3 +30,8 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/overrides_array/postgresql/pgx/v5/query/query.sql.go
+++ b/internal/endtoend/testdata/overrides_array/postgresql/pgx/v5/query/query.sql.go
@@ -14,8 +14,10 @@ SELECT id, name, bio, tags FROM authors
 WHERE id = $1 LIMIT 1
 `
 
-func (q *Queries) GetAuthor(ctx context.Context, id int64) (Author, error) {
-	row := q.db.QueryRow(ctx, getAuthor, id)
+func (q *Queries) GetAuthor(ctx context.Context, id int64, aq ...AdditionalQuery) (Author, error) {
+	query := getAuthor
+	queryParams := []interface{}{id}
+	row := q.db.QueryRow(ctx, query, queryParams...)
 	var i Author
 	err := row.Scan(
 		&i.ID,

--- a/internal/endtoend/testdata/overrides_array/postgresql/stdlib/query/db.go
+++ b/internal/endtoend/testdata/overrides_array/postgresql/stdlib/query/db.go
@@ -29,3 +29,8 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/overrides_array/postgresql/stdlib/query/db.go
+++ b/internal/endtoend/testdata/overrides_array/postgresql/stdlib/query/db.go
@@ -32,5 +32,5 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/overrides_array/postgresql/stdlib/query/query.sql.go
+++ b/internal/endtoend/testdata/overrides_array/postgresql/stdlib/query/query.sql.go
@@ -16,8 +16,16 @@ SELECT id, name, bio, tags FROM authors
 WHERE id = $1 LIMIT 1
 `
 
-func (q *Queries) GetAuthor(ctx context.Context, id int64) (Author, error) {
-	row := q.db.QueryRowContext(ctx, getAuthor, id)
+func (q *Queries) GetAuthor(ctx context.Context, id int64, aq ...AdditionalQuery) (Author, error) {
+	query := getAuthor
+	queryParams := []interface{}{id}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	row := q.db.QueryRowContext(ctx, query, queryParams...)
 	var i Author
 	err := row.Scan(
 		&i.ID,

--- a/internal/endtoend/testdata/overrides_go_struct_tags/mysql/go/db.go
+++ b/internal/endtoend/testdata/overrides_go_struct_tags/mysql/go/db.go
@@ -29,3 +29,8 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/overrides_go_struct_tags/mysql/go/db.go
+++ b/internal/endtoend/testdata/overrides_go_struct_tags/mysql/go/db.go
@@ -32,5 +32,5 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/overrides_go_struct_tags/postgresql/pgx/v4/go/db.go
+++ b/internal/endtoend/testdata/overrides_go_struct_tags/postgresql/pgx/v4/go/db.go
@@ -33,5 +33,5 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/overrides_go_struct_tags/postgresql/pgx/v4/go/db.go
+++ b/internal/endtoend/testdata/overrides_go_struct_tags/postgresql/pgx/v4/go/db.go
@@ -30,3 +30,8 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/overrides_go_struct_tags/postgresql/pgx/v5/go/db.go
+++ b/internal/endtoend/testdata/overrides_go_struct_tags/postgresql/pgx/v5/go/db.go
@@ -33,5 +33,5 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/overrides_go_struct_tags/postgresql/pgx/v5/go/db.go
+++ b/internal/endtoend/testdata/overrides_go_struct_tags/postgresql/pgx/v5/go/db.go
@@ -30,3 +30,8 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/overrides_go_struct_tags/postgresql/stdlib/go/db.go
+++ b/internal/endtoend/testdata/overrides_go_struct_tags/postgresql/stdlib/go/db.go
@@ -29,3 +29,8 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/overrides_go_struct_tags/postgresql/stdlib/go/db.go
+++ b/internal/endtoend/testdata/overrides_go_struct_tags/postgresql/stdlib/go/db.go
@@ -32,5 +32,5 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/overrides_go_struct_tags/sqlite/go/db.go
+++ b/internal/endtoend/testdata/overrides_go_struct_tags/sqlite/go/db.go
@@ -29,3 +29,8 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/overrides_go_struct_tags/sqlite/go/db.go
+++ b/internal/endtoend/testdata/overrides_go_struct_tags/sqlite/go/db.go
@@ -32,5 +32,5 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/overrides_go_types/mysql/go/db.go
+++ b/internal/endtoend/testdata/overrides_go_types/mysql/go/db.go
@@ -29,3 +29,8 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/overrides_go_types/mysql/go/db.go
+++ b/internal/endtoend/testdata/overrides_go_types/mysql/go/db.go
@@ -32,5 +32,5 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/overrides_go_types/mysql/go/query.sql.go
+++ b/internal/endtoend/testdata/overrides_go_types/mysql/go/query.sql.go
@@ -16,7 +16,7 @@ const testIN = `-- name: TestIN :many
 SELECT other, total, retyped FROM foo WHERE retyped IN (/*SLICE:paramname*/?)
 `
 
-func (q *Queries) TestIN(ctx context.Context, paramname []pkg.CustomType) ([]Foo, error) {
+func (q *Queries) TestIN(ctx context.Context, paramname []pkg.CustomType, aq ...AdditionalQuery) ([]Foo, error) {
 	query := testIN
 	var queryParams []interface{}
 	if len(paramname) > 0 {
@@ -27,6 +27,12 @@ func (q *Queries) TestIN(ctx context.Context, paramname []pkg.CustomType) ([]Foo
 	} else {
 		query = strings.Replace(query, "/*SLICE:paramname*/?", "NULL", 1)
 	}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
 	rows, err := q.db.QueryContext(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err

--- a/internal/endtoend/testdata/overrides_go_types/postgresql/pgx/v4/go/db.go
+++ b/internal/endtoend/testdata/overrides_go_types/postgresql/pgx/v4/go/db.go
@@ -33,5 +33,5 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/overrides_go_types/postgresql/pgx/v4/go/db.go
+++ b/internal/endtoend/testdata/overrides_go_types/postgresql/pgx/v4/go/db.go
@@ -30,3 +30,8 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/overrides_go_types/postgresql/pgx/v4/go/query.sql.go
+++ b/internal/endtoend/testdata/overrides_go_types/postgresql/pgx/v4/go/query.sql.go
@@ -19,8 +19,16 @@ const loadFoo = `-- name: LoadFoo :many
 SELECT id, other_id, age, balance, bio, about FROM foo WHERE id = $1
 `
 
-func (q *Queries) LoadFoo(ctx context.Context, id uuid.UUID) ([]Foo, error) {
-	rows, err := q.db.Query(ctx, loadFoo, id)
+func (q *Queries) LoadFoo(ctx context.Context, id uuid.UUID, aq ...AdditionalQuery) ([]Foo, error) {
+	query := loadFoo
+	queryParams := []interface{}{id}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.Query(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}
@@ -67,8 +75,16 @@ type LoadFooWithAliasesRow struct {
 	AliasedAbout   *string
 }
 
-func (q *Queries) LoadFooWithAliases(ctx context.Context, namedParameterID uuid.UUID) ([]LoadFooWithAliasesRow, error) {
-	rows, err := q.db.Query(ctx, loadFooWithAliases, namedParameterID)
+func (q *Queries) LoadFooWithAliases(ctx context.Context, namedParameterID uuid.UUID, aq ...AdditionalQuery) ([]LoadFooWithAliasesRow, error) {
+	query := loadFooWithAliases
+	queryParams := []interface{}{namedParameterID}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.Query(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/endtoend/testdata/overrides_go_types/postgresql/pgx/v5/go/db.go
+++ b/internal/endtoend/testdata/overrides_go_types/postgresql/pgx/v5/go/db.go
@@ -33,5 +33,5 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/overrides_go_types/postgresql/pgx/v5/go/db.go
+++ b/internal/endtoend/testdata/overrides_go_types/postgresql/pgx/v5/go/db.go
@@ -30,3 +30,8 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/overrides_go_types/postgresql/pgx/v5/go/query.sql.go
+++ b/internal/endtoend/testdata/overrides_go_types/postgresql/pgx/v5/go/query.sql.go
@@ -15,8 +15,16 @@ const loadFoo = `-- name: LoadFoo :many
 SELECT id, other_id, age, balance, bio, about FROM foo WHERE id = $1
 `
 
-func (q *Queries) LoadFoo(ctx context.Context, id uuid.UUID) ([]Foo, error) {
-	rows, err := q.db.Query(ctx, loadFoo, id)
+func (q *Queries) LoadFoo(ctx context.Context, id uuid.UUID, aq ...AdditionalQuery) ([]Foo, error) {
+	query := loadFoo
+	queryParams := []interface{}{id}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.Query(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/endtoend/testdata/overrides_go_types/postgresql/stdlib/go/db.go
+++ b/internal/endtoend/testdata/overrides_go_types/postgresql/stdlib/go/db.go
@@ -29,3 +29,8 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/overrides_go_types/postgresql/stdlib/go/db.go
+++ b/internal/endtoend/testdata/overrides_go_types/postgresql/stdlib/go/db.go
@@ -32,5 +32,5 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/overrides_go_types/postgresql/stdlib/go/query.sql.go
+++ b/internal/endtoend/testdata/overrides_go_types/postgresql/stdlib/go/query.sql.go
@@ -15,8 +15,16 @@ const loadFoo = `-- name: LoadFoo :many
 SELECT id, other_id, age, balance, bio, about FROM foo WHERE id = $1
 `
 
-func (q *Queries) LoadFoo(ctx context.Context, id uuid.UUID) ([]Foo, error) {
-	rows, err := q.db.QueryContext(ctx, loadFoo, id)
+func (q *Queries) LoadFoo(ctx context.Context, id uuid.UUID, aq ...AdditionalQuery) ([]Foo, error) {
+	query := loadFoo
+	queryParams := []interface{}{id}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.QueryContext(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/endtoend/testdata/overrides_go_types/sqlite/go/db.go
+++ b/internal/endtoend/testdata/overrides_go_types/sqlite/go/db.go
@@ -29,3 +29,8 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/overrides_go_types/sqlite/go/db.go
+++ b/internal/endtoend/testdata/overrides_go_types/sqlite/go/db.go
@@ -32,5 +32,5 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/overrides_nullable/postgresql/pgx/v4/go/db.go
+++ b/internal/endtoend/testdata/overrides_nullable/postgresql/pgx/v4/go/db.go
@@ -33,5 +33,5 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/overrides_nullable/postgresql/pgx/v4/go/db.go
+++ b/internal/endtoend/testdata/overrides_nullable/postgresql/pgx/v4/go/db.go
@@ -30,3 +30,8 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/overrides_nullable/postgresql/pgx/v4/go/query.sql.go
+++ b/internal/endtoend/testdata/overrides_nullable/postgresql/pgx/v4/go/query.sql.go
@@ -13,8 +13,16 @@ const listFoo = `-- name: ListFoo :many
 SELECT bar, bam, baz FROM foo
 `
 
-func (q *Queries) ListFoo(ctx context.Context) ([]Foo, error) {
-	rows, err := q.db.Query(ctx, listFoo)
+func (q *Queries) ListFoo(ctx context.Context, aq ...AdditionalQuery) ([]Foo, error) {
+	query := listFoo
+	queryParams := []interface{}{}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.Query(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/endtoend/testdata/overrides_nullable/postgresql/pgx/v5/go/db.go
+++ b/internal/endtoend/testdata/overrides_nullable/postgresql/pgx/v5/go/db.go
@@ -33,5 +33,5 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/overrides_nullable/postgresql/pgx/v5/go/db.go
+++ b/internal/endtoend/testdata/overrides_nullable/postgresql/pgx/v5/go/db.go
@@ -30,3 +30,8 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/overrides_nullable/postgresql/pgx/v5/go/query.sql.go
+++ b/internal/endtoend/testdata/overrides_nullable/postgresql/pgx/v5/go/query.sql.go
@@ -13,8 +13,16 @@ const listFoo = `-- name: ListFoo :many
 SELECT bar, bam, baz FROM foo
 `
 
-func (q *Queries) ListFoo(ctx context.Context) ([]Foo, error) {
-	rows, err := q.db.Query(ctx, listFoo)
+func (q *Queries) ListFoo(ctx context.Context, aq ...AdditionalQuery) ([]Foo, error) {
+	query := listFoo
+	queryParams := []interface{}{}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.Query(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/endtoend/testdata/overrides_nullable/postgresql/stdlib/go/db.go
+++ b/internal/endtoend/testdata/overrides_nullable/postgresql/stdlib/go/db.go
@@ -29,3 +29,8 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/overrides_nullable/postgresql/stdlib/go/db.go
+++ b/internal/endtoend/testdata/overrides_nullable/postgresql/stdlib/go/db.go
@@ -32,5 +32,5 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/overrides_nullable/postgresql/stdlib/go/query.sql.go
+++ b/internal/endtoend/testdata/overrides_nullable/postgresql/stdlib/go/query.sql.go
@@ -13,8 +13,16 @@ const listFoo = `-- name: ListFoo :many
 SELECT bar, bam, baz FROM foo
 `
 
-func (q *Queries) ListFoo(ctx context.Context) ([]Foo, error) {
-	rows, err := q.db.QueryContext(ctx, listFoo)
+func (q *Queries) ListFoo(ctx context.Context, aq ...AdditionalQuery) ([]Foo, error) {
+	query := listFoo
+	queryParams := []interface{}{}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.QueryContext(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/endtoend/testdata/overrides_pointers/mysql/go/db.go
+++ b/internal/endtoend/testdata/overrides_pointers/mysql/go/db.go
@@ -29,3 +29,8 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/overrides_pointers/mysql/go/db.go
+++ b/internal/endtoend/testdata/overrides_pointers/mysql/go/db.go
@@ -32,5 +32,5 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/overrides_pointers/mysql/go/query.sql.go
+++ b/internal/endtoend/testdata/overrides_pointers/mysql/go/query.sql.go
@@ -21,6 +21,9 @@ type testParams struct {
 }
 
 func (q *Queries) test(ctx context.Context, arg testParams) error {
-	_, err := q.db.ExecContext(ctx, test, arg.Other, arg.Retyped)
+	query := test
+	queryParams := []interface{}{arg.Other, arg.Retyped}
+
+	_, err := q.db.ExecContext(ctx, query, queryParams...)
 	return err
 }

--- a/internal/endtoend/testdata/overrides_pointers/postgresql/pgx/v4/go/db.go
+++ b/internal/endtoend/testdata/overrides_pointers/postgresql/pgx/v4/go/db.go
@@ -33,5 +33,5 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/overrides_pointers/postgresql/pgx/v4/go/db.go
+++ b/internal/endtoend/testdata/overrides_pointers/postgresql/pgx/v4/go/db.go
@@ -30,3 +30,8 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/overrides_pointers/postgresql/pgx/v5/go/db.go
+++ b/internal/endtoend/testdata/overrides_pointers/postgresql/pgx/v5/go/db.go
@@ -33,5 +33,5 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/overrides_pointers/postgresql/pgx/v5/go/db.go
+++ b/internal/endtoend/testdata/overrides_pointers/postgresql/pgx/v5/go/db.go
@@ -30,3 +30,8 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/overrides_pointers/postgresql/stdlib/go/db.go
+++ b/internal/endtoend/testdata/overrides_pointers/postgresql/stdlib/go/db.go
@@ -29,3 +29,8 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/overrides_pointers/postgresql/stdlib/go/db.go
+++ b/internal/endtoend/testdata/overrides_pointers/postgresql/stdlib/go/db.go
@@ -32,5 +32,5 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/overrides_pointers/postgresql/stdlib/go/query.sql.go
+++ b/internal/endtoend/testdata/overrides_pointers/postgresql/stdlib/go/query.sql.go
@@ -16,6 +16,9 @@ UPDATE foo SET langs = $1
 `
 
 func (q *Queries) test(ctx context.Context, langs *t.Text) error {
-	_, err := q.db.ExecContext(ctx, test, langs)
+	query := test
+	queryParams := []interface{}{langs}
+
+	_, err := q.db.ExecContext(ctx, query, queryParams...)
 	return err
 }

--- a/internal/endtoend/testdata/overrides_result_tag/stdlib/go/db.go
+++ b/internal/endtoend/testdata/overrides_result_tag/stdlib/go/db.go
@@ -29,3 +29,8 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/overrides_result_tag/stdlib/go/db.go
+++ b/internal/endtoend/testdata/overrides_result_tag/stdlib/go/db.go
@@ -32,5 +32,5 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/overrides_result_tag/stdlib/go/query.sql.go
+++ b/internal/endtoend/testdata/overrides_result_tag/stdlib/go/query.sql.go
@@ -30,8 +30,16 @@ type FindAccountRow struct {
 	Name  sql.NullString
 }
 
-func (q *Queries) FindAccount(ctx context.Context, accountID uuid.UUID) (FindAccountRow, error) {
-	row := q.db.QueryRowContext(ctx, findAccount, accountID)
+func (q *Queries) FindAccount(ctx context.Context, accountID uuid.UUID, aq ...AdditionalQuery) (FindAccountRow, error) {
+	query := findAccount
+	queryParams := []interface{}{accountID}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	row := q.db.QueryRowContext(ctx, query, queryParams...)
 	var i FindAccountRow
 	err := row.Scan(&i.ID, &i.State, &i.Name)
 	return i, err

--- a/internal/endtoend/testdata/overrides_unsigned/mysql/go/db.go
+++ b/internal/endtoend/testdata/overrides_unsigned/mysql/go/db.go
@@ -29,3 +29,8 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/overrides_unsigned/mysql/go/db.go
+++ b/internal/endtoend/testdata/overrides_unsigned/mysql/go/db.go
@@ -32,5 +32,5 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/params_duplicate/mysql/go/db.go
+++ b/internal/endtoend/testdata/params_duplicate/mysql/go/db.go
@@ -29,3 +29,8 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/params_duplicate/mysql/go/db.go
+++ b/internal/endtoend/testdata/params_duplicate/mysql/go/db.go
@@ -32,5 +32,5 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/params_duplicate/mysql/go/query.sql.go
+++ b/internal/endtoend/testdata/params_duplicate/mysql/go/query.sql.go
@@ -19,8 +19,16 @@ type SelectUserByIDParams struct {
 	ID int32
 }
 
-func (q *Queries) SelectUserByID(ctx context.Context, arg SelectUserByIDParams) ([]sql.NullString, error) {
-	rows, err := q.db.QueryContext(ctx, selectUserByID, arg.ID, arg.ID)
+func (q *Queries) SelectUserByID(ctx context.Context, arg SelectUserByIDParams, aq ...AdditionalQuery) ([]sql.NullString, error) {
+	query := selectUserByID
+	queryParams := []interface{}{arg.ID, arg.ID}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.QueryContext(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}
@@ -53,8 +61,16 @@ type SelectUserByNameParams struct {
 	Name sql.NullString
 }
 
-func (q *Queries) SelectUserByName(ctx context.Context, arg SelectUserByNameParams) ([]sql.NullString, error) {
-	rows, err := q.db.QueryContext(ctx, selectUserByName, arg.Name, arg.Name)
+func (q *Queries) SelectUserByName(ctx context.Context, arg SelectUserByNameParams, aq ...AdditionalQuery) ([]sql.NullString, error) {
+	query := selectUserByName
+	queryParams := []interface{}{arg.Name, arg.Name}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.QueryContext(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}
@@ -86,8 +102,16 @@ type SelectUserQuestionParams struct {
 	Column2 interface{}
 }
 
-func (q *Queries) SelectUserQuestion(ctx context.Context, arg SelectUserQuestionParams) ([]sql.NullString, error) {
-	rows, err := q.db.QueryContext(ctx, selectUserQuestion, arg.ID, arg.Column2)
+func (q *Queries) SelectUserQuestion(ctx context.Context, arg SelectUserQuestionParams, aq ...AdditionalQuery) ([]sql.NullString, error) {
+	query := selectUserQuestion
+	queryParams := []interface{}{arg.ID, arg.Column2}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.QueryContext(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/endtoend/testdata/params_duplicate/postgresql/go/db.go
+++ b/internal/endtoend/testdata/params_duplicate/postgresql/go/db.go
@@ -29,3 +29,8 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/params_duplicate/postgresql/go/db.go
+++ b/internal/endtoend/testdata/params_duplicate/postgresql/go/db.go
@@ -32,5 +32,5 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/params_duplicate/postgresql/go/query.sql.go
+++ b/internal/endtoend/testdata/params_duplicate/postgresql/go/query.sql.go
@@ -15,8 +15,16 @@ SELECT first_name from
 users where ($1 = id OR $1 = 0)
 `
 
-func (q *Queries) SelectUserByID(ctx context.Context, id int32) ([]sql.NullString, error) {
-	rows, err := q.db.QueryContext(ctx, selectUserByID, id)
+func (q *Queries) SelectUserByID(ctx context.Context, id int32, aq ...AdditionalQuery) ([]sql.NullString, error) {
+	query := selectUserByID
+	queryParams := []interface{}{id}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.QueryContext(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}
@@ -45,8 +53,16 @@ WHERE first_name = $1
    OR last_name = $1
 `
 
-func (q *Queries) SelectUserByName(ctx context.Context, name sql.NullString) ([]sql.NullString, error) {
-	rows, err := q.db.QueryContext(ctx, selectUserByName, name)
+func (q *Queries) SelectUserByName(ctx context.Context, name sql.NullString, aq ...AdditionalQuery) ([]sql.NullString, error) {
+	query := selectUserByName
+	queryParams := []interface{}{name}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.QueryContext(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}
@@ -73,8 +89,16 @@ SELECT first_name from
 users where ($1 = id OR  $1 = 0)
 `
 
-func (q *Queries) SelectUserQuestion(ctx context.Context, id int32) ([]sql.NullString, error) {
-	rows, err := q.db.QueryContext(ctx, selectUserQuestion, id)
+func (q *Queries) SelectUserQuestion(ctx context.Context, id int32, aq ...AdditionalQuery) ([]sql.NullString, error) {
+	query := selectUserQuestion
+	queryParams := []interface{}{id}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.QueryContext(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/endtoend/testdata/params_location/mysql/go/db.go
+++ b/internal/endtoend/testdata/params_location/mysql/go/db.go
@@ -29,3 +29,8 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/params_location/mysql/go/db.go
+++ b/internal/endtoend/testdata/params_location/mysql/go/db.go
@@ -32,5 +32,5 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/params_location/mysql/go/query.sql.go
+++ b/internal/endtoend/testdata/params_location/mysql/go/query.sql.go
@@ -20,8 +20,16 @@ type GetUserByIDRow struct {
 	LastName  sql.NullString
 }
 
-func (q *Queries) GetUserByID(ctx context.Context, targetID int32) (GetUserByIDRow, error) {
-	row := q.db.QueryRowContext(ctx, getUserByID, targetID)
+func (q *Queries) GetUserByID(ctx context.Context, targetID int32, aq ...AdditionalQuery) (GetUserByIDRow, error) {
+	query := getUserByID
+	queryParams := []interface{}{targetID}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	row := q.db.QueryRowContext(ctx, query, queryParams...)
 	var i GetUserByIDRow
 	err := row.Scan(&i.FirstName, &i.ID, &i.LastName)
 	return i, err
@@ -37,7 +45,10 @@ type InsertNewUserParams struct {
 }
 
 func (q *Queries) InsertNewUser(ctx context.Context, arg InsertNewUserParams) error {
-	_, err := q.db.ExecContext(ctx, insertNewUser, arg.FirstName, arg.LastName)
+	query := insertNewUser
+	queryParams := []interface{}{arg.FirstName, arg.LastName}
+
+	_, err := q.db.ExecContext(ctx, query, queryParams...)
 	return err
 }
 
@@ -50,8 +61,16 @@ type LimitSQLCArgRow struct {
 	ID        int32
 }
 
-func (q *Queries) LimitSQLCArg(ctx context.Context, limit int32) ([]LimitSQLCArgRow, error) {
-	rows, err := q.db.QueryContext(ctx, limitSQLCArg, limit)
+func (q *Queries) LimitSQLCArg(ctx context.Context, limit int32, aq ...AdditionalQuery) ([]LimitSQLCArgRow, error) {
+	query := limitSQLCArg
+	queryParams := []interface{}{limit}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.QueryContext(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}
@@ -90,8 +109,16 @@ type ListUserOrdersRow struct {
 	Price     string
 }
 
-func (q *Queries) ListUserOrders(ctx context.Context, minPrice string) ([]ListUserOrdersRow, error) {
-	rows, err := q.db.QueryContext(ctx, listUserOrders, minPrice)
+func (q *Queries) ListUserOrders(ctx context.Context, minPrice string, aq ...AdditionalQuery) ([]ListUserOrdersRow, error) {
+	query := listUserOrders
+	queryParams := []interface{}{minPrice}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.QueryContext(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}
@@ -125,8 +152,16 @@ type ListUserParenExprParams struct {
 	Limit int32
 }
 
-func (q *Queries) ListUserParenExpr(ctx context.Context, arg ListUserParenExprParams) ([]User, error) {
-	rows, err := q.db.QueryContext(ctx, listUserParenExpr, arg.ID, arg.Limit)
+func (q *Queries) ListUserParenExpr(ctx context.Context, arg ListUserParenExprParams, aq ...AdditionalQuery) ([]User, error) {
+	query := listUserParenExpr
+	queryParams := []interface{}{arg.ID, arg.Limit}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.QueryContext(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}
@@ -168,8 +203,16 @@ type ListUsersByFamilyRow struct {
 	LastName  sql.NullString
 }
 
-func (q *Queries) ListUsersByFamily(ctx context.Context, arg ListUsersByFamilyParams) ([]ListUsersByFamilyRow, error) {
-	rows, err := q.db.QueryContext(ctx, listUsersByFamily, arg.MaxAge, arg.InFamily)
+func (q *Queries) ListUsersByFamily(ctx context.Context, arg ListUsersByFamilyParams, aq ...AdditionalQuery) ([]ListUsersByFamilyRow, error) {
+	query := listUsersByFamily
+	queryParams := []interface{}{arg.MaxAge, arg.InFamily}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.QueryContext(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}
@@ -201,8 +244,16 @@ type ListUsersByIDRow struct {
 	LastName  sql.NullString
 }
 
-func (q *Queries) ListUsersByID(ctx context.Context, id int32) ([]ListUsersByIDRow, error) {
-	rows, err := q.db.QueryContext(ctx, listUsersByID, id)
+func (q *Queries) ListUsersByID(ctx context.Context, id int32, aq ...AdditionalQuery) ([]ListUsersByIDRow, error) {
+	query := listUsersByID
+	queryParams := []interface{}{id}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.QueryContext(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}
@@ -233,8 +284,16 @@ type ListUsersWithLimitRow struct {
 	LastName  sql.NullString
 }
 
-func (q *Queries) ListUsersWithLimit(ctx context.Context, limit int32) ([]ListUsersWithLimitRow, error) {
-	rows, err := q.db.QueryContext(ctx, listUsersWithLimit, limit)
+func (q *Queries) ListUsersWithLimit(ctx context.Context, limit int32, aq ...AdditionalQuery) ([]ListUsersWithLimitRow, error) {
+	query := listUsersWithLimit
+	queryParams := []interface{}{limit}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.QueryContext(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/endtoend/testdata/params_location/postgresql/pgx/v4/go/db.go
+++ b/internal/endtoend/testdata/params_location/postgresql/pgx/v4/go/db.go
@@ -33,5 +33,5 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/params_location/postgresql/pgx/v4/go/db.go
+++ b/internal/endtoend/testdata/params_location/postgresql/pgx/v4/go/db.go
@@ -30,3 +30,8 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/params_location/postgresql/pgx/v4/go/query.sql.go
+++ b/internal/endtoend/testdata/params_location/postgresql/pgx/v4/go/query.sql.go
@@ -22,8 +22,10 @@ type GetUserByIDRow struct {
 	LastName  sql.NullString
 }
 
-func (q *Queries) GetUserByID(ctx context.Context, targetID int32) (GetUserByIDRow, error) {
-	row := q.db.QueryRow(ctx, getUserByID, targetID)
+func (q *Queries) GetUserByID(ctx context.Context, targetID int32, aq ...AdditionalQuery) (GetUserByIDRow, error) {
+	query := getUserByID
+	queryParams := []interface{}{targetID}
+	row := q.db.QueryRow(ctx, query, queryParams...)
 	var i GetUserByIDRow
 	err := row.Scan(&i.FirstName, &i.ID, &i.LastName)
 	return i, err
@@ -52,8 +54,16 @@ type LimitSQLCArgRow struct {
 	ID        int32
 }
 
-func (q *Queries) LimitSQLCArg(ctx context.Context, limit int32) ([]LimitSQLCArgRow, error) {
-	rows, err := q.db.Query(ctx, limitSQLCArg, limit)
+func (q *Queries) LimitSQLCArg(ctx context.Context, limit int32, aq ...AdditionalQuery) ([]LimitSQLCArgRow, error) {
+	query := limitSQLCArg
+	queryParams := []interface{}{limit}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.Query(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}
@@ -89,8 +99,16 @@ type ListUserOrdersRow struct {
 	Price     pgtype.Numeric
 }
 
-func (q *Queries) ListUserOrders(ctx context.Context, minPrice pgtype.Numeric) ([]ListUserOrdersRow, error) {
-	rows, err := q.db.Query(ctx, listUserOrders, minPrice)
+func (q *Queries) ListUserOrders(ctx context.Context, minPrice pgtype.Numeric, aq ...AdditionalQuery) ([]ListUserOrdersRow, error) {
+	query := listUserOrders
+	queryParams := []interface{}{minPrice}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.Query(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}
@@ -121,8 +139,16 @@ type ListUserParenExprParams struct {
 	Limit int32
 }
 
-func (q *Queries) ListUserParenExpr(ctx context.Context, arg ListUserParenExprParams) ([]User, error) {
-	rows, err := q.db.Query(ctx, listUserParenExpr, arg.ID, arg.Limit)
+func (q *Queries) ListUserParenExpr(ctx context.Context, arg ListUserParenExprParams, aq ...AdditionalQuery) ([]User, error) {
+	query := listUserParenExpr
+	queryParams := []interface{}{arg.ID, arg.Limit}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.Query(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}
@@ -161,8 +187,16 @@ type ListUsersByFamilyRow struct {
 	LastName  sql.NullString
 }
 
-func (q *Queries) ListUsersByFamily(ctx context.Context, arg ListUsersByFamilyParams) ([]ListUsersByFamilyRow, error) {
-	rows, err := q.db.Query(ctx, listUsersByFamily, arg.MaxAge, arg.InFamily)
+func (q *Queries) ListUsersByFamily(ctx context.Context, arg ListUsersByFamilyParams, aq ...AdditionalQuery) ([]ListUsersByFamilyRow, error) {
+	query := listUsersByFamily
+	queryParams := []interface{}{arg.MaxAge, arg.InFamily}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.Query(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}
@@ -191,8 +225,16 @@ type ListUsersByIDRow struct {
 	LastName  sql.NullString
 }
 
-func (q *Queries) ListUsersByID(ctx context.Context, id int32) ([]ListUsersByIDRow, error) {
-	rows, err := q.db.Query(ctx, listUsersByID, id)
+func (q *Queries) ListUsersByID(ctx context.Context, id int32, aq ...AdditionalQuery) ([]ListUsersByIDRow, error) {
+	query := listUsersByID
+	queryParams := []interface{}{id}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.Query(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}
@@ -220,8 +262,16 @@ type ListUsersWithLimitRow struct {
 	LastName  sql.NullString
 }
 
-func (q *Queries) ListUsersWithLimit(ctx context.Context, limit int32) ([]ListUsersWithLimitRow, error) {
-	rows, err := q.db.Query(ctx, listUsersWithLimit, limit)
+func (q *Queries) ListUsersWithLimit(ctx context.Context, limit int32, aq ...AdditionalQuery) ([]ListUsersWithLimitRow, error) {
+	query := listUsersWithLimit
+	queryParams := []interface{}{limit}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.Query(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/endtoend/testdata/params_location/postgresql/pgx/v5/go/db.go
+++ b/internal/endtoend/testdata/params_location/postgresql/pgx/v5/go/db.go
@@ -33,5 +33,5 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/params_location/postgresql/pgx/v5/go/db.go
+++ b/internal/endtoend/testdata/params_location/postgresql/pgx/v5/go/db.go
@@ -30,3 +30,8 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/params_location/postgresql/pgx/v5/go/query.sql.go
+++ b/internal/endtoend/testdata/params_location/postgresql/pgx/v5/go/query.sql.go
@@ -21,8 +21,10 @@ type GetUserByIDRow struct {
 	LastName  pgtype.Text
 }
 
-func (q *Queries) GetUserByID(ctx context.Context, targetID int32) (GetUserByIDRow, error) {
-	row := q.db.QueryRow(ctx, getUserByID, targetID)
+func (q *Queries) GetUserByID(ctx context.Context, targetID int32, aq ...AdditionalQuery) (GetUserByIDRow, error) {
+	query := getUserByID
+	queryParams := []interface{}{targetID}
+	row := q.db.QueryRow(ctx, query, queryParams...)
 	var i GetUserByIDRow
 	err := row.Scan(&i.FirstName, &i.ID, &i.LastName)
 	return i, err
@@ -51,8 +53,16 @@ type LimitSQLCArgRow struct {
 	ID        int32
 }
 
-func (q *Queries) LimitSQLCArg(ctx context.Context, limit int32) ([]LimitSQLCArgRow, error) {
-	rows, err := q.db.Query(ctx, limitSQLCArg, limit)
+func (q *Queries) LimitSQLCArg(ctx context.Context, limit int32, aq ...AdditionalQuery) ([]LimitSQLCArgRow, error) {
+	query := limitSQLCArg
+	queryParams := []interface{}{limit}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.Query(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}
@@ -88,8 +98,16 @@ type ListUserOrdersRow struct {
 	Price     pgtype.Numeric
 }
 
-func (q *Queries) ListUserOrders(ctx context.Context, minPrice pgtype.Numeric) ([]ListUserOrdersRow, error) {
-	rows, err := q.db.Query(ctx, listUserOrders, minPrice)
+func (q *Queries) ListUserOrders(ctx context.Context, minPrice pgtype.Numeric, aq ...AdditionalQuery) ([]ListUserOrdersRow, error) {
+	query := listUserOrders
+	queryParams := []interface{}{minPrice}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.Query(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}
@@ -120,8 +138,16 @@ type ListUserParenExprParams struct {
 	Limit int32
 }
 
-func (q *Queries) ListUserParenExpr(ctx context.Context, arg ListUserParenExprParams) ([]User, error) {
-	rows, err := q.db.Query(ctx, listUserParenExpr, arg.ID, arg.Limit)
+func (q *Queries) ListUserParenExpr(ctx context.Context, arg ListUserParenExprParams, aq ...AdditionalQuery) ([]User, error) {
+	query := listUserParenExpr
+	queryParams := []interface{}{arg.ID, arg.Limit}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.Query(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}
@@ -160,8 +186,16 @@ type ListUsersByFamilyRow struct {
 	LastName  pgtype.Text
 }
 
-func (q *Queries) ListUsersByFamily(ctx context.Context, arg ListUsersByFamilyParams) ([]ListUsersByFamilyRow, error) {
-	rows, err := q.db.Query(ctx, listUsersByFamily, arg.MaxAge, arg.InFamily)
+func (q *Queries) ListUsersByFamily(ctx context.Context, arg ListUsersByFamilyParams, aq ...AdditionalQuery) ([]ListUsersByFamilyRow, error) {
+	query := listUsersByFamily
+	queryParams := []interface{}{arg.MaxAge, arg.InFamily}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.Query(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}
@@ -190,8 +224,16 @@ type ListUsersByIDRow struct {
 	LastName  pgtype.Text
 }
 
-func (q *Queries) ListUsersByID(ctx context.Context, id int32) ([]ListUsersByIDRow, error) {
-	rows, err := q.db.Query(ctx, listUsersByID, id)
+func (q *Queries) ListUsersByID(ctx context.Context, id int32, aq ...AdditionalQuery) ([]ListUsersByIDRow, error) {
+	query := listUsersByID
+	queryParams := []interface{}{id}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.Query(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}
@@ -219,8 +261,16 @@ type ListUsersWithLimitRow struct {
 	LastName  pgtype.Text
 }
 
-func (q *Queries) ListUsersWithLimit(ctx context.Context, limit int32) ([]ListUsersWithLimitRow, error) {
-	rows, err := q.db.Query(ctx, listUsersWithLimit, limit)
+func (q *Queries) ListUsersWithLimit(ctx context.Context, limit int32, aq ...AdditionalQuery) ([]ListUsersWithLimitRow, error) {
+	query := listUsersWithLimit
+	queryParams := []interface{}{limit}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.Query(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/endtoend/testdata/params_location/postgresql/stdlib/go/db.go
+++ b/internal/endtoend/testdata/params_location/postgresql/stdlib/go/db.go
@@ -29,3 +29,8 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/params_location/postgresql/stdlib/go/db.go
+++ b/internal/endtoend/testdata/params_location/postgresql/stdlib/go/db.go
@@ -32,5 +32,5 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/params_location/postgresql/stdlib/go/query.sql.go
+++ b/internal/endtoend/testdata/params_location/postgresql/stdlib/go/query.sql.go
@@ -20,8 +20,16 @@ type GetUserByIDRow struct {
 	LastName  sql.NullString
 }
 
-func (q *Queries) GetUserByID(ctx context.Context, targetID int32) (GetUserByIDRow, error) {
-	row := q.db.QueryRowContext(ctx, getUserByID, targetID)
+func (q *Queries) GetUserByID(ctx context.Context, targetID int32, aq ...AdditionalQuery) (GetUserByIDRow, error) {
+	query := getUserByID
+	queryParams := []interface{}{targetID}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	row := q.db.QueryRowContext(ctx, query, queryParams...)
 	var i GetUserByIDRow
 	err := row.Scan(&i.FirstName, &i.ID, &i.LastName)
 	return i, err
@@ -37,7 +45,10 @@ type InsertNewUserParams struct {
 }
 
 func (q *Queries) InsertNewUser(ctx context.Context, arg InsertNewUserParams) error {
-	_, err := q.db.ExecContext(ctx, insertNewUser, arg.FirstName, arg.LastName)
+	query := insertNewUser
+	queryParams := []interface{}{arg.FirstName, arg.LastName}
+
+	_, err := q.db.ExecContext(ctx, query, queryParams...)
 	return err
 }
 
@@ -50,8 +61,16 @@ type LimitSQLCArgRow struct {
 	ID        int32
 }
 
-func (q *Queries) LimitSQLCArg(ctx context.Context, limit int32) ([]LimitSQLCArgRow, error) {
-	rows, err := q.db.QueryContext(ctx, limitSQLCArg, limit)
+func (q *Queries) LimitSQLCArg(ctx context.Context, limit int32, aq ...AdditionalQuery) ([]LimitSQLCArgRow, error) {
+	query := limitSQLCArg
+	queryParams := []interface{}{limit}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.QueryContext(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}
@@ -90,8 +109,16 @@ type ListUserOrdersRow struct {
 	Price     string
 }
 
-func (q *Queries) ListUserOrders(ctx context.Context, minPrice string) ([]ListUserOrdersRow, error) {
-	rows, err := q.db.QueryContext(ctx, listUserOrders, minPrice)
+func (q *Queries) ListUserOrders(ctx context.Context, minPrice string, aq ...AdditionalQuery) ([]ListUserOrdersRow, error) {
+	query := listUserOrders
+	queryParams := []interface{}{minPrice}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.QueryContext(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}
@@ -125,8 +152,16 @@ type ListUserParenExprParams struct {
 	Limit int32
 }
 
-func (q *Queries) ListUserParenExpr(ctx context.Context, arg ListUserParenExprParams) ([]User, error) {
-	rows, err := q.db.QueryContext(ctx, listUserParenExpr, arg.ID, arg.Limit)
+func (q *Queries) ListUserParenExpr(ctx context.Context, arg ListUserParenExprParams, aq ...AdditionalQuery) ([]User, error) {
+	query := listUserParenExpr
+	queryParams := []interface{}{arg.ID, arg.Limit}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.QueryContext(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}
@@ -168,8 +203,16 @@ type ListUsersByFamilyRow struct {
 	LastName  sql.NullString
 }
 
-func (q *Queries) ListUsersByFamily(ctx context.Context, arg ListUsersByFamilyParams) ([]ListUsersByFamilyRow, error) {
-	rows, err := q.db.QueryContext(ctx, listUsersByFamily, arg.MaxAge, arg.InFamily)
+func (q *Queries) ListUsersByFamily(ctx context.Context, arg ListUsersByFamilyParams, aq ...AdditionalQuery) ([]ListUsersByFamilyRow, error) {
+	query := listUsersByFamily
+	queryParams := []interface{}{arg.MaxAge, arg.InFamily}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.QueryContext(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}
@@ -201,8 +244,16 @@ type ListUsersByIDRow struct {
 	LastName  sql.NullString
 }
 
-func (q *Queries) ListUsersByID(ctx context.Context, id int32) ([]ListUsersByIDRow, error) {
-	rows, err := q.db.QueryContext(ctx, listUsersByID, id)
+func (q *Queries) ListUsersByID(ctx context.Context, id int32, aq ...AdditionalQuery) ([]ListUsersByIDRow, error) {
+	query := listUsersByID
+	queryParams := []interface{}{id}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.QueryContext(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}
@@ -233,8 +284,16 @@ type ListUsersWithLimitRow struct {
 	LastName  sql.NullString
 }
 
-func (q *Queries) ListUsersWithLimit(ctx context.Context, limit int32) ([]ListUsersWithLimitRow, error) {
-	rows, err := q.db.QueryContext(ctx, listUsersWithLimit, limit)
+func (q *Queries) ListUsersWithLimit(ctx context.Context, limit int32, aq ...AdditionalQuery) ([]ListUsersWithLimitRow, error) {
+	query := listUsersWithLimit
+	queryParams := []interface{}{limit}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.QueryContext(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/endtoend/testdata/params_placeholder_in_left_expr/mysql/go/db.go
+++ b/internal/endtoend/testdata/params_placeholder_in_left_expr/mysql/go/db.go
@@ -29,3 +29,8 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/params_placeholder_in_left_expr/mysql/go/db.go
+++ b/internal/endtoend/testdata/params_placeholder_in_left_expr/mysql/go/db.go
@@ -32,5 +32,5 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/params_placeholder_in_left_expr/mysql/go/query.sql.go
+++ b/internal/endtoend/testdata/params_placeholder_in_left_expr/mysql/go/query.sql.go
@@ -14,8 +14,16 @@ const findByID = `-- name: FindByID :many
 SELECT id, name FROM users WHERE ? = id
 `
 
-func (q *Queries) FindByID(ctx context.Context, id int32) ([]User, error) {
-	rows, err := q.db.QueryContext(ctx, findByID, id)
+func (q *Queries) FindByID(ctx context.Context, id int32, aq ...AdditionalQuery) ([]User, error) {
+	query := findByID
+	queryParams := []interface{}{id}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.QueryContext(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}
@@ -46,8 +54,16 @@ type FindByIDAndNameParams struct {
 	Name sql.NullString
 }
 
-func (q *Queries) FindByIDAndName(ctx context.Context, arg FindByIDAndNameParams) ([]User, error) {
-	rows, err := q.db.QueryContext(ctx, findByIDAndName, arg.ID, arg.Name)
+func (q *Queries) FindByIDAndName(ctx context.Context, arg FindByIDAndNameParams, aq ...AdditionalQuery) ([]User, error) {
+	query := findByIDAndName
+	queryParams := []interface{}{arg.ID, arg.Name}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.QueryContext(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/endtoend/testdata/params_placeholder_in_left_expr/postgresql/go/db.go
+++ b/internal/endtoend/testdata/params_placeholder_in_left_expr/postgresql/go/db.go
@@ -29,3 +29,8 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/params_placeholder_in_left_expr/postgresql/go/db.go
+++ b/internal/endtoend/testdata/params_placeholder_in_left_expr/postgresql/go/db.go
@@ -32,5 +32,5 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/params_placeholder_in_left_expr/postgresql/go/query.sql.go
+++ b/internal/endtoend/testdata/params_placeholder_in_left_expr/postgresql/go/query.sql.go
@@ -13,8 +13,16 @@ const findByID = `-- name: FindByID :many
 SELECT id, name FROM users WHERE $1 = id
 `
 
-func (q *Queries) FindByID(ctx context.Context, id int32) ([]User, error) {
-	rows, err := q.db.QueryContext(ctx, findByID, id)
+func (q *Queries) FindByID(ctx context.Context, id int32, aq ...AdditionalQuery) ([]User, error) {
+	query := findByID
+	queryParams := []interface{}{id}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.QueryContext(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}
@@ -40,8 +48,16 @@ const findByIDAndName = `-- name: FindByIDAndName :many
 SELECT id, name FROM users WHERE $1 = id AND $1 = name
 `
 
-func (q *Queries) FindByIDAndName(ctx context.Context, id int32) ([]User, error) {
-	rows, err := q.db.QueryContext(ctx, findByIDAndName, id)
+func (q *Queries) FindByIDAndName(ctx context.Context, id int32, aq ...AdditionalQuery) ([]User, error) {
+	query := findByIDAndName
+	queryParams := []interface{}{id}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.QueryContext(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/endtoend/testdata/params_two/mysql/go/db.go
+++ b/internal/endtoend/testdata/params_two/mysql/go/db.go
@@ -29,3 +29,8 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/params_two/mysql/go/db.go
+++ b/internal/endtoend/testdata/params_two/mysql/go/db.go
@@ -32,5 +32,5 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/params_two/mysql/go/query.sql.go
+++ b/internal/endtoend/testdata/params_two/mysql/go/query.sql.go
@@ -20,8 +20,16 @@ type FooByAandBParams struct {
 	B sql.NullString
 }
 
-func (q *Queries) FooByAandB(ctx context.Context, arg FooByAandBParams) ([]Foo, error) {
-	rows, err := q.db.QueryContext(ctx, fooByAandB, arg.A, arg.B)
+func (q *Queries) FooByAandB(ctx context.Context, arg FooByAandBParams, aq ...AdditionalQuery) ([]Foo, error) {
+	query := fooByAandB
+	queryParams := []interface{}{arg.A, arg.B}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.QueryContext(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/endtoend/testdata/params_two/postgresql/pgx/v4/go/db.go
+++ b/internal/endtoend/testdata/params_two/postgresql/pgx/v4/go/db.go
@@ -33,5 +33,5 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/params_two/postgresql/pgx/v4/go/db.go
+++ b/internal/endtoend/testdata/params_two/postgresql/pgx/v4/go/db.go
@@ -30,3 +30,8 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/params_two/postgresql/pgx/v4/go/query.sql.go
+++ b/internal/endtoend/testdata/params_two/postgresql/pgx/v4/go/query.sql.go
@@ -20,8 +20,16 @@ type FooByAandBParams struct {
 	B sql.NullString
 }
 
-func (q *Queries) FooByAandB(ctx context.Context, arg FooByAandBParams) ([]Foo, error) {
-	rows, err := q.db.Query(ctx, fooByAandB, arg.A, arg.B)
+func (q *Queries) FooByAandB(ctx context.Context, arg FooByAandBParams, aq ...AdditionalQuery) ([]Foo, error) {
+	query := fooByAandB
+	queryParams := []interface{}{arg.A, arg.B}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.Query(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/endtoend/testdata/params_two/postgresql/pgx/v5/go/db.go
+++ b/internal/endtoend/testdata/params_two/postgresql/pgx/v5/go/db.go
@@ -33,5 +33,5 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/params_two/postgresql/pgx/v5/go/db.go
+++ b/internal/endtoend/testdata/params_two/postgresql/pgx/v5/go/db.go
@@ -30,3 +30,8 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/params_two/postgresql/pgx/v5/go/query.sql.go
+++ b/internal/endtoend/testdata/params_two/postgresql/pgx/v5/go/query.sql.go
@@ -21,8 +21,16 @@ type FooByAandBParams struct {
 	B pgtype.Text
 }
 
-func (q *Queries) FooByAandB(ctx context.Context, arg FooByAandBParams) ([]Foo, error) {
-	rows, err := q.db.Query(ctx, fooByAandB, arg.A, arg.B)
+func (q *Queries) FooByAandB(ctx context.Context, arg FooByAandBParams, aq ...AdditionalQuery) ([]Foo, error) {
+	query := fooByAandB
+	queryParams := []interface{}{arg.A, arg.B}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.Query(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/endtoend/testdata/params_two/postgresql/stdlib/go/db.go
+++ b/internal/endtoend/testdata/params_two/postgresql/stdlib/go/db.go
@@ -29,3 +29,8 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/params_two/postgresql/stdlib/go/db.go
+++ b/internal/endtoend/testdata/params_two/postgresql/stdlib/go/db.go
@@ -32,5 +32,5 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/params_two/postgresql/stdlib/go/query.sql.go
+++ b/internal/endtoend/testdata/params_two/postgresql/stdlib/go/query.sql.go
@@ -20,8 +20,16 @@ type FooByAandBParams struct {
 	B sql.NullString
 }
 
-func (q *Queries) FooByAandB(ctx context.Context, arg FooByAandBParams) ([]Foo, error) {
-	rows, err := q.db.QueryContext(ctx, fooByAandB, arg.A, arg.B)
+func (q *Queries) FooByAandB(ctx context.Context, arg FooByAandBParams, aq ...AdditionalQuery) ([]Foo, error) {
+	query := fooByAandB
+	queryParams := []interface{}{arg.A, arg.B}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.QueryContext(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/endtoend/testdata/pattern_in_expr/mysql/go/db.go
+++ b/internal/endtoend/testdata/pattern_in_expr/mysql/go/db.go
@@ -29,3 +29,8 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/pattern_in_expr/mysql/go/db.go
+++ b/internal/endtoend/testdata/pattern_in_expr/mysql/go/db.go
@@ -32,5 +32,5 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/pattern_in_expr/mysql/go/query.sql.go
+++ b/internal/endtoend/testdata/pattern_in_expr/mysql/go/query.sql.go
@@ -14,8 +14,16 @@ const fooByBarB = `-- name: FooByBarB :many
 SELECT a, b from foo where foo.a in (select a from bar where bar.b = ?)
 `
 
-func (q *Queries) FooByBarB(ctx context.Context, b sql.NullString) ([]Foo, error) {
-	rows, err := q.db.QueryContext(ctx, fooByBarB, b)
+func (q *Queries) FooByBarB(ctx context.Context, b sql.NullString, aq ...AdditionalQuery) ([]Foo, error) {
+	query := fooByBarB
+	queryParams := []interface{}{b}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.QueryContext(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}
@@ -46,8 +54,16 @@ type FooByListParams struct {
 	A_2 sql.NullString
 }
 
-func (q *Queries) FooByList(ctx context.Context, arg FooByListParams) ([]Foo, error) {
-	rows, err := q.db.QueryContext(ctx, fooByList, arg.A, arg.A_2)
+func (q *Queries) FooByList(ctx context.Context, arg FooByListParams, aq ...AdditionalQuery) ([]Foo, error) {
+	query := fooByList
+	queryParams := []interface{}{arg.A, arg.A_2}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.QueryContext(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}
@@ -78,8 +94,16 @@ type FooByNotListParams struct {
 	A_2 sql.NullString
 }
 
-func (q *Queries) FooByNotList(ctx context.Context, arg FooByNotListParams) ([]Foo, error) {
-	rows, err := q.db.QueryContext(ctx, fooByNotList, arg.A, arg.A_2)
+func (q *Queries) FooByNotList(ctx context.Context, arg FooByNotListParams, aq ...AdditionalQuery) ([]Foo, error) {
+	query := fooByNotList
+	queryParams := []interface{}{arg.A, arg.A_2}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.QueryContext(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}
@@ -105,8 +129,16 @@ const fooByParamList = `-- name: FooByParamList :many
 SELECT a, b from foo where ? in (foo.a, foo.b)
 `
 
-func (q *Queries) FooByParamList(ctx context.Context, a sql.NullString) ([]Foo, error) {
-	rows, err := q.db.QueryContext(ctx, fooByParamList, a)
+func (q *Queries) FooByParamList(ctx context.Context, a sql.NullString, aq ...AdditionalQuery) ([]Foo, error) {
+	query := fooByParamList
+	queryParams := []interface{}{a}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.QueryContext(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/endtoend/testdata/pattern_matching/mysql/go/db.go
+++ b/internal/endtoend/testdata/pattern_matching/mysql/go/db.go
@@ -29,3 +29,8 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/pattern_matching/mysql/go/db.go
+++ b/internal/endtoend/testdata/pattern_matching/mysql/go/db.go
@@ -32,5 +32,5 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/pattern_matching/mysql/go/query.sql.go
+++ b/internal/endtoend/testdata/pattern_matching/mysql/go/query.sql.go
@@ -14,8 +14,16 @@ const petsByName = `-- name: PetsByName :many
 SELECT name FROM pet WHERE name LIKE ?
 `
 
-func (q *Queries) PetsByName(ctx context.Context, name sql.NullString) ([]sql.NullString, error) {
-	rows, err := q.db.QueryContext(ctx, petsByName, name)
+func (q *Queries) PetsByName(ctx context.Context, name sql.NullString, aq ...AdditionalQuery) ([]sql.NullString, error) {
+	query := petsByName
+	queryParams := []interface{}{name}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.QueryContext(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/endtoend/testdata/pattern_matching/postgresql/go/db.go
+++ b/internal/endtoend/testdata/pattern_matching/postgresql/go/db.go
@@ -29,3 +29,8 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/pattern_matching/postgresql/go/db.go
+++ b/internal/endtoend/testdata/pattern_matching/postgresql/go/db.go
@@ -32,5 +32,5 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/pattern_matching/postgresql/go/query.sql.go
+++ b/internal/endtoend/testdata/pattern_matching/postgresql/go/query.sql.go
@@ -14,8 +14,16 @@ const petsByName = `-- name: PetsByName :many
 SELECT name FROM pet WHERE name LIKE $1
 `
 
-func (q *Queries) PetsByName(ctx context.Context, name sql.NullString) ([]sql.NullString, error) {
-	rows, err := q.db.QueryContext(ctx, petsByName, name)
+func (q *Queries) PetsByName(ctx context.Context, name sql.NullString, aq ...AdditionalQuery) ([]sql.NullString, error) {
+	query := petsByName
+	queryParams := []interface{}{name}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.QueryContext(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/endtoend/testdata/pg_advisory_xact_lock/postgresql/pgx/v4/go/db.go
+++ b/internal/endtoend/testdata/pg_advisory_xact_lock/postgresql/pgx/v4/go/db.go
@@ -33,5 +33,5 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/pg_advisory_xact_lock/postgresql/pgx/v4/go/db.go
+++ b/internal/endtoend/testdata/pg_advisory_xact_lock/postgresql/pgx/v4/go/db.go
@@ -30,3 +30,8 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/pg_advisory_xact_lock/postgresql/pgx/v4/go/query.sql.go
+++ b/internal/endtoend/testdata/pg_advisory_xact_lock/postgresql/pgx/v4/go/query.sql.go
@@ -23,8 +23,10 @@ const advisoryLockOne = `-- name: AdvisoryLockOne :one
 SELECT pg_advisory_lock($1)
 `
 
-func (q *Queries) AdvisoryLockOne(ctx context.Context, pgAdvisoryLock int64) (interface{}, error) {
-	row := q.db.QueryRow(ctx, advisoryLockOne, pgAdvisoryLock)
+func (q *Queries) AdvisoryLockOne(ctx context.Context, pgAdvisoryLock int64, aq ...AdditionalQuery) (interface{}, error) {
+	query := advisoryLockOne
+	queryParams := []interface{}{pgAdvisoryLock}
+	row := q.db.QueryRow(ctx, query, queryParams...)
 	var pg_advisory_lock interface{}
 	err := row.Scan(&pg_advisory_lock)
 	return pg_advisory_lock, err
@@ -34,8 +36,16 @@ const advisoryUnlock = `-- name: AdvisoryUnlock :many
 SELECT pg_advisory_unlock($1)
 `
 
-func (q *Queries) AdvisoryUnlock(ctx context.Context, pgAdvisoryUnlock int64) ([]bool, error) {
-	rows, err := q.db.Query(ctx, advisoryUnlock, pgAdvisoryUnlock)
+func (q *Queries) AdvisoryUnlock(ctx context.Context, pgAdvisoryUnlock int64, aq ...AdditionalQuery) ([]bool, error) {
+	query := advisoryUnlock
+	queryParams := []interface{}{pgAdvisoryUnlock}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.Query(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/endtoend/testdata/pg_advisory_xact_lock/postgresql/pgx/v5/go/db.go
+++ b/internal/endtoend/testdata/pg_advisory_xact_lock/postgresql/pgx/v5/go/db.go
@@ -33,5 +33,5 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/pg_advisory_xact_lock/postgresql/pgx/v5/go/db.go
+++ b/internal/endtoend/testdata/pg_advisory_xact_lock/postgresql/pgx/v5/go/db.go
@@ -30,3 +30,8 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/pg_advisory_xact_lock/postgresql/pgx/v5/go/query.sql.go
+++ b/internal/endtoend/testdata/pg_advisory_xact_lock/postgresql/pgx/v5/go/query.sql.go
@@ -23,8 +23,10 @@ const advisoryLockOne = `-- name: AdvisoryLockOne :one
 SELECT pg_advisory_lock($1)
 `
 
-func (q *Queries) AdvisoryLockOne(ctx context.Context, pgAdvisoryLock int64) (interface{}, error) {
-	row := q.db.QueryRow(ctx, advisoryLockOne, pgAdvisoryLock)
+func (q *Queries) AdvisoryLockOne(ctx context.Context, pgAdvisoryLock int64, aq ...AdditionalQuery) (interface{}, error) {
+	query := advisoryLockOne
+	queryParams := []interface{}{pgAdvisoryLock}
+	row := q.db.QueryRow(ctx, query, queryParams...)
 	var pg_advisory_lock interface{}
 	err := row.Scan(&pg_advisory_lock)
 	return pg_advisory_lock, err
@@ -34,8 +36,16 @@ const advisoryUnlock = `-- name: AdvisoryUnlock :many
 SELECT pg_advisory_unlock($1)
 `
 
-func (q *Queries) AdvisoryUnlock(ctx context.Context, pgAdvisoryUnlock int64) ([]bool, error) {
-	rows, err := q.db.Query(ctx, advisoryUnlock, pgAdvisoryUnlock)
+func (q *Queries) AdvisoryUnlock(ctx context.Context, pgAdvisoryUnlock int64, aq ...AdditionalQuery) ([]bool, error) {
+	query := advisoryUnlock
+	queryParams := []interface{}{pgAdvisoryUnlock}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.Query(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/endtoend/testdata/pg_advisory_xact_lock/postgresql/stdlib/go/db.go
+++ b/internal/endtoend/testdata/pg_advisory_xact_lock/postgresql/stdlib/go/db.go
@@ -29,3 +29,8 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/pg_advisory_xact_lock/postgresql/stdlib/go/db.go
+++ b/internal/endtoend/testdata/pg_advisory_xact_lock/postgresql/stdlib/go/db.go
@@ -32,5 +32,5 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/pg_advisory_xact_lock/postgresql/stdlib/go/exec.sql.go
+++ b/internal/endtoend/testdata/pg_advisory_xact_lock/postgresql/stdlib/go/exec.sql.go
@@ -14,7 +14,10 @@ SELECT pg_advisory_lock($1)
 `
 
 func (q *Queries) AdvisoryLockExec(ctx context.Context, pgAdvisoryLock int64) error {
-	_, err := q.db.ExecContext(ctx, advisoryLockExec, pgAdvisoryLock)
+	query := advisoryLockExec
+	queryParams := []interface{}{pgAdvisoryLock}
+
+	_, err := q.db.ExecContext(ctx, query, queryParams...)
 	return err
 }
 
@@ -23,7 +26,10 @@ SELECT pg_advisory_lock($1)
 `
 
 func (q *Queries) AdvisoryLockExecRows(ctx context.Context, pgAdvisoryLock int64) (int64, error) {
-	result, err := q.db.ExecContext(ctx, advisoryLockExecRows, pgAdvisoryLock)
+	query := advisoryLockExecRows
+	queryParams := []interface{}{pgAdvisoryLock}
+
+	result, err := q.db.ExecContext(ctx, query, queryParams...)
 	if err != nil {
 		return 0, err
 	}

--- a/internal/endtoend/testdata/pg_dump/db/db.go
+++ b/internal/endtoend/testdata/pg_dump/db/db.go
@@ -29,3 +29,8 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/pg_dump/db/db.go
+++ b/internal/endtoend/testdata/pg_dump/db/db.go
@@ -32,5 +32,5 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/pg_ext_ltree/postgresql/pgx/v4/go/db.go
+++ b/internal/endtoend/testdata/pg_ext_ltree/postgresql/pgx/v4/go/db.go
@@ -33,5 +33,5 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/pg_ext_ltree/postgresql/pgx/v4/go/db.go
+++ b/internal/endtoend/testdata/pg_ext_ltree/postgresql/pgx/v4/go/db.go
@@ -30,3 +30,8 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/pg_ext_ltree/postgresql/pgx/v5/go/db.go
+++ b/internal/endtoend/testdata/pg_ext_ltree/postgresql/pgx/v5/go/db.go
@@ -33,5 +33,5 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/pg_ext_ltree/postgresql/pgx/v5/go/db.go
+++ b/internal/endtoend/testdata/pg_ext_ltree/postgresql/pgx/v5/go/db.go
@@ -30,3 +30,8 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/pg_ext_ltree/postgresql/stdlib/go/db.go
+++ b/internal/endtoend/testdata/pg_ext_ltree/postgresql/stdlib/go/db.go
@@ -29,3 +29,8 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/pg_ext_ltree/postgresql/stdlib/go/db.go
+++ b/internal/endtoend/testdata/pg_ext_ltree/postgresql/stdlib/go/db.go
@@ -32,5 +32,5 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/pg_extensions/postgresql/pgx/v4/go/db.go
+++ b/internal/endtoend/testdata/pg_extensions/postgresql/pgx/v4/go/db.go
@@ -33,5 +33,5 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/pg_extensions/postgresql/pgx/v4/go/db.go
+++ b/internal/endtoend/testdata/pg_extensions/postgresql/pgx/v4/go/db.go
@@ -30,3 +30,8 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/pg_extensions/postgresql/pgx/v4/go/pg_trgm.sql.go
+++ b/internal/endtoend/testdata/pg_extensions/postgresql/pgx/v4/go/pg_trgm.sql.go
@@ -13,8 +13,10 @@ const wordSimilarity = `-- name: WordSimilarity :one
 SELECT word_similarity('word', 'two words')
 `
 
-func (q *Queries) WordSimilarity(ctx context.Context) (float32, error) {
-	row := q.db.QueryRow(ctx, wordSimilarity)
+func (q *Queries) WordSimilarity(ctx context.Context, aq ...AdditionalQuery) (float32, error) {
+	query := wordSimilarity
+	queryParams := []interface{}{}
+	row := q.db.QueryRow(ctx, query, queryParams...)
 	var word_similarity float32
 	err := row.Scan(&word_similarity)
 	return word_similarity, err

--- a/internal/endtoend/testdata/pg_extensions/postgresql/pgx/v4/go/pgcrypto.sql.go
+++ b/internal/endtoend/testdata/pg_extensions/postgresql/pgx/v4/go/pgcrypto.sql.go
@@ -13,8 +13,10 @@ const encodeDigest = `-- name: EncodeDigest :one
 SELECT encode(digest($1, 'sha1'), 'hex')
 `
 
-func (q *Queries) EncodeDigest(ctx context.Context, digest string) (string, error) {
-	row := q.db.QueryRow(ctx, encodeDigest, digest)
+func (q *Queries) EncodeDigest(ctx context.Context, digest string, aq ...AdditionalQuery) (string, error) {
+	query := encodeDigest
+	queryParams := []interface{}{digest}
+	row := q.db.QueryRow(ctx, query, queryParams...)
 	var encode string
 	err := row.Scan(&encode)
 	return encode, err

--- a/internal/endtoend/testdata/pg_extensions/postgresql/pgx/v4/go/uuid_ossp.sql.go
+++ b/internal/endtoend/testdata/pg_extensions/postgresql/pgx/v4/go/uuid_ossp.sql.go
@@ -15,8 +15,10 @@ const generateUUID = `-- name: GenerateUUID :one
 SELECT uuid_generate_v4()
 `
 
-func (q *Queries) GenerateUUID(ctx context.Context) (uuid.UUID, error) {
-	row := q.db.QueryRow(ctx, generateUUID)
+func (q *Queries) GenerateUUID(ctx context.Context, aq ...AdditionalQuery) (uuid.UUID, error) {
+	query := generateUUID
+	queryParams := []interface{}{}
+	row := q.db.QueryRow(ctx, query, queryParams...)
 	var uuid_generate_v4 uuid.UUID
 	err := row.Scan(&uuid_generate_v4)
 	return uuid_generate_v4, err

--- a/internal/endtoend/testdata/pg_extensions/postgresql/pgx/v5/go/db.go
+++ b/internal/endtoend/testdata/pg_extensions/postgresql/pgx/v5/go/db.go
@@ -33,5 +33,5 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/pg_extensions/postgresql/pgx/v5/go/db.go
+++ b/internal/endtoend/testdata/pg_extensions/postgresql/pgx/v5/go/db.go
@@ -30,3 +30,8 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/pg_extensions/postgresql/pgx/v5/go/pg_trgm.sql.go
+++ b/internal/endtoend/testdata/pg_extensions/postgresql/pgx/v5/go/pg_trgm.sql.go
@@ -13,8 +13,10 @@ const wordSimilarity = `-- name: WordSimilarity :one
 SELECT word_similarity('word', 'two words')
 `
 
-func (q *Queries) WordSimilarity(ctx context.Context) (float32, error) {
-	row := q.db.QueryRow(ctx, wordSimilarity)
+func (q *Queries) WordSimilarity(ctx context.Context, aq ...AdditionalQuery) (float32, error) {
+	query := wordSimilarity
+	queryParams := []interface{}{}
+	row := q.db.QueryRow(ctx, query, queryParams...)
 	var word_similarity float32
 	err := row.Scan(&word_similarity)
 	return word_similarity, err

--- a/internal/endtoend/testdata/pg_extensions/postgresql/pgx/v5/go/pgcrypto.sql.go
+++ b/internal/endtoend/testdata/pg_extensions/postgresql/pgx/v5/go/pgcrypto.sql.go
@@ -13,8 +13,10 @@ const encodeDigest = `-- name: EncodeDigest :one
 SELECT encode(digest($1, 'sha1'), 'hex')
 `
 
-func (q *Queries) EncodeDigest(ctx context.Context, digest string) (string, error) {
-	row := q.db.QueryRow(ctx, encodeDigest, digest)
+func (q *Queries) EncodeDigest(ctx context.Context, digest string, aq ...AdditionalQuery) (string, error) {
+	query := encodeDigest
+	queryParams := []interface{}{digest}
+	row := q.db.QueryRow(ctx, query, queryParams...)
 	var encode string
 	err := row.Scan(&encode)
 	return encode, err

--- a/internal/endtoend/testdata/pg_extensions/postgresql/pgx/v5/go/uuid_ossp.sql.go
+++ b/internal/endtoend/testdata/pg_extensions/postgresql/pgx/v5/go/uuid_ossp.sql.go
@@ -15,8 +15,10 @@ const generateUUID = `-- name: GenerateUUID :one
 SELECT uuid_generate_v4()
 `
 
-func (q *Queries) GenerateUUID(ctx context.Context) (pgtype.UUID, error) {
-	row := q.db.QueryRow(ctx, generateUUID)
+func (q *Queries) GenerateUUID(ctx context.Context, aq ...AdditionalQuery) (pgtype.UUID, error) {
+	query := generateUUID
+	queryParams := []interface{}{}
+	row := q.db.QueryRow(ctx, query, queryParams...)
 	var uuid_generate_v4 pgtype.UUID
 	err := row.Scan(&uuid_generate_v4)
 	return uuid_generate_v4, err

--- a/internal/endtoend/testdata/pg_extensions/postgresql/stdlib/go/db.go
+++ b/internal/endtoend/testdata/pg_extensions/postgresql/stdlib/go/db.go
@@ -29,3 +29,8 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/pg_extensions/postgresql/stdlib/go/db.go
+++ b/internal/endtoend/testdata/pg_extensions/postgresql/stdlib/go/db.go
@@ -32,5 +32,5 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/pg_extensions/postgresql/stdlib/go/pg_trgm.sql.go
+++ b/internal/endtoend/testdata/pg_extensions/postgresql/stdlib/go/pg_trgm.sql.go
@@ -13,8 +13,16 @@ const wordSimilarity = `-- name: WordSimilarity :one
 SELECT word_similarity('word', 'two words')
 `
 
-func (q *Queries) WordSimilarity(ctx context.Context) (float32, error) {
-	row := q.db.QueryRowContext(ctx, wordSimilarity)
+func (q *Queries) WordSimilarity(ctx context.Context, aq ...AdditionalQuery) (float32, error) {
+	query := wordSimilarity
+	queryParams := []interface{}{}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	row := q.db.QueryRowContext(ctx, query, queryParams...)
 	var word_similarity float32
 	err := row.Scan(&word_similarity)
 	return word_similarity, err

--- a/internal/endtoend/testdata/pg_extensions/postgresql/stdlib/go/pgcrypto.sql.go
+++ b/internal/endtoend/testdata/pg_extensions/postgresql/stdlib/go/pgcrypto.sql.go
@@ -13,8 +13,16 @@ const encodeDigest = `-- name: EncodeDigest :one
 SELECT encode(digest($1, 'sha1'), 'hex')
 `
 
-func (q *Queries) EncodeDigest(ctx context.Context, digest string) (string, error) {
-	row := q.db.QueryRowContext(ctx, encodeDigest, digest)
+func (q *Queries) EncodeDigest(ctx context.Context, digest string, aq ...AdditionalQuery) (string, error) {
+	query := encodeDigest
+	queryParams := []interface{}{digest}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	row := q.db.QueryRowContext(ctx, query, queryParams...)
 	var encode string
 	err := row.Scan(&encode)
 	return encode, err

--- a/internal/endtoend/testdata/pg_extensions/postgresql/stdlib/go/uuid_ossp.sql.go
+++ b/internal/endtoend/testdata/pg_extensions/postgresql/stdlib/go/uuid_ossp.sql.go
@@ -15,8 +15,16 @@ const generateUUID = `-- name: GenerateUUID :one
 SELECT uuid_generate_v4()
 `
 
-func (q *Queries) GenerateUUID(ctx context.Context) (uuid.UUID, error) {
-	row := q.db.QueryRowContext(ctx, generateUUID)
+func (q *Queries) GenerateUUID(ctx context.Context, aq ...AdditionalQuery) (uuid.UUID, error) {
+	query := generateUUID
+	queryParams := []interface{}{}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	row := q.db.QueryRowContext(ctx, query, queryParams...)
 	var uuid_generate_v4 uuid.UUID
 	err := row.Scan(&uuid_generate_v4)
 	return uuid_generate_v4, err

--- a/internal/endtoend/testdata/pg_generate_series/postgresql/pgx/v4/go/db.go
+++ b/internal/endtoend/testdata/pg_generate_series/postgresql/pgx/v4/go/db.go
@@ -33,5 +33,5 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/pg_generate_series/postgresql/pgx/v4/go/db.go
+++ b/internal/endtoend/testdata/pg_generate_series/postgresql/pgx/v4/go/db.go
@@ -30,3 +30,8 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/pg_generate_series/postgresql/pgx/v4/go/query.sql.go
+++ b/internal/endtoend/testdata/pg_generate_series/postgresql/pgx/v4/go/query.sql.go
@@ -21,8 +21,16 @@ type GenerateSeriesParams struct {
 	Column2 time.Time `json:"column_2"`
 }
 
-func (q *Queries) GenerateSeries(ctx context.Context, arg GenerateSeriesParams) ([]pgtype.Numeric, error) {
-	rows, err := q.db.Query(ctx, generateSeries, arg.Column1, arg.Column2)
+func (q *Queries) GenerateSeries(ctx context.Context, arg GenerateSeriesParams, aq ...AdditionalQuery) ([]pgtype.Numeric, error) {
+	query := generateSeries
+	queryParams := []interface{}{arg.Column1, arg.Column2}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.Query(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/endtoend/testdata/pg_generate_series/postgresql/pgx/v5/go/db.go
+++ b/internal/endtoend/testdata/pg_generate_series/postgresql/pgx/v5/go/db.go
@@ -33,5 +33,5 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/pg_generate_series/postgresql/pgx/v5/go/db.go
+++ b/internal/endtoend/testdata/pg_generate_series/postgresql/pgx/v5/go/db.go
@@ -30,3 +30,8 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/pg_generate_series/postgresql/pgx/v5/go/query.sql.go
+++ b/internal/endtoend/testdata/pg_generate_series/postgresql/pgx/v5/go/query.sql.go
@@ -20,8 +20,16 @@ type GenerateSeriesParams struct {
 	Column2 pgtype.Timestamp `json:"column_2"`
 }
 
-func (q *Queries) GenerateSeries(ctx context.Context, arg GenerateSeriesParams) ([]pgtype.Numeric, error) {
-	rows, err := q.db.Query(ctx, generateSeries, arg.Column1, arg.Column2)
+func (q *Queries) GenerateSeries(ctx context.Context, arg GenerateSeriesParams, aq ...AdditionalQuery) ([]pgtype.Numeric, error) {
+	query := generateSeries
+	queryParams := []interface{}{arg.Column1, arg.Column2}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.Query(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/endtoend/testdata/pg_generate_series/postgresql/stdlib/go/db.go
+++ b/internal/endtoend/testdata/pg_generate_series/postgresql/stdlib/go/db.go
@@ -29,3 +29,8 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/pg_generate_series/postgresql/stdlib/go/db.go
+++ b/internal/endtoend/testdata/pg_generate_series/postgresql/stdlib/go/db.go
@@ -32,5 +32,5 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/pg_generate_series/postgresql/stdlib/go/query.sql.go
+++ b/internal/endtoend/testdata/pg_generate_series/postgresql/stdlib/go/query.sql.go
@@ -19,8 +19,16 @@ type GenerateSeriesParams struct {
 	Column2 time.Time `json:"column_2"`
 }
 
-func (q *Queries) GenerateSeries(ctx context.Context, arg GenerateSeriesParams) ([]string, error) {
-	rows, err := q.db.QueryContext(ctx, generateSeries, arg.Column1, arg.Column2)
+func (q *Queries) GenerateSeries(ctx context.Context, arg GenerateSeriesParams, aq ...AdditionalQuery) ([]string, error) {
+	query := generateSeries
+	queryParams := []interface{}{arg.Column1, arg.Column2}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.QueryContext(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/endtoend/testdata/pg_timezone_names/go_pgx/v4/db.go
+++ b/internal/endtoend/testdata/pg_timezone_names/go_pgx/v4/db.go
@@ -33,5 +33,5 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/pg_timezone_names/go_pgx/v4/db.go
+++ b/internal/endtoend/testdata/pg_timezone_names/go_pgx/v4/db.go
@@ -30,3 +30,8 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/pg_timezone_names/go_pgx/v4/query.sql.go
+++ b/internal/endtoend/testdata/pg_timezone_names/go_pgx/v4/query.sql.go
@@ -19,8 +19,16 @@ type GetColumnsRow struct {
 	ColumnName string
 }
 
-func (q *Queries) GetColumns(ctx context.Context) ([]GetColumnsRow, error) {
-	rows, err := q.db.Query(ctx, getColumns)
+func (q *Queries) GetColumns(ctx context.Context, aq ...AdditionalQuery) ([]GetColumnsRow, error) {
+	query := getColumns
+	queryParams := []interface{}{}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.Query(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}
@@ -43,8 +51,16 @@ const getTables = `-- name: GetTables :many
 SELECT table_name::text from information_schema.tables
 `
 
-func (q *Queries) GetTables(ctx context.Context) ([]string, error) {
-	rows, err := q.db.Query(ctx, getTables)
+func (q *Queries) GetTables(ctx context.Context, aq ...AdditionalQuery) ([]string, error) {
+	query := getTables
+	queryParams := []interface{}{}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.Query(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}
@@ -74,8 +90,16 @@ type GetTimezonesRow struct {
 	IsDst     sql.NullBool
 }
 
-func (q *Queries) GetTimezones(ctx context.Context) ([]GetTimezonesRow, error) {
-	rows, err := q.db.Query(ctx, getTimezones)
+func (q *Queries) GetTimezones(ctx context.Context, aq ...AdditionalQuery) ([]GetTimezonesRow, error) {
+	query := getTimezones
+	queryParams := []interface{}{}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.Query(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/endtoend/testdata/pg_timezone_names/go_pgx/v5/db.go
+++ b/internal/endtoend/testdata/pg_timezone_names/go_pgx/v5/db.go
@@ -33,5 +33,5 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/pg_timezone_names/go_pgx/v5/db.go
+++ b/internal/endtoend/testdata/pg_timezone_names/go_pgx/v5/db.go
@@ -30,3 +30,8 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/pg_timezone_names/go_pgx/v5/query.sql.go
+++ b/internal/endtoend/testdata/pg_timezone_names/go_pgx/v5/query.sql.go
@@ -20,8 +20,16 @@ type GetColumnsRow struct {
 	ColumnName string
 }
 
-func (q *Queries) GetColumns(ctx context.Context) ([]GetColumnsRow, error) {
-	rows, err := q.db.Query(ctx, getColumns)
+func (q *Queries) GetColumns(ctx context.Context, aq ...AdditionalQuery) ([]GetColumnsRow, error) {
+	query := getColumns
+	queryParams := []interface{}{}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.Query(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}
@@ -44,8 +52,16 @@ const getTables = `-- name: GetTables :many
 SELECT table_name::text from information_schema.tables
 `
 
-func (q *Queries) GetTables(ctx context.Context) ([]string, error) {
-	rows, err := q.db.Query(ctx, getTables)
+func (q *Queries) GetTables(ctx context.Context, aq ...AdditionalQuery) ([]string, error) {
+	query := getTables
+	queryParams := []interface{}{}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.Query(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}
@@ -75,8 +91,16 @@ type GetTimezonesRow struct {
 	IsDst     pgtype.Bool
 }
 
-func (q *Queries) GetTimezones(ctx context.Context) ([]GetTimezonesRow, error) {
-	rows, err := q.db.Query(ctx, getTimezones)
+func (q *Queries) GetTimezones(ctx context.Context, aq ...AdditionalQuery) ([]GetTimezonesRow, error) {
+	query := getTimezones
+	queryParams := []interface{}{}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.Query(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/endtoend/testdata/pg_timezone_names/go_stdlib/db.go
+++ b/internal/endtoend/testdata/pg_timezone_names/go_stdlib/db.go
@@ -29,3 +29,8 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/pg_timezone_names/go_stdlib/db.go
+++ b/internal/endtoend/testdata/pg_timezone_names/go_stdlib/db.go
@@ -32,5 +32,5 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/pg_timezone_names/go_stdlib/query.sql.go
+++ b/internal/endtoend/testdata/pg_timezone_names/go_stdlib/query.sql.go
@@ -19,8 +19,16 @@ type GetColumnsRow struct {
 	ColumnName string
 }
 
-func (q *Queries) GetColumns(ctx context.Context) ([]GetColumnsRow, error) {
-	rows, err := q.db.QueryContext(ctx, getColumns)
+func (q *Queries) GetColumns(ctx context.Context, aq ...AdditionalQuery) ([]GetColumnsRow, error) {
+	query := getColumns
+	queryParams := []interface{}{}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.QueryContext(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}
@@ -46,8 +54,16 @@ const getTables = `-- name: GetTables :many
 SELECT table_name::text from information_schema.tables
 `
 
-func (q *Queries) GetTables(ctx context.Context) ([]string, error) {
-	rows, err := q.db.QueryContext(ctx, getTables)
+func (q *Queries) GetTables(ctx context.Context, aq ...AdditionalQuery) ([]string, error) {
+	query := getTables
+	queryParams := []interface{}{}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.QueryContext(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}
@@ -80,8 +96,16 @@ type GetTimezonesRow struct {
 	IsDst     sql.NullBool
 }
 
-func (q *Queries) GetTimezones(ctx context.Context) ([]GetTimezonesRow, error) {
-	rows, err := q.db.QueryContext(ctx, getTimezones)
+func (q *Queries) GetTimezones(ctx context.Context, aq ...AdditionalQuery) ([]GetTimezonesRow, error) {
+	query := getTimezones
+	queryParams := []interface{}{}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.QueryContext(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/endtoend/testdata/pg_user_table/postgresql/pgx/v4/go/db.go
+++ b/internal/endtoend/testdata/pg_user_table/postgresql/pgx/v4/go/db.go
@@ -33,5 +33,5 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/pg_user_table/postgresql/pgx/v4/go/db.go
+++ b/internal/endtoend/testdata/pg_user_table/postgresql/pgx/v4/go/db.go
@@ -30,3 +30,8 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/pg_user_table/postgresql/pgx/v4/go/query.sql.go
+++ b/internal/endtoend/testdata/pg_user_table/postgresql/pgx/v4/go/query.sql.go
@@ -13,8 +13,16 @@ const user = `-- name: User :many
 SELECT "user".id FROM "user"
 `
 
-func (q *Queries) User(ctx context.Context) ([]int64, error) {
-	rows, err := q.db.Query(ctx, user)
+func (q *Queries) User(ctx context.Context, aq ...AdditionalQuery) ([]int64, error) {
+	query := user
+	queryParams := []interface{}{}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.Query(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/endtoend/testdata/pg_user_table/postgresql/pgx/v5/go/db.go
+++ b/internal/endtoend/testdata/pg_user_table/postgresql/pgx/v5/go/db.go
@@ -33,5 +33,5 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/pg_user_table/postgresql/pgx/v5/go/db.go
+++ b/internal/endtoend/testdata/pg_user_table/postgresql/pgx/v5/go/db.go
@@ -30,3 +30,8 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/pg_user_table/postgresql/pgx/v5/go/query.sql.go
+++ b/internal/endtoend/testdata/pg_user_table/postgresql/pgx/v5/go/query.sql.go
@@ -13,8 +13,16 @@ const user = `-- name: User :many
 SELECT "user".id FROM "user"
 `
 
-func (q *Queries) User(ctx context.Context) ([]int64, error) {
-	rows, err := q.db.Query(ctx, user)
+func (q *Queries) User(ctx context.Context, aq ...AdditionalQuery) ([]int64, error) {
+	query := user
+	queryParams := []interface{}{}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.Query(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/endtoend/testdata/pg_user_table/postgresql/stdlib/go/db.go
+++ b/internal/endtoend/testdata/pg_user_table/postgresql/stdlib/go/db.go
@@ -29,3 +29,8 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/pg_user_table/postgresql/stdlib/go/db.go
+++ b/internal/endtoend/testdata/pg_user_table/postgresql/stdlib/go/db.go
@@ -32,5 +32,5 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/pg_user_table/postgresql/stdlib/go/query.sql.go
+++ b/internal/endtoend/testdata/pg_user_table/postgresql/stdlib/go/query.sql.go
@@ -13,8 +13,16 @@ const user = `-- name: User :many
 SELECT "user".id FROM "user"
 `
 
-func (q *Queries) User(ctx context.Context) ([]int64, error) {
-	rows, err := q.db.QueryContext(ctx, user)
+func (q *Queries) User(ctx context.Context, aq ...AdditionalQuery) ([]int64, error) {
+	query := user
+	queryParams := []interface{}{}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.QueryContext(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/endtoend/testdata/pointer_type_import/postgresql/pgx/v4/go/db.go
+++ b/internal/endtoend/testdata/pointer_type_import/postgresql/pgx/v4/go/db.go
@@ -33,5 +33,5 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/pointer_type_import/postgresql/pgx/v4/go/db.go
+++ b/internal/endtoend/testdata/pointer_type_import/postgresql/pgx/v4/go/db.go
@@ -30,3 +30,8 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/pointer_type_import/postgresql/pgx/v5/go/db.go
+++ b/internal/endtoend/testdata/pointer_type_import/postgresql/pgx/v5/go/db.go
@@ -33,5 +33,5 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/pointer_type_import/postgresql/pgx/v5/go/db.go
+++ b/internal/endtoend/testdata/pointer_type_import/postgresql/pgx/v5/go/db.go
@@ -30,3 +30,8 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/pointer_type_import/postgresql/pgx/v5/go/query.sql.go
+++ b/internal/endtoend/testdata/pointer_type_import/postgresql/pgx/v5/go/query.sql.go
@@ -14,8 +14,10 @@ const find = `-- name: Find :one
 SELECT bar FROM foo WHERE baz = $1
 `
 
-func (q *Queries) Find(ctx context.Context, baz *netip.Prefix) (*netip.Addr, error) {
-	row := q.db.QueryRow(ctx, find, baz)
+func (q *Queries) Find(ctx context.Context, baz *netip.Prefix, aq ...AdditionalQuery) (*netip.Addr, error) {
+	query := find
+	queryParams := []interface{}{baz}
+	row := q.db.QueryRow(ctx, query, queryParams...)
 	var bar *netip.Addr
 	err := row.Scan(&bar)
 	return bar, err
@@ -25,8 +27,16 @@ const list = `-- name: List :many
 SELECT bar, baz FROM foo
 `
 
-func (q *Queries) List(ctx context.Context) ([]Foo, error) {
-	rows, err := q.db.Query(ctx, list)
+func (q *Queries) List(ctx context.Context, aq ...AdditionalQuery) ([]Foo, error) {
+	query := list
+	queryParams := []interface{}{}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.Query(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/endtoend/testdata/prepared_queries/mysql/go/db.go
+++ b/internal/endtoend/testdata/prepared_queries/mysql/go/db.go
@@ -129,5 +129,5 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/prepared_queries/mysql/go/db.go
+++ b/internal/endtoend/testdata/prepared_queries/mysql/go/db.go
@@ -126,3 +126,8 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 		listUsersStmt:               q.listUsersStmt,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/prepared_queries/postgresql/stdlib/go/db.go
+++ b/internal/endtoend/testdata/prepared_queries/postgresql/stdlib/go/db.go
@@ -129,5 +129,5 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/prepared_queries/postgresql/stdlib/go/db.go
+++ b/internal/endtoend/testdata/prepared_queries/postgresql/stdlib/go/db.go
@@ -126,3 +126,8 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 		listUsersStmt:               q.listUsersStmt,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/prepared_queries/postgresql/stdlib/go/query.sql.go
+++ b/internal/endtoend/testdata/prepared_queries/postgresql/stdlib/go/query.sql.go
@@ -20,7 +20,10 @@ type DeleteUsersByNameParams struct {
 }
 
 func (q *Queries) DeleteUsersByName(ctx context.Context, arg DeleteUsersByNameParams) (int64, error) {
-	result, err := q.exec(ctx, q.deleteUsersByNameStmt, deleteUsersByName, arg.FirstName, arg.LastName)
+	query := deleteUsersByName
+	queryParams := []interface{}{arg.FirstName, arg.LastName}
+
+	result, err := q.exec(ctx, q.deleteUsersByNameStmt, query, queryParams...)
 	if err != nil {
 		return 0, err
 	}
@@ -37,8 +40,16 @@ type GetUserByIDRow struct {
 	LastName  sql.NullString
 }
 
-func (q *Queries) GetUserByID(ctx context.Context, targetID int32) (GetUserByIDRow, error) {
-	row := q.queryRow(ctx, q.getUserByIDStmt, getUserByID, targetID)
+func (q *Queries) GetUserByID(ctx context.Context, targetID int32, aq ...AdditionalQuery) (GetUserByIDRow, error) {
+	query := getUserByID
+	queryParams := []interface{}{targetID}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	row := q.queryRow(ctx, q.getUserByIDStmt, query, queryParams...)
 	var i GetUserByIDRow
 	err := row.Scan(&i.FirstName, &i.ID, &i.LastName)
 	return i, err
@@ -54,7 +65,10 @@ type InsertNewUserParams struct {
 }
 
 func (q *Queries) InsertNewUser(ctx context.Context, arg InsertNewUserParams) error {
-	_, err := q.exec(ctx, q.insertNewUserStmt, insertNewUser, arg.FirstName, arg.LastName)
+	query := insertNewUser
+	queryParams := []interface{}{arg.FirstName, arg.LastName}
+
+	_, err := q.exec(ctx, q.insertNewUserStmt, query, queryParams...)
 	return err
 }
 
@@ -68,7 +82,10 @@ type InsertNewUserWithResultParams struct {
 }
 
 func (q *Queries) InsertNewUserWithResult(ctx context.Context, arg InsertNewUserWithResultParams) (sql.Result, error) {
-	return q.exec(ctx, q.insertNewUserWithResultStmt, insertNewUserWithResult, arg.FirstName, arg.LastName)
+	query := insertNewUserWithResult
+	queryParams := []interface{}{arg.FirstName, arg.LastName}
+
+	return q.exec(ctx, q.insertNewUserWithResultStmt, query, queryParams...)
 }
 
 const listUsers = `-- name: ListUsers :many
@@ -80,8 +97,16 @@ type ListUsersRow struct {
 	LastName  sql.NullString
 }
 
-func (q *Queries) ListUsers(ctx context.Context) ([]ListUsersRow, error) {
-	rows, err := q.query(ctx, q.listUsersStmt, listUsers)
+func (q *Queries) ListUsers(ctx context.Context, aq ...AdditionalQuery) ([]ListUsersRow, error) {
+	query := listUsers
+	queryParams := []interface{}{}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.query(ctx, q.listUsersStmt, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/endtoend/testdata/primary_key_later/postgresql/pgx/v4/go/db.go
+++ b/internal/endtoend/testdata/primary_key_later/postgresql/pgx/v4/go/db.go
@@ -33,5 +33,5 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/primary_key_later/postgresql/pgx/v4/go/db.go
+++ b/internal/endtoend/testdata/primary_key_later/postgresql/pgx/v4/go/db.go
@@ -30,3 +30,8 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/primary_key_later/postgresql/pgx/v4/go/queries.sql.go
+++ b/internal/endtoend/testdata/primary_key_later/postgresql/pgx/v4/go/queries.sql.go
@@ -19,8 +19,10 @@ WHERE
 LIMIT 1
 `
 
-func (q *Queries) GetAuthor(ctx context.Context, id int64) (Author, error) {
-	row := q.db.QueryRow(ctx, getAuthor, id)
+func (q *Queries) GetAuthor(ctx context.Context, id int64, aq ...AdditionalQuery) (Author, error) {
+	query := getAuthor
+	queryParams := []interface{}{id}
+	row := q.db.QueryRow(ctx, query, queryParams...)
 	var i Author
 	err := row.Scan(&i.ID, &i.Name, &i.Bio)
 	return i, err

--- a/internal/endtoend/testdata/primary_key_later/postgresql/pgx/v5/go/db.go
+++ b/internal/endtoend/testdata/primary_key_later/postgresql/pgx/v5/go/db.go
@@ -33,5 +33,5 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/primary_key_later/postgresql/pgx/v5/go/db.go
+++ b/internal/endtoend/testdata/primary_key_later/postgresql/pgx/v5/go/db.go
@@ -30,3 +30,8 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/primary_key_later/postgresql/pgx/v5/go/queries.sql.go
+++ b/internal/endtoend/testdata/primary_key_later/postgresql/pgx/v5/go/queries.sql.go
@@ -19,8 +19,10 @@ WHERE
 LIMIT 1
 `
 
-func (q *Queries) GetAuthor(ctx context.Context, id int64) (Author, error) {
-	row := q.db.QueryRow(ctx, getAuthor, id)
+func (q *Queries) GetAuthor(ctx context.Context, id int64, aq ...AdditionalQuery) (Author, error) {
+	query := getAuthor
+	queryParams := []interface{}{id}
+	row := q.db.QueryRow(ctx, query, queryParams...)
 	var i Author
 	err := row.Scan(&i.ID, &i.Name, &i.Bio)
 	return i, err

--- a/internal/endtoend/testdata/primary_key_later/postgresql/stdlib/go/db.go
+++ b/internal/endtoend/testdata/primary_key_later/postgresql/stdlib/go/db.go
@@ -29,3 +29,8 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/primary_key_later/postgresql/stdlib/go/db.go
+++ b/internal/endtoend/testdata/primary_key_later/postgresql/stdlib/go/db.go
@@ -32,5 +32,5 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/primary_key_later/postgresql/stdlib/go/queries.sql.go
+++ b/internal/endtoend/testdata/primary_key_later/postgresql/stdlib/go/queries.sql.go
@@ -19,8 +19,16 @@ WHERE
 LIMIT 1
 `
 
-func (q *Queries) GetAuthor(ctx context.Context, id int64) (Author, error) {
-	row := q.db.QueryRowContext(ctx, getAuthor, id)
+func (q *Queries) GetAuthor(ctx context.Context, id int64, aq ...AdditionalQuery) (Author, error) {
+	query := getAuthor
+	queryParams := []interface{}{id}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	row := q.db.QueryRowContext(ctx, query, queryParams...)
 	var i Author
 	err := row.Scan(&i.ID, &i.Name, &i.Bio)
 	return i, err

--- a/internal/endtoend/testdata/process_plugin_disabled/stderr.txt
+++ b/internal/endtoend/testdata/process_plugin_disabled/stderr.txt
@@ -1,0 +1,1 @@
+error validating sqlc.json: plugin: process-based plugins disabled via SQLCDEBUG=processplugins=0

--- a/internal/endtoend/testdata/process_plugin_disabled/stderr.txt
+++ b/internal/endtoend/testdata/process_plugin_disabled/stderr.txt
@@ -1,1 +1,0 @@
-error validating sqlc.json: plugin: process-based plugins disabled via SQLCDEBUG=processplugins=0

--- a/internal/endtoend/testdata/query_parameter_limit_to_two/postgresql/go/db.go
+++ b/internal/endtoend/testdata/query_parameter_limit_to_two/postgresql/go/db.go
@@ -29,3 +29,8 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/query_parameter_limit_to_two/postgresql/go/db.go
+++ b/internal/endtoend/testdata/query_parameter_limit_to_two/postgresql/go/db.go
@@ -32,5 +32,5 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/query_parameter_limit_to_two/postgresql/go/query.sql.go
+++ b/internal/endtoend/testdata/query_parameter_limit_to_two/postgresql/go/query.sql.go
@@ -29,13 +29,21 @@ type CreateAuthorParams struct {
 	Titles      []string
 }
 
-func (q *Queries) CreateAuthor(ctx context.Context, arg CreateAuthorParams) (Author, error) {
-	row := q.db.QueryRowContext(ctx, createAuthor,
+func (q *Queries) CreateAuthor(ctx context.Context, arg CreateAuthorParams, aq ...AdditionalQuery) (Author, error) {
+	query := createAuthor
+	queryParams := []interface{}{
 		arg.Name,
 		arg.Bio,
 		arg.CountryCode,
 		pq.Array(arg.Titles),
-	)
+	}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	row := q.db.QueryRowContext(ctx, query, queryParams...)
 	var i Author
 	err := row.Scan(
 		&i.ID,
@@ -51,8 +59,16 @@ const createAuthorOnlyTitles = `-- name: CreateAuthorOnlyTitles :one
 INSERT INTO authors (name, titles) VALUES ($1, $2) RETURNING id, name, bio, country_code, titles
 `
 
-func (q *Queries) CreateAuthorOnlyTitles(ctx context.Context, name string, titles []string) (Author, error) {
-	row := q.db.QueryRowContext(ctx, createAuthorOnlyTitles, name, pq.Array(titles))
+func (q *Queries) CreateAuthorOnlyTitles(ctx context.Context, name string, titles []string, aq ...AdditionalQuery) (Author, error) {
+	query := createAuthorOnlyTitles
+	queryParams := []interface{}{name, pq.Array(titles)}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	row := q.db.QueryRowContext(ctx, query, queryParams...)
 	var i Author
 	err := row.Scan(
 		&i.ID,
@@ -70,7 +86,10 @@ WHERE id = $1
 `
 
 func (q *Queries) DeleteAuthor(ctx context.Context, id int64) error {
-	_, err := q.db.ExecContext(ctx, deleteAuthor, id)
+	query := deleteAuthor
+	queryParams := []interface{}{id}
+
+	_, err := q.db.ExecContext(ctx, query, queryParams...)
 	return err
 }
 
@@ -91,6 +110,7 @@ func (q *Queries) DeleteAuthors(ctx context.Context, name string, ids []int64) e
 	} else {
 		query = strings.Replace(query, "/*SLICE:ids*/?", "NULL", 1)
 	}
+
 	_, err := q.db.ExecContext(ctx, query, queryParams...)
 	return err
 }
@@ -100,8 +120,16 @@ SELECT id, name, bio, country_code, titles FROM authors
 WHERE name = $1 AND country_code = $2 LIMIT 1
 `
 
-func (q *Queries) GetAuthor(ctx context.Context, name string, countryCode string) (Author, error) {
-	row := q.db.QueryRowContext(ctx, getAuthor, name, countryCode)
+func (q *Queries) GetAuthor(ctx context.Context, name string, countryCode string, aq ...AdditionalQuery) (Author, error) {
+	query := getAuthor
+	queryParams := []interface{}{name, countryCode}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	row := q.db.QueryRowContext(ctx, query, queryParams...)
 	var i Author
 	err := row.Scan(
 		&i.ID,
@@ -118,8 +146,16 @@ SELECT id, name, bio, country_code, titles FROM authors
 ORDER BY name
 `
 
-func (q *Queries) ListAuthors(ctx context.Context) ([]Author, error) {
-	rows, err := q.db.QueryContext(ctx, listAuthors)
+func (q *Queries) ListAuthors(ctx context.Context, aq ...AdditionalQuery) ([]Author, error) {
+	query := listAuthors
+	queryParams := []interface{}{}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.QueryContext(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/endtoend/testdata/query_parameter_limit_to_zero/postgresql/go/db.go
+++ b/internal/endtoend/testdata/query_parameter_limit_to_zero/postgresql/go/db.go
@@ -29,3 +29,8 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/query_parameter_limit_to_zero/postgresql/go/db.go
+++ b/internal/endtoend/testdata/query_parameter_limit_to_zero/postgresql/go/db.go
@@ -32,5 +32,5 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/query_parameter_limit_to_zero/postgresql/go/query.sql.go
+++ b/internal/endtoend/testdata/query_parameter_limit_to_zero/postgresql/go/query.sql.go
@@ -25,8 +25,16 @@ type CreateAuthorParams struct {
 	CountryCode string
 }
 
-func (q *Queries) CreateAuthor(ctx context.Context, arg CreateAuthorParams) (Author, error) {
-	row := q.db.QueryRowContext(ctx, createAuthor, arg.Name, arg.Bio, arg.CountryCode)
+func (q *Queries) CreateAuthor(ctx context.Context, arg CreateAuthorParams, aq ...AdditionalQuery) (Author, error) {
+	query := createAuthor
+	queryParams := []interface{}{arg.Name, arg.Bio, arg.CountryCode}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	row := q.db.QueryRowContext(ctx, query, queryParams...)
 	var i Author
 	err := row.Scan(
 		&i.ID,
@@ -47,7 +55,10 @@ type DeleteAuthorParams struct {
 }
 
 func (q *Queries) DeleteAuthor(ctx context.Context, arg DeleteAuthorParams) error {
-	_, err := q.db.ExecContext(ctx, deleteAuthor, arg.ID)
+	query := deleteAuthor
+	queryParams := []interface{}{arg.ID}
+
+	_, err := q.db.ExecContext(ctx, query, queryParams...)
 	return err
 }
 
@@ -61,8 +72,16 @@ type GetAuthorParams struct {
 	CountryCode string
 }
 
-func (q *Queries) GetAuthor(ctx context.Context, arg GetAuthorParams) (Author, error) {
-	row := q.db.QueryRowContext(ctx, getAuthor, arg.Name, arg.CountryCode)
+func (q *Queries) GetAuthor(ctx context.Context, arg GetAuthorParams, aq ...AdditionalQuery) (Author, error) {
+	query := getAuthor
+	queryParams := []interface{}{arg.Name, arg.CountryCode}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	row := q.db.QueryRowContext(ctx, query, queryParams...)
 	var i Author
 	err := row.Scan(
 		&i.ID,
@@ -78,8 +97,16 @@ SELECT id, name, bio, country_code FROM authors
 ORDER BY name
 `
 
-func (q *Queries) ListAuthors(ctx context.Context) ([]Author, error) {
-	rows, err := q.db.QueryContext(ctx, listAuthors)
+func (q *Queries) ListAuthors(ctx context.Context, aq ...AdditionalQuery) ([]Author, error) {
+	query := listAuthors
+	queryParams := []interface{}{}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.QueryContext(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/endtoend/testdata/quoted_colname/sqlite/go/db.go
+++ b/internal/endtoend/testdata/quoted_colname/sqlite/go/db.go
@@ -29,3 +29,8 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/quoted_colname/sqlite/go/db.go
+++ b/internal/endtoend/testdata/quoted_colname/sqlite/go/db.go
@@ -32,5 +32,5 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/quoted_colname/sqlite/go/query.sql.go
+++ b/internal/endtoend/testdata/quoted_colname/sqlite/go/query.sql.go
@@ -13,8 +13,16 @@ const testList = `-- name: TestList :many
 SELECT id FROM "test"
 `
 
-func (q *Queries) TestList(ctx context.Context) ([]string, error) {
-	rows, err := q.db.QueryContext(ctx, testList)
+func (q *Queries) TestList(ctx context.Context, aq ...AdditionalQuery) ([]string, error) {
+	query := testList
+	queryParams := []interface{}{}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.QueryContext(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/endtoend/testdata/ranges/pgx/v5/go/db.go
+++ b/internal/endtoend/testdata/ranges/pgx/v5/go/db.go
@@ -33,5 +33,5 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/ranges/pgx/v5/go/db.go
+++ b/internal/endtoend/testdata/ranges/pgx/v5/go/db.go
@@ -30,3 +30,8 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/ranges/pgx/v5/go/query.sql.go
+++ b/internal/endtoend/testdata/ranges/pgx/v5/go/query.sql.go
@@ -13,8 +13,16 @@ const selectTest = `-- name: SelectTest :many
 SELECT v_daterange_null, v_datemultirange_null, v_tsrange_null, v_tsmultirange_null, v_tstzrange_null, v_tstzmultirange_null, v_numrange_null, v_nummultirange_null, v_int4range_null, v_int4multirange_null, v_int8range_null, v_int8multirange_null, v_daterange, v_datemultirange, v_tsrange, v_tsmultirange, v_tstzrange, v_tstzmultirange, v_numrange, v_nummultirange, v_int4range, v_int4multirange, v_int8range, v_int8multirange from test_table
 `
 
-func (q *Queries) SelectTest(ctx context.Context) ([]TestTable, error) {
-	rows, err := q.db.Query(ctx, selectTest)
+func (q *Queries) SelectTest(ctx context.Context, aq ...AdditionalQuery) ([]TestTable, error) {
+	query := selectTest
+	queryParams := []interface{}{}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.Query(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/endtoend/testdata/refreshmatview/postgresql/pgx/v4/go/db.go
+++ b/internal/endtoend/testdata/refreshmatview/postgresql/pgx/v4/go/db.go
@@ -33,5 +33,5 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/refreshmatview/postgresql/pgx/v4/go/db.go
+++ b/internal/endtoend/testdata/refreshmatview/postgresql/pgx/v4/go/db.go
@@ -30,3 +30,8 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/refreshmatview/postgresql/pgx/v5/go/db.go
+++ b/internal/endtoend/testdata/refreshmatview/postgresql/pgx/v5/go/db.go
@@ -33,5 +33,5 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/refreshmatview/postgresql/pgx/v5/go/db.go
+++ b/internal/endtoend/testdata/refreshmatview/postgresql/pgx/v5/go/db.go
@@ -30,3 +30,8 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/rename/v1/pgx/v4/go/db.go
+++ b/internal/endtoend/testdata/rename/v1/pgx/v4/go/db.go
@@ -33,5 +33,5 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/rename/v1/pgx/v4/go/db.go
+++ b/internal/endtoend/testdata/rename/v1/pgx/v4/go/db.go
@@ -30,3 +30,8 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/rename/v1/pgx/v4/go/query.sql.go
+++ b/internal/endtoend/testdata/rename/v1/pgx/v4/go/query.sql.go
@@ -13,8 +13,16 @@ const listBar = `-- name: ListBar :many
 SELECT id_old, ip_old FROM bar_old
 `
 
-func (q *Queries) ListBar(ctx context.Context) ([]BarNew, error) {
-	rows, err := q.db.Query(ctx, listBar)
+func (q *Queries) ListBar(ctx context.Context, aq ...AdditionalQuery) ([]BarNew, error) {
+	query := listBar
+	queryParams := []interface{}{}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.Query(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}
@@ -49,8 +57,16 @@ type ListFooRow struct {
 	BazOld int32
 }
 
-func (q *Queries) ListFoo(ctx context.Context, arg ListFooParams) ([]ListFooRow, error) {
-	rows, err := q.db.Query(ctx, listFoo, arg.IpOld, arg.IDNew)
+func (q *Queries) ListFoo(ctx context.Context, arg ListFooParams, aq ...AdditionalQuery) ([]ListFooRow, error) {
+	query := listFoo
+	queryParams := []interface{}{arg.IpOld, arg.IDNew}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.Query(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/endtoend/testdata/rename/v1/pgx/v5/go/db.go
+++ b/internal/endtoend/testdata/rename/v1/pgx/v5/go/db.go
@@ -33,5 +33,5 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/rename/v1/pgx/v5/go/db.go
+++ b/internal/endtoend/testdata/rename/v1/pgx/v5/go/db.go
@@ -30,3 +30,8 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/rename/v1/pgx/v5/go/query.sql.go
+++ b/internal/endtoend/testdata/rename/v1/pgx/v5/go/query.sql.go
@@ -13,8 +13,16 @@ const listBar = `-- name: ListBar :many
 SELECT id_old, ip_old FROM bar_old
 `
 
-func (q *Queries) ListBar(ctx context.Context) ([]BarNew, error) {
-	rows, err := q.db.Query(ctx, listBar)
+func (q *Queries) ListBar(ctx context.Context, aq ...AdditionalQuery) ([]BarNew, error) {
+	query := listBar
+	queryParams := []interface{}{}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.Query(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}
@@ -49,8 +57,16 @@ type ListFooRow struct {
 	BazOld int32
 }
 
-func (q *Queries) ListFoo(ctx context.Context, arg ListFooParams) ([]ListFooRow, error) {
-	rows, err := q.db.Query(ctx, listFoo, arg.IpOld, arg.IDNew)
+func (q *Queries) ListFoo(ctx context.Context, arg ListFooParams, aq ...AdditionalQuery) ([]ListFooRow, error) {
+	query := listFoo
+	queryParams := []interface{}{arg.IpOld, arg.IDNew}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.Query(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/endtoend/testdata/rename/v1/stdlib/go/db.go
+++ b/internal/endtoend/testdata/rename/v1/stdlib/go/db.go
@@ -29,3 +29,8 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/rename/v1/stdlib/go/db.go
+++ b/internal/endtoend/testdata/rename/v1/stdlib/go/db.go
@@ -32,5 +32,5 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/rename/v1/stdlib/go/query.sql.go
+++ b/internal/endtoend/testdata/rename/v1/stdlib/go/query.sql.go
@@ -13,8 +13,16 @@ const listBar = `-- name: ListBar :many
 SELECT id_old, ip_old FROM bar_old
 `
 
-func (q *Queries) ListBar(ctx context.Context) ([]BarNew, error) {
-	rows, err := q.db.QueryContext(ctx, listBar)
+func (q *Queries) ListBar(ctx context.Context, aq ...AdditionalQuery) ([]BarNew, error) {
+	query := listBar
+	queryParams := []interface{}{}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.QueryContext(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}
@@ -52,8 +60,16 @@ type ListFooRow struct {
 	BazOld int32
 }
 
-func (q *Queries) ListFoo(ctx context.Context, arg ListFooParams) ([]ListFooRow, error) {
-	rows, err := q.db.QueryContext(ctx, listFoo, arg.IpOld, arg.IDNew)
+func (q *Queries) ListFoo(ctx context.Context, arg ListFooParams, aq ...AdditionalQuery) ([]ListFooRow, error) {
+	query := listFoo
+	queryParams := []interface{}{arg.IpOld, arg.IDNew}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.QueryContext(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/endtoend/testdata/rename/v2/pgx/v4/go/db.go
+++ b/internal/endtoend/testdata/rename/v2/pgx/v4/go/db.go
@@ -33,5 +33,5 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/rename/v2/pgx/v4/go/db.go
+++ b/internal/endtoend/testdata/rename/v2/pgx/v4/go/db.go
@@ -30,3 +30,8 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/rename/v2/pgx/v4/go/query.sql.go
+++ b/internal/endtoend/testdata/rename/v2/pgx/v4/go/query.sql.go
@@ -13,8 +13,16 @@ const listBar = `-- name: ListBar :many
 SELECT id_old, ip_old FROM bar_old
 `
 
-func (q *Queries) ListBar(ctx context.Context) ([]BarNew, error) {
-	rows, err := q.db.Query(ctx, listBar)
+func (q *Queries) ListBar(ctx context.Context, aq ...AdditionalQuery) ([]BarNew, error) {
+	query := listBar
+	queryParams := []interface{}{}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.Query(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}
@@ -49,8 +57,16 @@ type ListFooRow struct {
 	BazOld int32
 }
 
-func (q *Queries) ListFoo(ctx context.Context, arg ListFooParams) ([]ListFooRow, error) {
-	rows, err := q.db.Query(ctx, listFoo, arg.IpOld, arg.IDNew)
+func (q *Queries) ListFoo(ctx context.Context, arg ListFooParams, aq ...AdditionalQuery) ([]ListFooRow, error) {
+	query := listFoo
+	queryParams := []interface{}{arg.IpOld, arg.IDNew}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.Query(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/endtoend/testdata/rename/v2/pgx/v5/go/db.go
+++ b/internal/endtoend/testdata/rename/v2/pgx/v5/go/db.go
@@ -33,5 +33,5 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/rename/v2/pgx/v5/go/db.go
+++ b/internal/endtoend/testdata/rename/v2/pgx/v5/go/db.go
@@ -30,3 +30,8 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/rename/v2/pgx/v5/go/query.sql.go
+++ b/internal/endtoend/testdata/rename/v2/pgx/v5/go/query.sql.go
@@ -13,8 +13,16 @@ const listBar = `-- name: ListBar :many
 SELECT id_old, ip_old FROM bar_old
 `
 
-func (q *Queries) ListBar(ctx context.Context) ([]BarNew, error) {
-	rows, err := q.db.Query(ctx, listBar)
+func (q *Queries) ListBar(ctx context.Context, aq ...AdditionalQuery) ([]BarNew, error) {
+	query := listBar
+	queryParams := []interface{}{}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.Query(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}
@@ -49,8 +57,16 @@ type ListFooRow struct {
 	BazOld int32
 }
 
-func (q *Queries) ListFoo(ctx context.Context, arg ListFooParams) ([]ListFooRow, error) {
-	rows, err := q.db.Query(ctx, listFoo, arg.IpOld, arg.IDNew)
+func (q *Queries) ListFoo(ctx context.Context, arg ListFooParams, aq ...AdditionalQuery) ([]ListFooRow, error) {
+	query := listFoo
+	queryParams := []interface{}{arg.IpOld, arg.IDNew}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.Query(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/endtoend/testdata/rename/v2/stdlib/go/db.go
+++ b/internal/endtoend/testdata/rename/v2/stdlib/go/db.go
@@ -29,3 +29,8 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/rename/v2/stdlib/go/db.go
+++ b/internal/endtoend/testdata/rename/v2/stdlib/go/db.go
@@ -32,5 +32,5 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/rename/v2/stdlib/go/query.sql.go
+++ b/internal/endtoend/testdata/rename/v2/stdlib/go/query.sql.go
@@ -13,8 +13,16 @@ const listBar = `-- name: ListBar :many
 SELECT id_old, ip_old FROM bar_old
 `
 
-func (q *Queries) ListBar(ctx context.Context) ([]BarNew, error) {
-	rows, err := q.db.QueryContext(ctx, listBar)
+func (q *Queries) ListBar(ctx context.Context, aq ...AdditionalQuery) ([]BarNew, error) {
+	query := listBar
+	queryParams := []interface{}{}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.QueryContext(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}
@@ -52,8 +60,16 @@ type ListFooRow struct {
 	BazOld int32
 }
 
-func (q *Queries) ListFoo(ctx context.Context, arg ListFooParams) ([]ListFooRow, error) {
-	rows, err := q.db.QueryContext(ctx, listFoo, arg.IpOld, arg.IDNew)
+func (q *Queries) ListFoo(ctx context.Context, arg ListFooParams, aq ...AdditionalQuery) ([]ListFooRow, error) {
+	query := listFoo
+	queryParams := []interface{}{arg.IpOld, arg.IDNew}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.QueryContext(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/endtoend/testdata/returning/postgresql/pgx/v4/go/db.go
+++ b/internal/endtoend/testdata/returning/postgresql/pgx/v4/go/db.go
@@ -33,5 +33,5 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/returning/postgresql/pgx/v4/go/db.go
+++ b/internal/endtoend/testdata/returning/postgresql/pgx/v4/go/db.go
@@ -30,3 +30,8 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/returning/postgresql/pgx/v4/go/query.sql.go
+++ b/internal/endtoend/testdata/returning/postgresql/pgx/v4/go/query.sql.go
@@ -16,8 +16,10 @@ DELETE FROM users
   RETURNING id
 `
 
-func (q *Queries) DeleteUserAndReturnID(ctx context.Context, name sql.NullString) (int32, error) {
-	row := q.db.QueryRow(ctx, deleteUserAndReturnID, name)
+func (q *Queries) DeleteUserAndReturnID(ctx context.Context, name sql.NullString, aq ...AdditionalQuery) (int32, error) {
+	query := deleteUserAndReturnID
+	queryParams := []interface{}{name}
+	row := q.db.QueryRow(ctx, query, queryParams...)
 	var id int32
 	err := row.Scan(&id)
 	return id, err
@@ -29,8 +31,10 @@ DELETE FROM users
   RETURNING name, id
 `
 
-func (q *Queries) DeleteUserAndReturnUser(ctx context.Context, name sql.NullString) (User, error) {
-	row := q.db.QueryRow(ctx, deleteUserAndReturnUser, name)
+func (q *Queries) DeleteUserAndReturnUser(ctx context.Context, name sql.NullString, aq ...AdditionalQuery) (User, error) {
+	query := deleteUserAndReturnUser
+	queryParams := []interface{}{name}
+	row := q.db.QueryRow(ctx, query, queryParams...)
 	var i User
 	err := row.Scan(&i.Name, &i.ID)
 	return i, err
@@ -41,8 +45,10 @@ INSERT INTO users (name) VALUES ($1)
   RETURNING id
 `
 
-func (q *Queries) InsertUserAndReturnID(ctx context.Context, name sql.NullString) (int32, error) {
-	row := q.db.QueryRow(ctx, insertUserAndReturnID, name)
+func (q *Queries) InsertUserAndReturnID(ctx context.Context, name sql.NullString, aq ...AdditionalQuery) (int32, error) {
+	query := insertUserAndReturnID
+	queryParams := []interface{}{name}
+	row := q.db.QueryRow(ctx, query, queryParams...)
 	var id int32
 	err := row.Scan(&id)
 	return id, err
@@ -53,8 +59,10 @@ INSERT INTO users (name) VALUES ($1)
   RETURNING name, id
 `
 
-func (q *Queries) InsertUserAndReturnUser(ctx context.Context, name sql.NullString) (User, error) {
-	row := q.db.QueryRow(ctx, insertUserAndReturnUser, name)
+func (q *Queries) InsertUserAndReturnUser(ctx context.Context, name sql.NullString, aq ...AdditionalQuery) (User, error) {
+	query := insertUserAndReturnUser
+	queryParams := []interface{}{name}
+	row := q.db.QueryRow(ctx, query, queryParams...)
 	var i User
 	err := row.Scan(&i.Name, &i.ID)
 	return i, err
@@ -71,8 +79,10 @@ type UpdateUserAndReturnIDParams struct {
 	Name_2 sql.NullString
 }
 
-func (q *Queries) UpdateUserAndReturnID(ctx context.Context, arg UpdateUserAndReturnIDParams) (int32, error) {
-	row := q.db.QueryRow(ctx, updateUserAndReturnID, arg.Name, arg.Name_2)
+func (q *Queries) UpdateUserAndReturnID(ctx context.Context, arg UpdateUserAndReturnIDParams, aq ...AdditionalQuery) (int32, error) {
+	query := updateUserAndReturnID
+	queryParams := []interface{}{arg.Name, arg.Name_2}
+	row := q.db.QueryRow(ctx, query, queryParams...)
 	var id int32
 	err := row.Scan(&id)
 	return id, err
@@ -89,8 +99,10 @@ type UpdateUserAndReturnUserParams struct {
 	Name_2 sql.NullString
 }
 
-func (q *Queries) UpdateUserAndReturnUser(ctx context.Context, arg UpdateUserAndReturnUserParams) (User, error) {
-	row := q.db.QueryRow(ctx, updateUserAndReturnUser, arg.Name, arg.Name_2)
+func (q *Queries) UpdateUserAndReturnUser(ctx context.Context, arg UpdateUserAndReturnUserParams, aq ...AdditionalQuery) (User, error) {
+	query := updateUserAndReturnUser
+	queryParams := []interface{}{arg.Name, arg.Name_2}
+	row := q.db.QueryRow(ctx, query, queryParams...)
 	var i User
 	err := row.Scan(&i.Name, &i.ID)
 	return i, err

--- a/internal/endtoend/testdata/returning/postgresql/pgx/v5/go/db.go
+++ b/internal/endtoend/testdata/returning/postgresql/pgx/v5/go/db.go
@@ -33,5 +33,5 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/returning/postgresql/pgx/v5/go/db.go
+++ b/internal/endtoend/testdata/returning/postgresql/pgx/v5/go/db.go
@@ -30,3 +30,8 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/returning/postgresql/pgx/v5/go/query.sql.go
+++ b/internal/endtoend/testdata/returning/postgresql/pgx/v5/go/query.sql.go
@@ -17,8 +17,10 @@ DELETE FROM users
   RETURNING id
 `
 
-func (q *Queries) DeleteUserAndReturnID(ctx context.Context, name pgtype.Text) (int32, error) {
-	row := q.db.QueryRow(ctx, deleteUserAndReturnID, name)
+func (q *Queries) DeleteUserAndReturnID(ctx context.Context, name pgtype.Text, aq ...AdditionalQuery) (int32, error) {
+	query := deleteUserAndReturnID
+	queryParams := []interface{}{name}
+	row := q.db.QueryRow(ctx, query, queryParams...)
 	var id int32
 	err := row.Scan(&id)
 	return id, err
@@ -30,8 +32,10 @@ DELETE FROM users
   RETURNING name, id
 `
 
-func (q *Queries) DeleteUserAndReturnUser(ctx context.Context, name pgtype.Text) (User, error) {
-	row := q.db.QueryRow(ctx, deleteUserAndReturnUser, name)
+func (q *Queries) DeleteUserAndReturnUser(ctx context.Context, name pgtype.Text, aq ...AdditionalQuery) (User, error) {
+	query := deleteUserAndReturnUser
+	queryParams := []interface{}{name}
+	row := q.db.QueryRow(ctx, query, queryParams...)
 	var i User
 	err := row.Scan(&i.Name, &i.ID)
 	return i, err
@@ -42,8 +46,10 @@ INSERT INTO users (name) VALUES ($1)
   RETURNING id
 `
 
-func (q *Queries) InsertUserAndReturnID(ctx context.Context, name pgtype.Text) (int32, error) {
-	row := q.db.QueryRow(ctx, insertUserAndReturnID, name)
+func (q *Queries) InsertUserAndReturnID(ctx context.Context, name pgtype.Text, aq ...AdditionalQuery) (int32, error) {
+	query := insertUserAndReturnID
+	queryParams := []interface{}{name}
+	row := q.db.QueryRow(ctx, query, queryParams...)
 	var id int32
 	err := row.Scan(&id)
 	return id, err
@@ -54,8 +60,10 @@ INSERT INTO users (name) VALUES ($1)
   RETURNING name, id
 `
 
-func (q *Queries) InsertUserAndReturnUser(ctx context.Context, name pgtype.Text) (User, error) {
-	row := q.db.QueryRow(ctx, insertUserAndReturnUser, name)
+func (q *Queries) InsertUserAndReturnUser(ctx context.Context, name pgtype.Text, aq ...AdditionalQuery) (User, error) {
+	query := insertUserAndReturnUser
+	queryParams := []interface{}{name}
+	row := q.db.QueryRow(ctx, query, queryParams...)
 	var i User
 	err := row.Scan(&i.Name, &i.ID)
 	return i, err
@@ -72,8 +80,10 @@ type UpdateUserAndReturnIDParams struct {
 	Name_2 pgtype.Text
 }
 
-func (q *Queries) UpdateUserAndReturnID(ctx context.Context, arg UpdateUserAndReturnIDParams) (int32, error) {
-	row := q.db.QueryRow(ctx, updateUserAndReturnID, arg.Name, arg.Name_2)
+func (q *Queries) UpdateUserAndReturnID(ctx context.Context, arg UpdateUserAndReturnIDParams, aq ...AdditionalQuery) (int32, error) {
+	query := updateUserAndReturnID
+	queryParams := []interface{}{arg.Name, arg.Name_2}
+	row := q.db.QueryRow(ctx, query, queryParams...)
 	var id int32
 	err := row.Scan(&id)
 	return id, err
@@ -90,8 +100,10 @@ type UpdateUserAndReturnUserParams struct {
 	Name_2 pgtype.Text
 }
 
-func (q *Queries) UpdateUserAndReturnUser(ctx context.Context, arg UpdateUserAndReturnUserParams) (User, error) {
-	row := q.db.QueryRow(ctx, updateUserAndReturnUser, arg.Name, arg.Name_2)
+func (q *Queries) UpdateUserAndReturnUser(ctx context.Context, arg UpdateUserAndReturnUserParams, aq ...AdditionalQuery) (User, error) {
+	query := updateUserAndReturnUser
+	queryParams := []interface{}{arg.Name, arg.Name_2}
+	row := q.db.QueryRow(ctx, query, queryParams...)
 	var i User
 	err := row.Scan(&i.Name, &i.ID)
 	return i, err

--- a/internal/endtoend/testdata/returning/postgresql/stdlib/go/db.go
+++ b/internal/endtoend/testdata/returning/postgresql/stdlib/go/db.go
@@ -29,3 +29,8 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/returning/postgresql/stdlib/go/db.go
+++ b/internal/endtoend/testdata/returning/postgresql/stdlib/go/db.go
@@ -32,5 +32,5 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/returning/postgresql/stdlib/go/query.sql.go
+++ b/internal/endtoend/testdata/returning/postgresql/stdlib/go/query.sql.go
@@ -16,8 +16,16 @@ DELETE FROM users
   RETURNING id
 `
 
-func (q *Queries) DeleteUserAndReturnID(ctx context.Context, name sql.NullString) (int32, error) {
-	row := q.db.QueryRowContext(ctx, deleteUserAndReturnID, name)
+func (q *Queries) DeleteUserAndReturnID(ctx context.Context, name sql.NullString, aq ...AdditionalQuery) (int32, error) {
+	query := deleteUserAndReturnID
+	queryParams := []interface{}{name}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	row := q.db.QueryRowContext(ctx, query, queryParams...)
 	var id int32
 	err := row.Scan(&id)
 	return id, err
@@ -29,8 +37,16 @@ DELETE FROM users
   RETURNING name, id
 `
 
-func (q *Queries) DeleteUserAndReturnUser(ctx context.Context, name sql.NullString) (User, error) {
-	row := q.db.QueryRowContext(ctx, deleteUserAndReturnUser, name)
+func (q *Queries) DeleteUserAndReturnUser(ctx context.Context, name sql.NullString, aq ...AdditionalQuery) (User, error) {
+	query := deleteUserAndReturnUser
+	queryParams := []interface{}{name}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	row := q.db.QueryRowContext(ctx, query, queryParams...)
 	var i User
 	err := row.Scan(&i.Name, &i.ID)
 	return i, err
@@ -41,8 +57,16 @@ INSERT INTO users (name) VALUES ($1)
   RETURNING id
 `
 
-func (q *Queries) InsertUserAndReturnID(ctx context.Context, name sql.NullString) (int32, error) {
-	row := q.db.QueryRowContext(ctx, insertUserAndReturnID, name)
+func (q *Queries) InsertUserAndReturnID(ctx context.Context, name sql.NullString, aq ...AdditionalQuery) (int32, error) {
+	query := insertUserAndReturnID
+	queryParams := []interface{}{name}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	row := q.db.QueryRowContext(ctx, query, queryParams...)
 	var id int32
 	err := row.Scan(&id)
 	return id, err
@@ -53,8 +77,16 @@ INSERT INTO users (name) VALUES ($1)
   RETURNING name, id
 `
 
-func (q *Queries) InsertUserAndReturnUser(ctx context.Context, name sql.NullString) (User, error) {
-	row := q.db.QueryRowContext(ctx, insertUserAndReturnUser, name)
+func (q *Queries) InsertUserAndReturnUser(ctx context.Context, name sql.NullString, aq ...AdditionalQuery) (User, error) {
+	query := insertUserAndReturnUser
+	queryParams := []interface{}{name}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	row := q.db.QueryRowContext(ctx, query, queryParams...)
 	var i User
 	err := row.Scan(&i.Name, &i.ID)
 	return i, err
@@ -71,8 +103,16 @@ type UpdateUserAndReturnIDParams struct {
 	Name_2 sql.NullString
 }
 
-func (q *Queries) UpdateUserAndReturnID(ctx context.Context, arg UpdateUserAndReturnIDParams) (int32, error) {
-	row := q.db.QueryRowContext(ctx, updateUserAndReturnID, arg.Name, arg.Name_2)
+func (q *Queries) UpdateUserAndReturnID(ctx context.Context, arg UpdateUserAndReturnIDParams, aq ...AdditionalQuery) (int32, error) {
+	query := updateUserAndReturnID
+	queryParams := []interface{}{arg.Name, arg.Name_2}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	row := q.db.QueryRowContext(ctx, query, queryParams...)
 	var id int32
 	err := row.Scan(&id)
 	return id, err
@@ -89,8 +129,16 @@ type UpdateUserAndReturnUserParams struct {
 	Name_2 sql.NullString
 }
 
-func (q *Queries) UpdateUserAndReturnUser(ctx context.Context, arg UpdateUserAndReturnUserParams) (User, error) {
-	row := q.db.QueryRowContext(ctx, updateUserAndReturnUser, arg.Name, arg.Name_2)
+func (q *Queries) UpdateUserAndReturnUser(ctx context.Context, arg UpdateUserAndReturnUserParams, aq ...AdditionalQuery) (User, error) {
+	query := updateUserAndReturnUser
+	queryParams := []interface{}{arg.Name, arg.Name_2}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	row := q.db.QueryRowContext(ctx, query, queryParams...)
 	var i User
 	err := row.Scan(&i.Name, &i.ID)
 	return i, err

--- a/internal/endtoend/testdata/returning/sqlite/go/db.go
+++ b/internal/endtoend/testdata/returning/sqlite/go/db.go
@@ -29,3 +29,8 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/returning/sqlite/go/db.go
+++ b/internal/endtoend/testdata/returning/sqlite/go/db.go
@@ -32,5 +32,5 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/returning/sqlite/go/query.sql.go
+++ b/internal/endtoend/testdata/returning/sqlite/go/query.sql.go
@@ -16,8 +16,16 @@ DELETE FROM users
   RETURNING id
 `
 
-func (q *Queries) DeleteUserAndReturnID(ctx context.Context, name sql.NullString) (int64, error) {
-	row := q.db.QueryRowContext(ctx, deleteUserAndReturnID, name)
+func (q *Queries) DeleteUserAndReturnID(ctx context.Context, name sql.NullString, aq ...AdditionalQuery) (int64, error) {
+	query := deleteUserAndReturnID
+	queryParams := []interface{}{name}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	row := q.db.QueryRowContext(ctx, query, queryParams...)
 	var id int64
 	err := row.Scan(&id)
 	return id, err
@@ -29,8 +37,16 @@ DELETE FROM users
   RETURNING name, id
 `
 
-func (q *Queries) DeleteUserAndReturnUser(ctx context.Context, name sql.NullString) (User, error) {
-	row := q.db.QueryRowContext(ctx, deleteUserAndReturnUser, name)
+func (q *Queries) DeleteUserAndReturnUser(ctx context.Context, name sql.NullString, aq ...AdditionalQuery) (User, error) {
+	query := deleteUserAndReturnUser
+	queryParams := []interface{}{name}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	row := q.db.QueryRowContext(ctx, query, queryParams...)
 	var i User
 	err := row.Scan(&i.Name, &i.ID)
 	return i, err
@@ -41,8 +57,16 @@ INSERT INTO users (name) VALUES (?1)
   RETURNING id
 `
 
-func (q *Queries) InsertUserAndReturnID(ctx context.Context, name sql.NullString) (int64, error) {
-	row := q.db.QueryRowContext(ctx, insertUserAndReturnID, name)
+func (q *Queries) InsertUserAndReturnID(ctx context.Context, name sql.NullString, aq ...AdditionalQuery) (int64, error) {
+	query := insertUserAndReturnID
+	queryParams := []interface{}{name}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	row := q.db.QueryRowContext(ctx, query, queryParams...)
 	var id int64
 	err := row.Scan(&id)
 	return id, err
@@ -53,8 +77,16 @@ INSERT INTO users (name) VALUES (?1)
   RETURNING name, id
 `
 
-func (q *Queries) InsertUserAndReturnUser(ctx context.Context, name sql.NullString) (User, error) {
-	row := q.db.QueryRowContext(ctx, insertUserAndReturnUser, name)
+func (q *Queries) InsertUserAndReturnUser(ctx context.Context, name sql.NullString, aq ...AdditionalQuery) (User, error) {
+	query := insertUserAndReturnUser
+	queryParams := []interface{}{name}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	row := q.db.QueryRowContext(ctx, query, queryParams...)
 	var i User
 	err := row.Scan(&i.Name, &i.ID)
 	return i, err
@@ -71,8 +103,16 @@ type UpdateUserAndReturnIDParams struct {
 	Name_2 sql.NullString
 }
 
-func (q *Queries) UpdateUserAndReturnID(ctx context.Context, arg UpdateUserAndReturnIDParams) (int64, error) {
-	row := q.db.QueryRowContext(ctx, updateUserAndReturnID, arg.Name, arg.Name_2)
+func (q *Queries) UpdateUserAndReturnID(ctx context.Context, arg UpdateUserAndReturnIDParams, aq ...AdditionalQuery) (int64, error) {
+	query := updateUserAndReturnID
+	queryParams := []interface{}{arg.Name, arg.Name_2}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	row := q.db.QueryRowContext(ctx, query, queryParams...)
 	var id int64
 	err := row.Scan(&id)
 	return id, err
@@ -89,8 +129,16 @@ type UpdateUserAndReturnUserParams struct {
 	Name_2 sql.NullString
 }
 
-func (q *Queries) UpdateUserAndReturnUser(ctx context.Context, arg UpdateUserAndReturnUserParams) (User, error) {
-	row := q.db.QueryRowContext(ctx, updateUserAndReturnUser, arg.Name, arg.Name_2)
+func (q *Queries) UpdateUserAndReturnUser(ctx context.Context, arg UpdateUserAndReturnUserParams, aq ...AdditionalQuery) (User, error) {
+	query := updateUserAndReturnUser
+	queryParams := []interface{}{arg.Name, arg.Name_2}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	row := q.db.QueryRowContext(ctx, query, queryParams...)
 	var i User
 	err := row.Scan(&i.Name, &i.ID)
 	return i, err

--- a/internal/endtoend/testdata/schema_scoped_create/mysql/go/db.go
+++ b/internal/endtoend/testdata/schema_scoped_create/mysql/go/db.go
@@ -29,3 +29,8 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/schema_scoped_create/mysql/go/db.go
+++ b/internal/endtoend/testdata/schema_scoped_create/mysql/go/db.go
@@ -32,5 +32,5 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/schema_scoped_create/mysql/go/query.sql.go
+++ b/internal/endtoend/testdata/schema_scoped_create/mysql/go/query.sql.go
@@ -20,5 +20,8 @@ type SchemaScopedCreateParams struct {
 }
 
 func (q *Queries) SchemaScopedCreate(ctx context.Context, arg SchemaScopedCreateParams) (sql.Result, error) {
-	return q.db.ExecContext(ctx, schemaScopedCreate, arg.ID, arg.Name)
+	query := schemaScopedCreate
+	queryParams := []interface{}{arg.ID, arg.Name}
+
+	return q.db.ExecContext(ctx, query, queryParams...)
 }

--- a/internal/endtoend/testdata/schema_scoped_create/postgresql/pgx/v4/go/db.go
+++ b/internal/endtoend/testdata/schema_scoped_create/postgresql/pgx/v4/go/db.go
@@ -33,5 +33,5 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/schema_scoped_create/postgresql/pgx/v4/go/db.go
+++ b/internal/endtoend/testdata/schema_scoped_create/postgresql/pgx/v4/go/db.go
@@ -30,3 +30,8 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/schema_scoped_create/postgresql/pgx/v4/go/query.sql.go
+++ b/internal/endtoend/testdata/schema_scoped_create/postgresql/pgx/v4/go/query.sql.go
@@ -18,8 +18,10 @@ type SchemaScopedCreateParams struct {
 	Name string
 }
 
-func (q *Queries) SchemaScopedCreate(ctx context.Context, arg SchemaScopedCreateParams) (int32, error) {
-	row := q.db.QueryRow(ctx, schemaScopedCreate, arg.ID, arg.Name)
+func (q *Queries) SchemaScopedCreate(ctx context.Context, arg SchemaScopedCreateParams, aq ...AdditionalQuery) (int32, error) {
+	query := schemaScopedCreate
+	queryParams := []interface{}{arg.ID, arg.Name}
+	row := q.db.QueryRow(ctx, query, queryParams...)
 	var id int32
 	err := row.Scan(&id)
 	return id, err

--- a/internal/endtoend/testdata/schema_scoped_create/postgresql/pgx/v5/go/db.go
+++ b/internal/endtoend/testdata/schema_scoped_create/postgresql/pgx/v5/go/db.go
@@ -33,5 +33,5 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/schema_scoped_create/postgresql/pgx/v5/go/db.go
+++ b/internal/endtoend/testdata/schema_scoped_create/postgresql/pgx/v5/go/db.go
@@ -30,3 +30,8 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/schema_scoped_create/postgresql/pgx/v5/go/query.sql.go
+++ b/internal/endtoend/testdata/schema_scoped_create/postgresql/pgx/v5/go/query.sql.go
@@ -18,8 +18,10 @@ type SchemaScopedCreateParams struct {
 	Name string
 }
 
-func (q *Queries) SchemaScopedCreate(ctx context.Context, arg SchemaScopedCreateParams) (int32, error) {
-	row := q.db.QueryRow(ctx, schemaScopedCreate, arg.ID, arg.Name)
+func (q *Queries) SchemaScopedCreate(ctx context.Context, arg SchemaScopedCreateParams, aq ...AdditionalQuery) (int32, error) {
+	query := schemaScopedCreate
+	queryParams := []interface{}{arg.ID, arg.Name}
+	row := q.db.QueryRow(ctx, query, queryParams...)
 	var id int32
 	err := row.Scan(&id)
 	return id, err

--- a/internal/endtoend/testdata/schema_scoped_create/postgresql/stdlib/go/db.go
+++ b/internal/endtoend/testdata/schema_scoped_create/postgresql/stdlib/go/db.go
@@ -29,3 +29,8 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/schema_scoped_create/postgresql/stdlib/go/db.go
+++ b/internal/endtoend/testdata/schema_scoped_create/postgresql/stdlib/go/db.go
@@ -32,5 +32,5 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/schema_scoped_create/postgresql/stdlib/go/query.sql.go
+++ b/internal/endtoend/testdata/schema_scoped_create/postgresql/stdlib/go/query.sql.go
@@ -18,8 +18,16 @@ type SchemaScopedCreateParams struct {
 	Name string
 }
 
-func (q *Queries) SchemaScopedCreate(ctx context.Context, arg SchemaScopedCreateParams) (int32, error) {
-	row := q.db.QueryRowContext(ctx, schemaScopedCreate, arg.ID, arg.Name)
+func (q *Queries) SchemaScopedCreate(ctx context.Context, arg SchemaScopedCreateParams, aq ...AdditionalQuery) (int32, error) {
+	query := schemaScopedCreate
+	queryParams := []interface{}{arg.ID, arg.Name}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	row := q.db.QueryRowContext(ctx, query, queryParams...)
 	var id int32
 	err := row.Scan(&id)
 	return id, err

--- a/internal/endtoend/testdata/schema_scoped_delete/mysql/go/db.go
+++ b/internal/endtoend/testdata/schema_scoped_delete/mysql/go/db.go
@@ -29,3 +29,8 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/schema_scoped_delete/mysql/go/db.go
+++ b/internal/endtoend/testdata/schema_scoped_delete/mysql/go/db.go
@@ -32,5 +32,5 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/schema_scoped_delete/mysql/go/query.sql.go
+++ b/internal/endtoend/testdata/schema_scoped_delete/mysql/go/query.sql.go
@@ -14,6 +14,9 @@ DELETE FROM foo.bar WHERE id = ?
 `
 
 func (q *Queries) SchemaScopedDelete(ctx context.Context, id uint64) error {
-	_, err := q.db.ExecContext(ctx, schemaScopedDelete, id)
+	query := schemaScopedDelete
+	queryParams := []interface{}{id}
+
+	_, err := q.db.ExecContext(ctx, query, queryParams...)
 	return err
 }

--- a/internal/endtoend/testdata/schema_scoped_delete/postgresql/pgx/v4/go/db.go
+++ b/internal/endtoend/testdata/schema_scoped_delete/postgresql/pgx/v4/go/db.go
@@ -33,5 +33,5 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/schema_scoped_delete/postgresql/pgx/v4/go/db.go
+++ b/internal/endtoend/testdata/schema_scoped_delete/postgresql/pgx/v4/go/db.go
@@ -30,3 +30,8 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/schema_scoped_delete/postgresql/pgx/v5/go/db.go
+++ b/internal/endtoend/testdata/schema_scoped_delete/postgresql/pgx/v5/go/db.go
@@ -33,5 +33,5 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/schema_scoped_delete/postgresql/pgx/v5/go/db.go
+++ b/internal/endtoend/testdata/schema_scoped_delete/postgresql/pgx/v5/go/db.go
@@ -30,3 +30,8 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/schema_scoped_delete/postgresql/stdlib/go/db.go
+++ b/internal/endtoend/testdata/schema_scoped_delete/postgresql/stdlib/go/db.go
@@ -29,3 +29,8 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/schema_scoped_delete/postgresql/stdlib/go/db.go
+++ b/internal/endtoend/testdata/schema_scoped_delete/postgresql/stdlib/go/db.go
@@ -32,5 +32,5 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/schema_scoped_delete/postgresql/stdlib/go/query.sql.go
+++ b/internal/endtoend/testdata/schema_scoped_delete/postgresql/stdlib/go/query.sql.go
@@ -14,6 +14,9 @@ DELETE FROM foo.bar WHERE id = $1
 `
 
 func (q *Queries) SchemaScopedDelete(ctx context.Context, id int32) error {
-	_, err := q.db.ExecContext(ctx, schemaScopedDelete, id)
+	query := schemaScopedDelete
+	queryParams := []interface{}{id}
+
+	_, err := q.db.ExecContext(ctx, query, queryParams...)
 	return err
 }

--- a/internal/endtoend/testdata/schema_scoped_enum/pgx/v4/go/db.go
+++ b/internal/endtoend/testdata/schema_scoped_enum/pgx/v4/go/db.go
@@ -33,5 +33,5 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/schema_scoped_enum/pgx/v4/go/db.go
+++ b/internal/endtoend/testdata/schema_scoped_enum/pgx/v4/go/db.go
@@ -30,3 +30,8 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/schema_scoped_enum/pgx/v4/go/query.sql.go
+++ b/internal/endtoend/testdata/schema_scoped_enum/pgx/v4/go/query.sql.go
@@ -13,8 +13,16 @@ const listUsersByRole = `-- name: ListUsersByRole :many
 SELECT role FROM foo.users WHERE role = $1
 `
 
-func (q *Queries) ListUsersByRole(ctx context.Context, role NullFooTypeUserRole) ([]NullFooTypeUserRole, error) {
-	rows, err := q.db.Query(ctx, listUsersByRole, role)
+func (q *Queries) ListUsersByRole(ctx context.Context, role NullFooTypeUserRole, aq ...AdditionalQuery) ([]NullFooTypeUserRole, error) {
+	query := listUsersByRole
+	queryParams := []interface{}{role}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.Query(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/endtoend/testdata/schema_scoped_enum/pgx/v5/go/db.go
+++ b/internal/endtoend/testdata/schema_scoped_enum/pgx/v5/go/db.go
@@ -33,5 +33,5 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/schema_scoped_enum/pgx/v5/go/db.go
+++ b/internal/endtoend/testdata/schema_scoped_enum/pgx/v5/go/db.go
@@ -30,3 +30,8 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/schema_scoped_enum/pgx/v5/go/query.sql.go
+++ b/internal/endtoend/testdata/schema_scoped_enum/pgx/v5/go/query.sql.go
@@ -13,8 +13,16 @@ const listUsersByRole = `-- name: ListUsersByRole :many
 SELECT role FROM foo.users WHERE role = $1
 `
 
-func (q *Queries) ListUsersByRole(ctx context.Context, role NullFooTypeUserRole) ([]NullFooTypeUserRole, error) {
-	rows, err := q.db.Query(ctx, listUsersByRole, role)
+func (q *Queries) ListUsersByRole(ctx context.Context, role NullFooTypeUserRole, aq ...AdditionalQuery) ([]NullFooTypeUserRole, error) {
+	query := listUsersByRole
+	queryParams := []interface{}{role}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.Query(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/endtoend/testdata/schema_scoped_enum/stdlib/go/db.go
+++ b/internal/endtoend/testdata/schema_scoped_enum/stdlib/go/db.go
@@ -29,3 +29,8 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/schema_scoped_enum/stdlib/go/db.go
+++ b/internal/endtoend/testdata/schema_scoped_enum/stdlib/go/db.go
@@ -32,5 +32,5 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/schema_scoped_enum/stdlib/go/query.sql.go
+++ b/internal/endtoend/testdata/schema_scoped_enum/stdlib/go/query.sql.go
@@ -13,8 +13,16 @@ const listUsersByRole = `-- name: ListUsersByRole :many
 SELECT role FROM foo.users WHERE role = $1
 `
 
-func (q *Queries) ListUsersByRole(ctx context.Context, role NullFooTypeUserRole) ([]NullFooTypeUserRole, error) {
-	rows, err := q.db.QueryContext(ctx, listUsersByRole, role)
+func (q *Queries) ListUsersByRole(ctx context.Context, role NullFooTypeUserRole, aq ...AdditionalQuery) ([]NullFooTypeUserRole, error) {
+	query := listUsersByRole
+	queryParams := []interface{}{role}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.QueryContext(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/endtoend/testdata/schema_scoped_filter/mysql/go/db.go
+++ b/internal/endtoend/testdata/schema_scoped_filter/mysql/go/db.go
@@ -29,3 +29,8 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/schema_scoped_filter/mysql/go/db.go
+++ b/internal/endtoend/testdata/schema_scoped_filter/mysql/go/db.go
@@ -32,5 +32,5 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/schema_scoped_filter/mysql/go/query.sql.go
+++ b/internal/endtoend/testdata/schema_scoped_filter/mysql/go/query.sql.go
@@ -13,8 +13,16 @@ const schemaScopedFilter = `-- name: SchemaScopedFilter :many
 SELECT id FROM foo.bar WHERE id = ?
 `
 
-func (q *Queries) SchemaScopedFilter(ctx context.Context, id uint64) ([]uint64, error) {
-	rows, err := q.db.QueryContext(ctx, schemaScopedFilter, id)
+func (q *Queries) SchemaScopedFilter(ctx context.Context, id uint64, aq ...AdditionalQuery) ([]uint64, error) {
+	query := schemaScopedFilter
+	queryParams := []interface{}{id}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.QueryContext(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/endtoend/testdata/schema_scoped_filter/postgresql/pgx/v4/go/db.go
+++ b/internal/endtoend/testdata/schema_scoped_filter/postgresql/pgx/v4/go/db.go
@@ -33,5 +33,5 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/schema_scoped_filter/postgresql/pgx/v4/go/db.go
+++ b/internal/endtoend/testdata/schema_scoped_filter/postgresql/pgx/v4/go/db.go
@@ -30,3 +30,8 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/schema_scoped_filter/postgresql/pgx/v4/go/query.sql.go
+++ b/internal/endtoend/testdata/schema_scoped_filter/postgresql/pgx/v4/go/query.sql.go
@@ -13,8 +13,16 @@ const schemaScopedFilter = `-- name: SchemaScopedFilter :many
 SELECT id FROM foo.bar WHERE id = $1
 `
 
-func (q *Queries) SchemaScopedFilter(ctx context.Context, id int32) ([]int32, error) {
-	rows, err := q.db.Query(ctx, schemaScopedFilter, id)
+func (q *Queries) SchemaScopedFilter(ctx context.Context, id int32, aq ...AdditionalQuery) ([]int32, error) {
+	query := schemaScopedFilter
+	queryParams := []interface{}{id}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.Query(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/endtoend/testdata/schema_scoped_filter/postgresql/pgx/v5/go/db.go
+++ b/internal/endtoend/testdata/schema_scoped_filter/postgresql/pgx/v5/go/db.go
@@ -33,5 +33,5 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/schema_scoped_filter/postgresql/pgx/v5/go/db.go
+++ b/internal/endtoend/testdata/schema_scoped_filter/postgresql/pgx/v5/go/db.go
@@ -30,3 +30,8 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/schema_scoped_filter/postgresql/pgx/v5/go/query.sql.go
+++ b/internal/endtoend/testdata/schema_scoped_filter/postgresql/pgx/v5/go/query.sql.go
@@ -13,8 +13,16 @@ const schemaScopedFilter = `-- name: SchemaScopedFilter :many
 SELECT id FROM foo.bar WHERE id = $1
 `
 
-func (q *Queries) SchemaScopedFilter(ctx context.Context, id int32) ([]int32, error) {
-	rows, err := q.db.Query(ctx, schemaScopedFilter, id)
+func (q *Queries) SchemaScopedFilter(ctx context.Context, id int32, aq ...AdditionalQuery) ([]int32, error) {
+	query := schemaScopedFilter
+	queryParams := []interface{}{id}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.Query(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/endtoend/testdata/schema_scoped_filter/postgresql/stdlib/go/db.go
+++ b/internal/endtoend/testdata/schema_scoped_filter/postgresql/stdlib/go/db.go
@@ -29,3 +29,8 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/schema_scoped_filter/postgresql/stdlib/go/db.go
+++ b/internal/endtoend/testdata/schema_scoped_filter/postgresql/stdlib/go/db.go
@@ -32,5 +32,5 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/schema_scoped_filter/postgresql/stdlib/go/query.sql.go
+++ b/internal/endtoend/testdata/schema_scoped_filter/postgresql/stdlib/go/query.sql.go
@@ -13,8 +13,16 @@ const schemaScopedFilter = `-- name: SchemaScopedFilter :many
 SELECT id FROM foo.bar WHERE id = $1
 `
 
-func (q *Queries) SchemaScopedFilter(ctx context.Context, id int32) ([]int32, error) {
-	rows, err := q.db.QueryContext(ctx, schemaScopedFilter, id)
+func (q *Queries) SchemaScopedFilter(ctx context.Context, id int32, aq ...AdditionalQuery) ([]int32, error) {
+	query := schemaScopedFilter
+	queryParams := []interface{}{id}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.QueryContext(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/endtoend/testdata/schema_scoped_list/mysql/go/db.go
+++ b/internal/endtoend/testdata/schema_scoped_list/mysql/go/db.go
@@ -29,3 +29,8 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/schema_scoped_list/mysql/go/db.go
+++ b/internal/endtoend/testdata/schema_scoped_list/mysql/go/db.go
@@ -32,5 +32,5 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/schema_scoped_list/mysql/go/query.sql.go
+++ b/internal/endtoend/testdata/schema_scoped_list/mysql/go/query.sql.go
@@ -13,8 +13,16 @@ const schemaScopedList = `-- name: SchemaScopedList :many
 SELECT id FROM foo.bar
 `
 
-func (q *Queries) SchemaScopedList(ctx context.Context) ([]uint64, error) {
-	rows, err := q.db.QueryContext(ctx, schemaScopedList)
+func (q *Queries) SchemaScopedList(ctx context.Context, aq ...AdditionalQuery) ([]uint64, error) {
+	query := schemaScopedList
+	queryParams := []interface{}{}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.QueryContext(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/endtoend/testdata/schema_scoped_list/postgresql/pgx/v4/go/db.go
+++ b/internal/endtoend/testdata/schema_scoped_list/postgresql/pgx/v4/go/db.go
@@ -33,5 +33,5 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/schema_scoped_list/postgresql/pgx/v4/go/db.go
+++ b/internal/endtoend/testdata/schema_scoped_list/postgresql/pgx/v4/go/db.go
@@ -30,3 +30,8 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/schema_scoped_list/postgresql/pgx/v4/go/query.sql.go
+++ b/internal/endtoend/testdata/schema_scoped_list/postgresql/pgx/v4/go/query.sql.go
@@ -13,8 +13,16 @@ const schemaScopedList = `-- name: SchemaScopedList :many
 SELECT id FROM foo.bar
 `
 
-func (q *Queries) SchemaScopedList(ctx context.Context) ([]int32, error) {
-	rows, err := q.db.Query(ctx, schemaScopedList)
+func (q *Queries) SchemaScopedList(ctx context.Context, aq ...AdditionalQuery) ([]int32, error) {
+	query := schemaScopedList
+	queryParams := []interface{}{}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.Query(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/endtoend/testdata/schema_scoped_list/postgresql/pgx/v5/go/db.go
+++ b/internal/endtoend/testdata/schema_scoped_list/postgresql/pgx/v5/go/db.go
@@ -33,5 +33,5 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/schema_scoped_list/postgresql/pgx/v5/go/db.go
+++ b/internal/endtoend/testdata/schema_scoped_list/postgresql/pgx/v5/go/db.go
@@ -30,3 +30,8 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/schema_scoped_list/postgresql/pgx/v5/go/query.sql.go
+++ b/internal/endtoend/testdata/schema_scoped_list/postgresql/pgx/v5/go/query.sql.go
@@ -13,8 +13,16 @@ const schemaScopedList = `-- name: SchemaScopedList :many
 SELECT id FROM foo.bar
 `
 
-func (q *Queries) SchemaScopedList(ctx context.Context) ([]int32, error) {
-	rows, err := q.db.Query(ctx, schemaScopedList)
+func (q *Queries) SchemaScopedList(ctx context.Context, aq ...AdditionalQuery) ([]int32, error) {
+	query := schemaScopedList
+	queryParams := []interface{}{}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.Query(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/endtoend/testdata/schema_scoped_list/postgresql/stdlib/go/db.go
+++ b/internal/endtoend/testdata/schema_scoped_list/postgresql/stdlib/go/db.go
@@ -29,3 +29,8 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/schema_scoped_list/postgresql/stdlib/go/db.go
+++ b/internal/endtoend/testdata/schema_scoped_list/postgresql/stdlib/go/db.go
@@ -32,5 +32,5 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/schema_scoped_list/postgresql/stdlib/go/query.sql.go
+++ b/internal/endtoend/testdata/schema_scoped_list/postgresql/stdlib/go/query.sql.go
@@ -13,8 +13,16 @@ const schemaScopedList = `-- name: SchemaScopedList :many
 SELECT id FROM foo.bar
 `
 
-func (q *Queries) SchemaScopedList(ctx context.Context) ([]int32, error) {
-	rows, err := q.db.QueryContext(ctx, schemaScopedList)
+func (q *Queries) SchemaScopedList(ctx context.Context, aq ...AdditionalQuery) ([]int32, error) {
+	query := schemaScopedList
+	queryParams := []interface{}{}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.QueryContext(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/endtoend/testdata/schema_scoped_update/mysql/go/db.go
+++ b/internal/endtoend/testdata/schema_scoped_update/mysql/go/db.go
@@ -29,3 +29,8 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/schema_scoped_update/mysql/go/db.go
+++ b/internal/endtoend/testdata/schema_scoped_update/mysql/go/db.go
@@ -32,5 +32,5 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/schema_scoped_update/mysql/go/query.sql.go
+++ b/internal/endtoend/testdata/schema_scoped_update/mysql/go/query.sql.go
@@ -19,6 +19,9 @@ type SchemaScopedUpdateParams struct {
 }
 
 func (q *Queries) SchemaScopedUpdate(ctx context.Context, arg SchemaScopedUpdateParams) error {
-	_, err := q.db.ExecContext(ctx, schemaScopedUpdate, arg.Name, arg.ID)
+	query := schemaScopedUpdate
+	queryParams := []interface{}{arg.Name, arg.ID}
+
+	_, err := q.db.ExecContext(ctx, query, queryParams...)
 	return err
 }

--- a/internal/endtoend/testdata/schema_scoped_update/postgresql/pgx/v4/go/db.go
+++ b/internal/endtoend/testdata/schema_scoped_update/postgresql/pgx/v4/go/db.go
@@ -33,5 +33,5 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/schema_scoped_update/postgresql/pgx/v4/go/db.go
+++ b/internal/endtoend/testdata/schema_scoped_update/postgresql/pgx/v4/go/db.go
@@ -30,3 +30,8 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/schema_scoped_update/postgresql/pgx/v5/go/db.go
+++ b/internal/endtoend/testdata/schema_scoped_update/postgresql/pgx/v5/go/db.go
@@ -33,5 +33,5 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/schema_scoped_update/postgresql/pgx/v5/go/db.go
+++ b/internal/endtoend/testdata/schema_scoped_update/postgresql/pgx/v5/go/db.go
@@ -30,3 +30,8 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/schema_scoped_update/postgresql/stdlib/go/db.go
+++ b/internal/endtoend/testdata/schema_scoped_update/postgresql/stdlib/go/db.go
@@ -29,3 +29,8 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/schema_scoped_update/postgresql/stdlib/go/db.go
+++ b/internal/endtoend/testdata/schema_scoped_update/postgresql/stdlib/go/db.go
@@ -32,5 +32,5 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/schema_scoped_update/postgresql/stdlib/go/query.sql.go
+++ b/internal/endtoend/testdata/schema_scoped_update/postgresql/stdlib/go/query.sql.go
@@ -19,6 +19,9 @@ type SchemaScopedUpdateParams struct {
 }
 
 func (q *Queries) SchemaScopedUpdate(ctx context.Context, arg SchemaScopedUpdateParams) error {
-	_, err := q.db.ExecContext(ctx, schemaScopedUpdate, arg.ID, arg.Name)
+	query := schemaScopedUpdate
+	queryParams := []interface{}{arg.ID, arg.Name}
+
+	_, err := q.db.ExecContext(ctx, query, queryParams...)
 	return err
 }

--- a/internal/endtoend/testdata/select_column_cast/mysql/go/db.go
+++ b/internal/endtoend/testdata/select_column_cast/mysql/go/db.go
@@ -29,3 +29,8 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/select_column_cast/mysql/go/db.go
+++ b/internal/endtoend/testdata/select_column_cast/mysql/go/db.go
@@ -32,5 +32,5 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/select_column_cast/mysql/go/query.sql.go
+++ b/internal/endtoend/testdata/select_column_cast/mysql/go/query.sql.go
@@ -13,8 +13,16 @@ const selectColumnCast = `-- name: SelectColumnCast :many
 SELECT CAST(bar AS UNSIGNED) FROM foo
 `
 
-func (q *Queries) SelectColumnCast(ctx context.Context) ([]int64, error) {
-	rows, err := q.db.QueryContext(ctx, selectColumnCast)
+func (q *Queries) SelectColumnCast(ctx context.Context, aq ...AdditionalQuery) ([]int64, error) {
+	query := selectColumnCast
+	queryParams := []interface{}{}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.QueryContext(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/endtoend/testdata/select_column_cast/postgresql/pgx/v4/go/db.go
+++ b/internal/endtoend/testdata/select_column_cast/postgresql/pgx/v4/go/db.go
@@ -33,5 +33,5 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/select_column_cast/postgresql/pgx/v4/go/db.go
+++ b/internal/endtoend/testdata/select_column_cast/postgresql/pgx/v4/go/db.go
@@ -30,3 +30,8 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/select_column_cast/postgresql/pgx/v4/go/query.sql.go
+++ b/internal/endtoend/testdata/select_column_cast/postgresql/pgx/v4/go/query.sql.go
@@ -13,8 +13,16 @@ const selectColumnCast = `-- name: SelectColumnCast :many
 SELECT bar::int FROM foo
 `
 
-func (q *Queries) SelectColumnCast(ctx context.Context) ([]int32, error) {
-	rows, err := q.db.Query(ctx, selectColumnCast)
+func (q *Queries) SelectColumnCast(ctx context.Context, aq ...AdditionalQuery) ([]int32, error) {
+	query := selectColumnCast
+	queryParams := []interface{}{}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.Query(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/endtoend/testdata/select_column_cast/postgresql/pgx/v5/go/db.go
+++ b/internal/endtoend/testdata/select_column_cast/postgresql/pgx/v5/go/db.go
@@ -33,5 +33,5 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/select_column_cast/postgresql/pgx/v5/go/db.go
+++ b/internal/endtoend/testdata/select_column_cast/postgresql/pgx/v5/go/db.go
@@ -30,3 +30,8 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/select_column_cast/postgresql/pgx/v5/go/query.sql.go
+++ b/internal/endtoend/testdata/select_column_cast/postgresql/pgx/v5/go/query.sql.go
@@ -13,8 +13,16 @@ const selectColumnCast = `-- name: SelectColumnCast :many
 SELECT bar::int FROM foo
 `
 
-func (q *Queries) SelectColumnCast(ctx context.Context) ([]int32, error) {
-	rows, err := q.db.Query(ctx, selectColumnCast)
+func (q *Queries) SelectColumnCast(ctx context.Context, aq ...AdditionalQuery) ([]int32, error) {
+	query := selectColumnCast
+	queryParams := []interface{}{}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.Query(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/endtoend/testdata/select_column_cast/postgresql/stdlib/go/db.go
+++ b/internal/endtoend/testdata/select_column_cast/postgresql/stdlib/go/db.go
@@ -29,3 +29,8 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/select_column_cast/postgresql/stdlib/go/db.go
+++ b/internal/endtoend/testdata/select_column_cast/postgresql/stdlib/go/db.go
@@ -32,5 +32,5 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/select_column_cast/postgresql/stdlib/go/query.sql.go
+++ b/internal/endtoend/testdata/select_column_cast/postgresql/stdlib/go/query.sql.go
@@ -13,8 +13,16 @@ const selectColumnCast = `-- name: SelectColumnCast :many
 SELECT bar::int FROM foo
 `
 
-func (q *Queries) SelectColumnCast(ctx context.Context) ([]int32, error) {
-	rows, err := q.db.QueryContext(ctx, selectColumnCast)
+func (q *Queries) SelectColumnCast(ctx context.Context, aq ...AdditionalQuery) ([]int32, error) {
+	query := selectColumnCast
+	queryParams := []interface{}{}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.QueryContext(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/endtoend/testdata/select_column_cast/sqlite/go/db.go
+++ b/internal/endtoend/testdata/select_column_cast/sqlite/go/db.go
@@ -29,3 +29,8 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/select_column_cast/sqlite/go/db.go
+++ b/internal/endtoend/testdata/select_column_cast/sqlite/go/db.go
@@ -32,5 +32,5 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/select_column_cast/sqlite/go/query.sql.go
+++ b/internal/endtoend/testdata/select_column_cast/sqlite/go/query.sql.go
@@ -13,8 +13,16 @@ const selectColumnCast = `-- name: SelectColumnCast :many
 SELECT CAST(bar AS BLOB) FROM foo
 `
 
-func (q *Queries) SelectColumnCast(ctx context.Context) ([][]byte, error) {
-	rows, err := q.db.QueryContext(ctx, selectColumnCast)
+func (q *Queries) SelectColumnCast(ctx context.Context, aq ...AdditionalQuery) ([][]byte, error) {
+	query := selectColumnCast
+	queryParams := []interface{}{}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.QueryContext(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/endtoend/testdata/select_cte/sqlite/go/db.go
+++ b/internal/endtoend/testdata/select_cte/sqlite/go/db.go
@@ -29,3 +29,8 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/select_cte/sqlite/go/db.go
+++ b/internal/endtoend/testdata/select_cte/sqlite/go/db.go
@@ -32,5 +32,5 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/select_cte/sqlite/go/query.sql.go
+++ b/internal/endtoend/testdata/select_cte/sqlite/go/query.sql.go
@@ -16,8 +16,16 @@ WITH abc AS (
 SELECT n FROM abc
 `
 
-func (q *Queries) ListAuthors(ctx context.Context) ([]int64, error) {
-	rows, err := q.db.QueryContext(ctx, listAuthors)
+func (q *Queries) ListAuthors(ctx context.Context, aq ...AdditionalQuery) ([]int64, error) {
+	query := listAuthors
+	queryParams := []interface{}{}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.QueryContext(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/endtoend/testdata/select_distinct/pgx/v4/go/db.go
+++ b/internal/endtoend/testdata/select_distinct/pgx/v4/go/db.go
@@ -33,5 +33,5 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/select_distinct/pgx/v4/go/db.go
+++ b/internal/endtoend/testdata/select_distinct/pgx/v4/go/db.go
@@ -30,3 +30,8 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/select_distinct/pgx/v4/go/query.sql.go
+++ b/internal/endtoend/testdata/select_distinct/pgx/v4/go/query.sql.go
@@ -14,8 +14,16 @@ SELECT DISTINCT ON (a.id) a.id, a.name
 FROM bar a
 `
 
-func (q *Queries) GetBars(ctx context.Context) ([]Bar, error) {
-	rows, err := q.db.Query(ctx, getBars)
+func (q *Queries) GetBars(ctx context.Context, aq ...AdditionalQuery) ([]Bar, error) {
+	query := getBars
+	queryParams := []interface{}{}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.Query(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/endtoend/testdata/select_distinct/pgx/v5/go/db.go
+++ b/internal/endtoend/testdata/select_distinct/pgx/v5/go/db.go
@@ -33,5 +33,5 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/select_distinct/pgx/v5/go/db.go
+++ b/internal/endtoend/testdata/select_distinct/pgx/v5/go/db.go
@@ -30,3 +30,8 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/select_distinct/pgx/v5/go/query.sql.go
+++ b/internal/endtoend/testdata/select_distinct/pgx/v5/go/query.sql.go
@@ -14,8 +14,16 @@ SELECT DISTINCT ON (a.id) a.id, a.name
 FROM bar a
 `
 
-func (q *Queries) GetBars(ctx context.Context) ([]Bar, error) {
-	rows, err := q.db.Query(ctx, getBars)
+func (q *Queries) GetBars(ctx context.Context, aq ...AdditionalQuery) ([]Bar, error) {
+	query := getBars
+	queryParams := []interface{}{}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.Query(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/endtoend/testdata/select_distinct/stdlib/go/db.go
+++ b/internal/endtoend/testdata/select_distinct/stdlib/go/db.go
@@ -29,3 +29,8 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/select_distinct/stdlib/go/db.go
+++ b/internal/endtoend/testdata/select_distinct/stdlib/go/db.go
@@ -32,5 +32,5 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/select_distinct/stdlib/go/query.sql.go
+++ b/internal/endtoend/testdata/select_distinct/stdlib/go/query.sql.go
@@ -14,8 +14,16 @@ SELECT DISTINCT ON (a.id) a.id, a.name
 FROM bar a
 `
 
-func (q *Queries) GetBars(ctx context.Context) ([]Bar, error) {
-	rows, err := q.db.QueryContext(ctx, getBars)
+func (q *Queries) GetBars(ctx context.Context, aq ...AdditionalQuery) ([]Bar, error) {
+	query := getBars
+	queryParams := []interface{}{}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.QueryContext(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/endtoend/testdata/select_empty_column_list/postgresql/pgx/v4/go/db.go
+++ b/internal/endtoend/testdata/select_empty_column_list/postgresql/pgx/v4/go/db.go
@@ -33,5 +33,5 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/select_empty_column_list/postgresql/pgx/v4/go/db.go
+++ b/internal/endtoend/testdata/select_empty_column_list/postgresql/pgx/v4/go/db.go
@@ -30,3 +30,8 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/select_empty_column_list/postgresql/pgx/v4/go/query.sql.go
+++ b/internal/endtoend/testdata/select_empty_column_list/postgresql/pgx/v4/go/query.sql.go
@@ -16,8 +16,16 @@ SELECT FROM bar LIMIT 5
 type GetBarsRow struct {
 }
 
-func (q *Queries) GetBars(ctx context.Context) ([]GetBarsRow, error) {
-	rows, err := q.db.Query(ctx, getBars)
+func (q *Queries) GetBars(ctx context.Context, aq ...AdditionalQuery) ([]GetBarsRow, error) {
+	query := getBars
+	queryParams := []interface{}{}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.Query(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/endtoend/testdata/select_empty_column_list/postgresql/pgx/v5/go/db.go
+++ b/internal/endtoend/testdata/select_empty_column_list/postgresql/pgx/v5/go/db.go
@@ -33,5 +33,5 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/select_empty_column_list/postgresql/pgx/v5/go/db.go
+++ b/internal/endtoend/testdata/select_empty_column_list/postgresql/pgx/v5/go/db.go
@@ -30,3 +30,8 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/select_empty_column_list/postgresql/pgx/v5/go/query.sql.go
+++ b/internal/endtoend/testdata/select_empty_column_list/postgresql/pgx/v5/go/query.sql.go
@@ -16,8 +16,16 @@ SELECT FROM bar LIMIT 5
 type GetBarsRow struct {
 }
 
-func (q *Queries) GetBars(ctx context.Context) ([]GetBarsRow, error) {
-	rows, err := q.db.Query(ctx, getBars)
+func (q *Queries) GetBars(ctx context.Context, aq ...AdditionalQuery) ([]GetBarsRow, error) {
+	query := getBars
+	queryParams := []interface{}{}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.Query(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/endtoend/testdata/select_empty_column_list/postgresql/stdlib/go/db.go
+++ b/internal/endtoend/testdata/select_empty_column_list/postgresql/stdlib/go/db.go
@@ -29,3 +29,8 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/select_empty_column_list/postgresql/stdlib/go/db.go
+++ b/internal/endtoend/testdata/select_empty_column_list/postgresql/stdlib/go/db.go
@@ -32,5 +32,5 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/select_empty_column_list/postgresql/stdlib/go/query.sql.go
+++ b/internal/endtoend/testdata/select_empty_column_list/postgresql/stdlib/go/query.sql.go
@@ -16,8 +16,16 @@ SELECT FROM bar LIMIT 5
 type GetBarsRow struct {
 }
 
-func (q *Queries) GetBars(ctx context.Context) ([]GetBarsRow, error) {
-	rows, err := q.db.QueryContext(ctx, getBars)
+func (q *Queries) GetBars(ctx context.Context, aq ...AdditionalQuery) ([]GetBarsRow, error) {
+	query := getBars
+	queryParams := []interface{}{}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.QueryContext(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/endtoend/testdata/select_exists/pgx/v4/go/db.go
+++ b/internal/endtoend/testdata/select_exists/pgx/v4/go/db.go
@@ -33,5 +33,5 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/select_exists/pgx/v4/go/db.go
+++ b/internal/endtoend/testdata/select_exists/pgx/v4/go/db.go
@@ -30,3 +30,8 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/select_exists/pgx/v4/go/query.sql.go
+++ b/internal/endtoend/testdata/select_exists/pgx/v4/go/query.sql.go
@@ -21,8 +21,10 @@ SELECT
     )
 `
 
-func (q *Queries) BarExists(ctx context.Context, id int32) (bool, error) {
-	row := q.db.QueryRow(ctx, barExists, id)
+func (q *Queries) BarExists(ctx context.Context, id int32, aq ...AdditionalQuery) (bool, error) {
+	query := barExists
+	queryParams := []interface{}{id}
+	row := q.db.QueryRow(ctx, query, queryParams...)
 	var exists bool
 	err := row.Scan(&exists)
 	return exists, err

--- a/internal/endtoend/testdata/select_exists/pgx/v5/go/db.go
+++ b/internal/endtoend/testdata/select_exists/pgx/v5/go/db.go
@@ -33,5 +33,5 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/select_exists/pgx/v5/go/db.go
+++ b/internal/endtoend/testdata/select_exists/pgx/v5/go/db.go
@@ -30,3 +30,8 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/select_exists/pgx/v5/go/query.sql.go
+++ b/internal/endtoend/testdata/select_exists/pgx/v5/go/query.sql.go
@@ -21,8 +21,10 @@ SELECT
     )
 `
 
-func (q *Queries) BarExists(ctx context.Context, id int32) (bool, error) {
-	row := q.db.QueryRow(ctx, barExists, id)
+func (q *Queries) BarExists(ctx context.Context, id int32, aq ...AdditionalQuery) (bool, error) {
+	query := barExists
+	queryParams := []interface{}{id}
+	row := q.db.QueryRow(ctx, query, queryParams...)
 	var exists bool
 	err := row.Scan(&exists)
 	return exists, err

--- a/internal/endtoend/testdata/select_exists/sqlite/go/db.go
+++ b/internal/endtoend/testdata/select_exists/sqlite/go/db.go
@@ -29,3 +29,8 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/select_exists/sqlite/go/db.go
+++ b/internal/endtoend/testdata/select_exists/sqlite/go/db.go
@@ -32,5 +32,5 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/select_exists/sqlite/go/query.sql.go
+++ b/internal/endtoend/testdata/select_exists/sqlite/go/query.sql.go
@@ -21,8 +21,16 @@ SELECT
     )
 `
 
-func (q *Queries) BarExists(ctx context.Context, id int64) (int64, error) {
-	row := q.db.QueryRowContext(ctx, barExists, id)
+func (q *Queries) BarExists(ctx context.Context, id int64, aq ...AdditionalQuery) (int64, error) {
+	query := barExists
+	queryParams := []interface{}{id}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	row := q.db.QueryRowContext(ctx, query, queryParams...)
 	var column_1 int64
 	err := row.Scan(&column_1)
 	return column_1, err

--- a/internal/endtoend/testdata/select_exists/stdlib/go/db.go
+++ b/internal/endtoend/testdata/select_exists/stdlib/go/db.go
@@ -29,3 +29,8 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/select_exists/stdlib/go/db.go
+++ b/internal/endtoend/testdata/select_exists/stdlib/go/db.go
@@ -32,5 +32,5 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/select_exists/stdlib/go/query.sql.go
+++ b/internal/endtoend/testdata/select_exists/stdlib/go/query.sql.go
@@ -21,8 +21,16 @@ SELECT
     )
 `
 
-func (q *Queries) BarExists(ctx context.Context, id int32) (bool, error) {
-	row := q.db.QueryRowContext(ctx, barExists, id)
+func (q *Queries) BarExists(ctx context.Context, id int32, aq ...AdditionalQuery) (bool, error) {
+	query := barExists
+	queryParams := []interface{}{id}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	row := q.db.QueryRowContext(ctx, query, queryParams...)
 	var exists bool
 	err := row.Scan(&exists)
 	return exists, err

--- a/internal/endtoend/testdata/select_in_and/sqlite/go/db.go
+++ b/internal/endtoend/testdata/select_in_and/sqlite/go/db.go
@@ -29,3 +29,8 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/select_in_and/sqlite/go/db.go
+++ b/internal/endtoend/testdata/select_in_and/sqlite/go/db.go
@@ -32,5 +32,5 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/select_in_and/sqlite/go/query.sql.go
+++ b/internal/endtoend/testdata/select_in_and/sqlite/go/query.sql.go
@@ -40,6 +40,9 @@ type DeleteAuthorParams struct {
 }
 
 func (q *Queries) DeleteAuthor(ctx context.Context, arg DeleteAuthorParams) error {
-	_, err := q.db.ExecContext(ctx, deleteAuthor, arg.Age, arg.Age_2, arg.Year)
+	query := deleteAuthor
+	queryParams := []interface{}{arg.Age, arg.Age_2, arg.Year}
+
+	_, err := q.db.ExecContext(ctx, query, queryParams...)
 	return err
 }

--- a/internal/endtoend/testdata/select_limit/mysql/go/db.go
+++ b/internal/endtoend/testdata/select_limit/mysql/go/db.go
@@ -29,3 +29,8 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/select_limit/mysql/go/db.go
+++ b/internal/endtoend/testdata/select_limit/mysql/go/db.go
@@ -32,5 +32,5 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/select_limit/mysql/go/query.sql.go
+++ b/internal/endtoend/testdata/select_limit/mysql/go/query.sql.go
@@ -15,8 +15,16 @@ SELECT a FROM foo
 LIMIT ?
 `
 
-func (q *Queries) FooLimit(ctx context.Context, limit int32) ([]sql.NullString, error) {
-	rows, err := q.db.QueryContext(ctx, fooLimit, limit)
+func (q *Queries) FooLimit(ctx context.Context, limit int32, aq ...AdditionalQuery) ([]sql.NullString, error) {
+	query := fooLimit
+	queryParams := []interface{}{limit}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.QueryContext(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}
@@ -48,8 +56,16 @@ type FooLimitOffsetParams struct {
 	Offset int32
 }
 
-func (q *Queries) FooLimitOffset(ctx context.Context, arg FooLimitOffsetParams) ([]sql.NullString, error) {
-	rows, err := q.db.QueryContext(ctx, fooLimitOffset, arg.Limit, arg.Offset)
+func (q *Queries) FooLimitOffset(ctx context.Context, arg FooLimitOffsetParams, aq ...AdditionalQuery) ([]sql.NullString, error) {
+	query := fooLimitOffset
+	queryParams := []interface{}{arg.Limit, arg.Offset}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.QueryContext(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/endtoend/testdata/select_limit/postgresql/pgx/v4/go/db.go
+++ b/internal/endtoend/testdata/select_limit/postgresql/pgx/v4/go/db.go
@@ -33,5 +33,5 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/select_limit/postgresql/pgx/v4/go/db.go
+++ b/internal/endtoend/testdata/select_limit/postgresql/pgx/v4/go/db.go
@@ -30,3 +30,8 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/select_limit/postgresql/pgx/v4/go/query.sql.go
+++ b/internal/endtoend/testdata/select_limit/postgresql/pgx/v4/go/query.sql.go
@@ -15,8 +15,16 @@ SELECT a FROM foo
 LIMIT $1
 `
 
-func (q *Queries) FooLimit(ctx context.Context, limit int32) ([]sql.NullString, error) {
-	rows, err := q.db.Query(ctx, fooLimit, limit)
+func (q *Queries) FooLimit(ctx context.Context, limit int32, aq ...AdditionalQuery) ([]sql.NullString, error) {
+	query := fooLimit
+	queryParams := []interface{}{limit}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.Query(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}
@@ -45,8 +53,16 @@ type FooLimitOffsetParams struct {
 	Offset int32
 }
 
-func (q *Queries) FooLimitOffset(ctx context.Context, arg FooLimitOffsetParams) ([]sql.NullString, error) {
-	rows, err := q.db.Query(ctx, fooLimitOffset, arg.Limit, arg.Offset)
+func (q *Queries) FooLimitOffset(ctx context.Context, arg FooLimitOffsetParams, aq ...AdditionalQuery) ([]sql.NullString, error) {
+	query := fooLimitOffset
+	queryParams := []interface{}{arg.Limit, arg.Offset}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.Query(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/endtoend/testdata/select_limit/postgresql/pgx/v5/go/db.go
+++ b/internal/endtoend/testdata/select_limit/postgresql/pgx/v5/go/db.go
@@ -33,5 +33,5 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/select_limit/postgresql/pgx/v5/go/db.go
+++ b/internal/endtoend/testdata/select_limit/postgresql/pgx/v5/go/db.go
@@ -30,3 +30,8 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/select_limit/postgresql/pgx/v5/go/query.sql.go
+++ b/internal/endtoend/testdata/select_limit/postgresql/pgx/v5/go/query.sql.go
@@ -16,8 +16,16 @@ SELECT a FROM foo
 LIMIT $1
 `
 
-func (q *Queries) FooLimit(ctx context.Context, limit int32) ([]pgtype.Text, error) {
-	rows, err := q.db.Query(ctx, fooLimit, limit)
+func (q *Queries) FooLimit(ctx context.Context, limit int32, aq ...AdditionalQuery) ([]pgtype.Text, error) {
+	query := fooLimit
+	queryParams := []interface{}{limit}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.Query(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}
@@ -46,8 +54,16 @@ type FooLimitOffsetParams struct {
 	Offset int32
 }
 
-func (q *Queries) FooLimitOffset(ctx context.Context, arg FooLimitOffsetParams) ([]pgtype.Text, error) {
-	rows, err := q.db.Query(ctx, fooLimitOffset, arg.Limit, arg.Offset)
+func (q *Queries) FooLimitOffset(ctx context.Context, arg FooLimitOffsetParams, aq ...AdditionalQuery) ([]pgtype.Text, error) {
+	query := fooLimitOffset
+	queryParams := []interface{}{arg.Limit, arg.Offset}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.Query(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/endtoend/testdata/select_limit/postgresql/stdlib/go/db.go
+++ b/internal/endtoend/testdata/select_limit/postgresql/stdlib/go/db.go
@@ -29,3 +29,8 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/select_limit/postgresql/stdlib/go/db.go
+++ b/internal/endtoend/testdata/select_limit/postgresql/stdlib/go/db.go
@@ -32,5 +32,5 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/select_limit/postgresql/stdlib/go/query.sql.go
+++ b/internal/endtoend/testdata/select_limit/postgresql/stdlib/go/query.sql.go
@@ -15,8 +15,16 @@ SELECT a FROM foo
 LIMIT $1
 `
 
-func (q *Queries) FooLimit(ctx context.Context, limit int32) ([]sql.NullString, error) {
-	rows, err := q.db.QueryContext(ctx, fooLimit, limit)
+func (q *Queries) FooLimit(ctx context.Context, limit int32, aq ...AdditionalQuery) ([]sql.NullString, error) {
+	query := fooLimit
+	queryParams := []interface{}{limit}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.QueryContext(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}
@@ -48,8 +56,16 @@ type FooLimitOffsetParams struct {
 	Offset int32
 }
 
-func (q *Queries) FooLimitOffset(ctx context.Context, arg FooLimitOffsetParams) ([]sql.NullString, error) {
-	rows, err := q.db.QueryContext(ctx, fooLimitOffset, arg.Limit, arg.Offset)
+func (q *Queries) FooLimitOffset(ctx context.Context, arg FooLimitOffsetParams, aq ...AdditionalQuery) ([]sql.NullString, error) {
+	query := fooLimitOffset
+	queryParams := []interface{}{arg.Limit, arg.Offset}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.QueryContext(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/endtoend/testdata/select_limit/sqlite/go/db.go
+++ b/internal/endtoend/testdata/select_limit/sqlite/go/db.go
@@ -29,3 +29,8 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/select_limit/sqlite/go/db.go
+++ b/internal/endtoend/testdata/select_limit/sqlite/go/db.go
@@ -32,5 +32,5 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/select_limit/sqlite/go/query.sql.go
+++ b/internal/endtoend/testdata/select_limit/sqlite/go/query.sql.go
@@ -15,8 +15,16 @@ SELECT a FROM foo
 LIMIT ?
 `
 
-func (q *Queries) FooLimit(ctx context.Context, limit int64) ([]sql.NullString, error) {
-	rows, err := q.db.QueryContext(ctx, fooLimit, limit)
+func (q *Queries) FooLimit(ctx context.Context, limit int64, aq ...AdditionalQuery) ([]sql.NullString, error) {
+	query := fooLimit
+	queryParams := []interface{}{limit}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.QueryContext(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}
@@ -48,8 +56,16 @@ type FooLimitOffsetParams struct {
 	Offset int64
 }
 
-func (q *Queries) FooLimitOffset(ctx context.Context, arg FooLimitOffsetParams) ([]sql.NullString, error) {
-	rows, err := q.db.QueryContext(ctx, fooLimitOffset, arg.Limit, arg.Offset)
+func (q *Queries) FooLimitOffset(ctx context.Context, arg FooLimitOffsetParams, aq ...AdditionalQuery) ([]sql.NullString, error) {
+	query := fooLimitOffset
+	queryParams := []interface{}{arg.Limit, arg.Offset}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.QueryContext(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/endtoend/testdata/select_nested_count/mysql/go/db.go
+++ b/internal/endtoend/testdata/select_nested_count/mysql/go/db.go
@@ -29,3 +29,8 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/select_nested_count/mysql/go/db.go
+++ b/internal/endtoend/testdata/select_nested_count/mysql/go/db.go
@@ -32,5 +32,5 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/select_nested_count/mysql/go/query.sql.go
+++ b/internal/endtoend/testdata/select_nested_count/mysql/go/query.sql.go
@@ -25,8 +25,16 @@ type GetAuthorsWithBooksCountRow struct {
 	BooksCount int64
 }
 
-func (q *Queries) GetAuthorsWithBooksCount(ctx context.Context) ([]GetAuthorsWithBooksCountRow, error) {
-	rows, err := q.db.QueryContext(ctx, getAuthorsWithBooksCount)
+func (q *Queries) GetAuthorsWithBooksCount(ctx context.Context, aq ...AdditionalQuery) ([]GetAuthorsWithBooksCountRow, error) {
+	query := getAuthorsWithBooksCount
+	queryParams := []interface{}{}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.QueryContext(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/endtoend/testdata/select_nested_count/postgresql/go/db.go
+++ b/internal/endtoend/testdata/select_nested_count/postgresql/go/db.go
@@ -29,3 +29,8 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/select_nested_count/postgresql/go/db.go
+++ b/internal/endtoend/testdata/select_nested_count/postgresql/go/db.go
@@ -32,5 +32,5 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/select_nested_count/postgresql/go/query.sql.go
+++ b/internal/endtoend/testdata/select_nested_count/postgresql/go/query.sql.go
@@ -25,8 +25,16 @@ type GetAuthorsWithBooksCountRow struct {
 	BooksCount int64
 }
 
-func (q *Queries) GetAuthorsWithBooksCount(ctx context.Context) ([]GetAuthorsWithBooksCountRow, error) {
-	rows, err := q.db.QueryContext(ctx, getAuthorsWithBooksCount)
+func (q *Queries) GetAuthorsWithBooksCount(ctx context.Context, aq ...AdditionalQuery) ([]GetAuthorsWithBooksCountRow, error) {
+	query := getAuthorsWithBooksCount
+	queryParams := []interface{}{}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.QueryContext(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/endtoend/testdata/select_nested_count/sqlite/go/db.go
+++ b/internal/endtoend/testdata/select_nested_count/sqlite/go/db.go
@@ -29,3 +29,8 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/select_nested_count/sqlite/go/db.go
+++ b/internal/endtoend/testdata/select_nested_count/sqlite/go/db.go
@@ -32,5 +32,5 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/select_nested_count/sqlite/go/query.sql.go
+++ b/internal/endtoend/testdata/select_nested_count/sqlite/go/query.sql.go
@@ -25,8 +25,16 @@ type GetAuthorsWithBooksCountRow struct {
 	BooksCount int64
 }
 
-func (q *Queries) GetAuthorsWithBooksCount(ctx context.Context) ([]GetAuthorsWithBooksCountRow, error) {
-	rows, err := q.db.QueryContext(ctx, getAuthorsWithBooksCount)
+func (q *Queries) GetAuthorsWithBooksCount(ctx context.Context, aq ...AdditionalQuery) ([]GetAuthorsWithBooksCountRow, error) {
+	query := getAuthorsWithBooksCount
+	queryParams := []interface{}{}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.QueryContext(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/endtoend/testdata/select_not_exists/pgx/v4/go/db.go
+++ b/internal/endtoend/testdata/select_not_exists/pgx/v4/go/db.go
@@ -33,5 +33,5 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/select_not_exists/pgx/v4/go/db.go
+++ b/internal/endtoend/testdata/select_not_exists/pgx/v4/go/db.go
@@ -30,3 +30,8 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/select_not_exists/pgx/v4/go/query.sql.go
+++ b/internal/endtoend/testdata/select_not_exists/pgx/v4/go/query.sql.go
@@ -21,8 +21,10 @@ SELECT
     )
 `
 
-func (q *Queries) BarNotExists(ctx context.Context, id int32) (bool, error) {
-	row := q.db.QueryRow(ctx, barNotExists, id)
+func (q *Queries) BarNotExists(ctx context.Context, id int32, aq ...AdditionalQuery) (bool, error) {
+	query := barNotExists
+	queryParams := []interface{}{id}
+	row := q.db.QueryRow(ctx, query, queryParams...)
 	var not_exists bool
 	err := row.Scan(&not_exists)
 	return not_exists, err

--- a/internal/endtoend/testdata/select_not_exists/pgx/v5/go/db.go
+++ b/internal/endtoend/testdata/select_not_exists/pgx/v5/go/db.go
@@ -33,5 +33,5 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/select_not_exists/pgx/v5/go/db.go
+++ b/internal/endtoend/testdata/select_not_exists/pgx/v5/go/db.go
@@ -30,3 +30,8 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/select_not_exists/pgx/v5/go/query.sql.go
+++ b/internal/endtoend/testdata/select_not_exists/pgx/v5/go/query.sql.go
@@ -21,8 +21,10 @@ SELECT
     )
 `
 
-func (q *Queries) BarNotExists(ctx context.Context, id int32) (bool, error) {
-	row := q.db.QueryRow(ctx, barNotExists, id)
+func (q *Queries) BarNotExists(ctx context.Context, id int32, aq ...AdditionalQuery) (bool, error) {
+	query := barNotExists
+	queryParams := []interface{}{id}
+	row := q.db.QueryRow(ctx, query, queryParams...)
 	var not_exists bool
 	err := row.Scan(&not_exists)
 	return not_exists, err

--- a/internal/endtoend/testdata/select_not_exists/sqlite/go/db.go
+++ b/internal/endtoend/testdata/select_not_exists/sqlite/go/db.go
@@ -29,3 +29,8 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/select_not_exists/sqlite/go/db.go
+++ b/internal/endtoend/testdata/select_not_exists/sqlite/go/db.go
@@ -32,5 +32,5 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/select_not_exists/sqlite/go/query.sql.go
+++ b/internal/endtoend/testdata/select_not_exists/sqlite/go/query.sql.go
@@ -21,8 +21,16 @@ SELECT
     )
 `
 
-func (q *Queries) BarNotExists(ctx context.Context) (interface{}, error) {
-	row := q.db.QueryRowContext(ctx, barNotExists)
+func (q *Queries) BarNotExists(ctx context.Context, aq ...AdditionalQuery) (interface{}, error) {
+	query := barNotExists
+	queryParams := []interface{}{}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	row := q.db.QueryRowContext(ctx, query, queryParams...)
 	var column_1 interface{}
 	err := row.Scan(&column_1)
 	return column_1, err

--- a/internal/endtoend/testdata/select_not_exists/stdlib/go/db.go
+++ b/internal/endtoend/testdata/select_not_exists/stdlib/go/db.go
@@ -29,3 +29,8 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/select_not_exists/stdlib/go/db.go
+++ b/internal/endtoend/testdata/select_not_exists/stdlib/go/db.go
@@ -32,5 +32,5 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/select_not_exists/stdlib/go/query.sql.go
+++ b/internal/endtoend/testdata/select_not_exists/stdlib/go/query.sql.go
@@ -21,8 +21,16 @@ SELECT
     )
 `
 
-func (q *Queries) BarNotExists(ctx context.Context, id int32) (bool, error) {
-	row := q.db.QueryRowContext(ctx, barNotExists, id)
+func (q *Queries) BarNotExists(ctx context.Context, id int32, aq ...AdditionalQuery) (bool, error) {
+	query := barNotExists
+	queryParams := []interface{}{id}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	row := q.db.QueryRowContext(ctx, query, queryParams...)
 	var not_exists bool
 	err := row.Scan(&not_exists)
 	return not_exists, err

--- a/internal/endtoend/testdata/select_star/mysql/go/db.go
+++ b/internal/endtoend/testdata/select_star/mysql/go/db.go
@@ -29,3 +29,8 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/select_star/mysql/go/db.go
+++ b/internal/endtoend/testdata/select_star/mysql/go/db.go
@@ -32,5 +32,5 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/select_star/mysql/go/query.sql.go
+++ b/internal/endtoend/testdata/select_star/mysql/go/query.sql.go
@@ -13,8 +13,16 @@ const getAll = `-- name: GetAll :many
 SELECT id, first_name, last_name, age FROM users
 `
 
-func (q *Queries) GetAll(ctx context.Context) ([]User, error) {
-	rows, err := q.db.QueryContext(ctx, getAll)
+func (q *Queries) GetAll(ctx context.Context, aq ...AdditionalQuery) ([]User, error) {
+	query := getAll
+	queryParams := []interface{}{}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.QueryContext(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/endtoend/testdata/select_star/postgresql/pgx/v4/go/db.go
+++ b/internal/endtoend/testdata/select_star/postgresql/pgx/v4/go/db.go
@@ -33,5 +33,5 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/select_star/postgresql/pgx/v4/go/db.go
+++ b/internal/endtoend/testdata/select_star/postgresql/pgx/v4/go/db.go
@@ -30,3 +30,8 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/select_star/postgresql/pgx/v4/go/query.sql.go
+++ b/internal/endtoend/testdata/select_star/postgresql/pgx/v4/go/query.sql.go
@@ -13,8 +13,16 @@ const getAll = `-- name: GetAll :many
 SELECT id, first_name, last_name, age FROM users
 `
 
-func (q *Queries) GetAll(ctx context.Context) ([]User, error) {
-	rows, err := q.db.Query(ctx, getAll)
+func (q *Queries) GetAll(ctx context.Context, aq ...AdditionalQuery) ([]User, error) {
+	query := getAll
+	queryParams := []interface{}{}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.Query(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/endtoend/testdata/select_star/postgresql/pgx/v5/go/db.go
+++ b/internal/endtoend/testdata/select_star/postgresql/pgx/v5/go/db.go
@@ -33,5 +33,5 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/select_star/postgresql/pgx/v5/go/db.go
+++ b/internal/endtoend/testdata/select_star/postgresql/pgx/v5/go/db.go
@@ -30,3 +30,8 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/select_star/postgresql/pgx/v5/go/query.sql.go
+++ b/internal/endtoend/testdata/select_star/postgresql/pgx/v5/go/query.sql.go
@@ -13,8 +13,16 @@ const getAll = `-- name: GetAll :many
 SELECT id, first_name, last_name, age FROM users
 `
 
-func (q *Queries) GetAll(ctx context.Context) ([]User, error) {
-	rows, err := q.db.Query(ctx, getAll)
+func (q *Queries) GetAll(ctx context.Context, aq ...AdditionalQuery) ([]User, error) {
+	query := getAll
+	queryParams := []interface{}{}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.Query(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/endtoend/testdata/select_star/postgresql/stdlib/go/db.go
+++ b/internal/endtoend/testdata/select_star/postgresql/stdlib/go/db.go
@@ -29,3 +29,8 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/select_star/postgresql/stdlib/go/db.go
+++ b/internal/endtoend/testdata/select_star/postgresql/stdlib/go/db.go
@@ -32,5 +32,5 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/select_star/postgresql/stdlib/go/query.sql.go
+++ b/internal/endtoend/testdata/select_star/postgresql/stdlib/go/query.sql.go
@@ -13,8 +13,16 @@ const getAll = `-- name: GetAll :many
 SELECT id, first_name, last_name, age FROM users
 `
 
-func (q *Queries) GetAll(ctx context.Context) ([]User, error) {
-	rows, err := q.db.QueryContext(ctx, getAll)
+func (q *Queries) GetAll(ctx context.Context, aq ...AdditionalQuery) ([]User, error) {
+	query := getAll
+	queryParams := []interface{}{}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.QueryContext(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/endtoend/testdata/select_star/sqlite/go/db.go
+++ b/internal/endtoend/testdata/select_star/sqlite/go/db.go
@@ -29,3 +29,8 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/select_star/sqlite/go/db.go
+++ b/internal/endtoend/testdata/select_star/sqlite/go/db.go
@@ -32,5 +32,5 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/select_star/sqlite/go/query.sql.go
+++ b/internal/endtoend/testdata/select_star/sqlite/go/query.sql.go
@@ -13,8 +13,16 @@ const getAll = `-- name: GetAll :many
 SELECT id, first_name, last_name, age FROM users
 `
 
-func (q *Queries) GetAll(ctx context.Context) ([]User, error) {
-	rows, err := q.db.QueryContext(ctx, getAll)
+func (q *Queries) GetAll(ctx context.Context, aq ...AdditionalQuery) ([]User, error) {
+	query := getAll
+	queryParams := []interface{}{}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.QueryContext(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/endtoend/testdata/select_star_quoted/mysql/go/db.go
+++ b/internal/endtoend/testdata/select_star_quoted/mysql/go/db.go
@@ -29,3 +29,8 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/select_star_quoted/mysql/go/db.go
+++ b/internal/endtoend/testdata/select_star_quoted/mysql/go/db.go
@@ -32,5 +32,5 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/select_star_quoted/mysql/go/query.sql.go
+++ b/internal/endtoend/testdata/select_star_quoted/mysql/go/query.sql.go
@@ -14,8 +14,16 @@ const getAll = `-- name: GetAll :many
 SELECT camelcase FROM users
 `
 
-func (q *Queries) GetAll(ctx context.Context) ([]sql.NullString, error) {
-	rows, err := q.db.QueryContext(ctx, getAll)
+func (q *Queries) GetAll(ctx context.Context, aq ...AdditionalQuery) ([]sql.NullString, error) {
+	query := getAll
+	queryParams := []interface{}{}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.QueryContext(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/endtoend/testdata/select_star_quoted/postgresql/pgx/v4/go/db.go
+++ b/internal/endtoend/testdata/select_star_quoted/postgresql/pgx/v4/go/db.go
@@ -33,5 +33,5 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/select_star_quoted/postgresql/pgx/v4/go/db.go
+++ b/internal/endtoend/testdata/select_star_quoted/postgresql/pgx/v4/go/db.go
@@ -30,3 +30,8 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/select_star_quoted/postgresql/pgx/v4/go/query.sql.go
+++ b/internal/endtoend/testdata/select_star_quoted/postgresql/pgx/v4/go/query.sql.go
@@ -14,8 +14,16 @@ const getAll = `-- name: GetAll :many
 SELECT "CamelCase" FROM users
 `
 
-func (q *Queries) GetAll(ctx context.Context) ([]sql.NullString, error) {
-	rows, err := q.db.Query(ctx, getAll)
+func (q *Queries) GetAll(ctx context.Context, aq ...AdditionalQuery) ([]sql.NullString, error) {
+	query := getAll
+	queryParams := []interface{}{}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.Query(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/endtoend/testdata/select_star_quoted/postgresql/pgx/v5/go/db.go
+++ b/internal/endtoend/testdata/select_star_quoted/postgresql/pgx/v5/go/db.go
@@ -33,5 +33,5 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/select_star_quoted/postgresql/pgx/v5/go/db.go
+++ b/internal/endtoend/testdata/select_star_quoted/postgresql/pgx/v5/go/db.go
@@ -30,3 +30,8 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/select_star_quoted/postgresql/pgx/v5/go/query.sql.go
+++ b/internal/endtoend/testdata/select_star_quoted/postgresql/pgx/v5/go/query.sql.go
@@ -15,8 +15,16 @@ const getAll = `-- name: GetAll :many
 SELECT "CamelCase" FROM users
 `
 
-func (q *Queries) GetAll(ctx context.Context) ([]pgtype.Text, error) {
-	rows, err := q.db.Query(ctx, getAll)
+func (q *Queries) GetAll(ctx context.Context, aq ...AdditionalQuery) ([]pgtype.Text, error) {
+	query := getAll
+	queryParams := []interface{}{}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.Query(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/endtoend/testdata/select_star_quoted/postgresql/stdlib/go/db.go
+++ b/internal/endtoend/testdata/select_star_quoted/postgresql/stdlib/go/db.go
@@ -29,3 +29,8 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/select_star_quoted/postgresql/stdlib/go/db.go
+++ b/internal/endtoend/testdata/select_star_quoted/postgresql/stdlib/go/db.go
@@ -32,5 +32,5 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/select_star_quoted/postgresql/stdlib/go/query.sql.go
+++ b/internal/endtoend/testdata/select_star_quoted/postgresql/stdlib/go/query.sql.go
@@ -14,8 +14,16 @@ const getAll = `-- name: GetAll :many
 SELECT "CamelCase" FROM users
 `
 
-func (q *Queries) GetAll(ctx context.Context) ([]sql.NullString, error) {
-	rows, err := q.db.QueryContext(ctx, getAll)
+func (q *Queries) GetAll(ctx context.Context, aq ...AdditionalQuery) ([]sql.NullString, error) {
+	query := getAll
+	queryParams := []interface{}{}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.QueryContext(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/endtoend/testdata/select_text_array/pgx/v4/go/db.go
+++ b/internal/endtoend/testdata/select_text_array/pgx/v4/go/db.go
@@ -33,5 +33,5 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/select_text_array/pgx/v4/go/db.go
+++ b/internal/endtoend/testdata/select_text_array/pgx/v4/go/db.go
@@ -30,3 +30,8 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/select_text_array/pgx/v4/go/query.sql.go
+++ b/internal/endtoend/testdata/select_text_array/pgx/v4/go/query.sql.go
@@ -13,8 +13,16 @@ const selectTextArray = `-- name: SelectTextArray :many
 SELECT $1::TEXT[]
 `
 
-func (q *Queries) SelectTextArray(ctx context.Context, dollar_1 []string) ([][]string, error) {
-	rows, err := q.db.Query(ctx, selectTextArray, dollar_1)
+func (q *Queries) SelectTextArray(ctx context.Context, dollar_1 []string, aq ...AdditionalQuery) ([][]string, error) {
+	query := selectTextArray
+	queryParams := []interface{}{dollar_1}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.Query(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/endtoend/testdata/select_text_array/pgx/v5/go/db.go
+++ b/internal/endtoend/testdata/select_text_array/pgx/v5/go/db.go
@@ -33,5 +33,5 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/select_text_array/pgx/v5/go/db.go
+++ b/internal/endtoend/testdata/select_text_array/pgx/v5/go/db.go
@@ -30,3 +30,8 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/select_text_array/pgx/v5/go/query.sql.go
+++ b/internal/endtoend/testdata/select_text_array/pgx/v5/go/query.sql.go
@@ -13,8 +13,16 @@ const selectTextArray = `-- name: SelectTextArray :many
 SELECT $1::TEXT[]
 `
 
-func (q *Queries) SelectTextArray(ctx context.Context, dollar_1 []string) ([][]string, error) {
-	rows, err := q.db.Query(ctx, selectTextArray, dollar_1)
+func (q *Queries) SelectTextArray(ctx context.Context, dollar_1 []string, aq ...AdditionalQuery) ([][]string, error) {
+	query := selectTextArray
+	queryParams := []interface{}{dollar_1}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.Query(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/endtoend/testdata/select_text_array/stdlib/go/db.go
+++ b/internal/endtoend/testdata/select_text_array/stdlib/go/db.go
@@ -29,3 +29,8 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/select_text_array/stdlib/go/db.go
+++ b/internal/endtoend/testdata/select_text_array/stdlib/go/db.go
@@ -32,5 +32,5 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/select_text_array/stdlib/go/query.sql.go
+++ b/internal/endtoend/testdata/select_text_array/stdlib/go/query.sql.go
@@ -15,8 +15,16 @@ const selectTextArray = `-- name: SelectTextArray :many
 SELECT $1::TEXT[]
 `
 
-func (q *Queries) SelectTextArray(ctx context.Context, dollar_1 []string) ([][]string, error) {
-	rows, err := q.db.QueryContext(ctx, selectTextArray, pq.Array(dollar_1))
+func (q *Queries) SelectTextArray(ctx context.Context, dollar_1 []string, aq ...AdditionalQuery) ([][]string, error) {
+	query := selectTextArray
+	queryParams := []interface{}{pq.Array(dollar_1)}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.QueryContext(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/endtoend/testdata/select_union/mysql/go/db.go
+++ b/internal/endtoend/testdata/select_union/mysql/go/db.go
@@ -29,3 +29,8 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/select_union/mysql/go/db.go
+++ b/internal/endtoend/testdata/select_union/mysql/go/db.go
@@ -32,5 +32,5 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/select_union/mysql/go/query.sql.go
+++ b/internal/endtoend/testdata/select_union/mysql/go/query.sql.go
@@ -15,8 +15,16 @@ EXCEPT
 SELECT a, b FROM foo
 `
 
-func (q *Queries) SelectExcept(ctx context.Context) ([]Foo, error) {
-	rows, err := q.db.QueryContext(ctx, selectExcept)
+func (q *Queries) SelectExcept(ctx context.Context, aq ...AdditionalQuery) ([]Foo, error) {
+	query := selectExcept
+	queryParams := []interface{}{}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.QueryContext(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}
@@ -44,8 +52,16 @@ INTERSECT
 SELECT a, b FROM foo
 `
 
-func (q *Queries) SelectIntersect(ctx context.Context) ([]Foo, error) {
-	rows, err := q.db.QueryContext(ctx, selectIntersect)
+func (q *Queries) SelectIntersect(ctx context.Context, aq ...AdditionalQuery) ([]Foo, error) {
+	query := selectIntersect
+	queryParams := []interface{}{}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.QueryContext(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}
@@ -73,8 +89,16 @@ UNION
 SELECT a, b FROM foo
 `
 
-func (q *Queries) SelectUnion(ctx context.Context) ([]Foo, error) {
-	rows, err := q.db.QueryContext(ctx, selectUnion)
+func (q *Queries) SelectUnion(ctx context.Context, aq ...AdditionalQuery) ([]Foo, error) {
+	query := selectUnion
+	queryParams := []interface{}{}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.QueryContext(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/endtoend/testdata/select_union/postgres/pgx/v4/go/db.go
+++ b/internal/endtoend/testdata/select_union/postgres/pgx/v4/go/db.go
@@ -33,5 +33,5 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/select_union/postgres/pgx/v4/go/db.go
+++ b/internal/endtoend/testdata/select_union/postgres/pgx/v4/go/db.go
@@ -30,3 +30,8 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/select_union/postgres/pgx/v4/go/query.sql.go
+++ b/internal/endtoend/testdata/select_union/postgres/pgx/v4/go/query.sql.go
@@ -15,8 +15,16 @@ EXCEPT
 SELECT a, b FROM foo
 `
 
-func (q *Queries) SelectExcept(ctx context.Context) ([]Foo, error) {
-	rows, err := q.db.Query(ctx, selectExcept)
+func (q *Queries) SelectExcept(ctx context.Context, aq ...AdditionalQuery) ([]Foo, error) {
+	query := selectExcept
+	queryParams := []interface{}{}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.Query(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}
@@ -41,8 +49,16 @@ INTERSECT
 SELECT a, b FROM foo
 `
 
-func (q *Queries) SelectIntersect(ctx context.Context) ([]Foo, error) {
-	rows, err := q.db.Query(ctx, selectIntersect)
+func (q *Queries) SelectIntersect(ctx context.Context, aq ...AdditionalQuery) ([]Foo, error) {
+	query := selectIntersect
+	queryParams := []interface{}{}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.Query(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}
@@ -67,8 +83,16 @@ UNION
 SELECT a, b FROM foo
 `
 
-func (q *Queries) SelectUnion(ctx context.Context) ([]Foo, error) {
-	rows, err := q.db.Query(ctx, selectUnion)
+func (q *Queries) SelectUnion(ctx context.Context, aq ...AdditionalQuery) ([]Foo, error) {
+	query := selectUnion
+	queryParams := []interface{}{}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.Query(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/endtoend/testdata/select_union/postgres/pgx/v5/go/db.go
+++ b/internal/endtoend/testdata/select_union/postgres/pgx/v5/go/db.go
@@ -33,5 +33,5 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/select_union/postgres/pgx/v5/go/db.go
+++ b/internal/endtoend/testdata/select_union/postgres/pgx/v5/go/db.go
@@ -30,3 +30,8 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/select_union/postgres/pgx/v5/go/query.sql.go
+++ b/internal/endtoend/testdata/select_union/postgres/pgx/v5/go/query.sql.go
@@ -15,8 +15,16 @@ EXCEPT
 SELECT a, b FROM foo
 `
 
-func (q *Queries) SelectExcept(ctx context.Context) ([]Foo, error) {
-	rows, err := q.db.Query(ctx, selectExcept)
+func (q *Queries) SelectExcept(ctx context.Context, aq ...AdditionalQuery) ([]Foo, error) {
+	query := selectExcept
+	queryParams := []interface{}{}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.Query(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}
@@ -41,8 +49,16 @@ INTERSECT
 SELECT a, b FROM foo
 `
 
-func (q *Queries) SelectIntersect(ctx context.Context) ([]Foo, error) {
-	rows, err := q.db.Query(ctx, selectIntersect)
+func (q *Queries) SelectIntersect(ctx context.Context, aq ...AdditionalQuery) ([]Foo, error) {
+	query := selectIntersect
+	queryParams := []interface{}{}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.Query(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}
@@ -67,8 +83,16 @@ UNION
 SELECT a, b FROM foo
 `
 
-func (q *Queries) SelectUnion(ctx context.Context) ([]Foo, error) {
-	rows, err := q.db.Query(ctx, selectUnion)
+func (q *Queries) SelectUnion(ctx context.Context, aq ...AdditionalQuery) ([]Foo, error) {
+	query := selectUnion
+	queryParams := []interface{}{}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.Query(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/endtoend/testdata/select_union/postgres/stdlib/go/db.go
+++ b/internal/endtoend/testdata/select_union/postgres/stdlib/go/db.go
@@ -29,3 +29,8 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/select_union/postgres/stdlib/go/db.go
+++ b/internal/endtoend/testdata/select_union/postgres/stdlib/go/db.go
@@ -32,5 +32,5 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/select_union/postgres/stdlib/go/query.sql.go
+++ b/internal/endtoend/testdata/select_union/postgres/stdlib/go/query.sql.go
@@ -15,8 +15,16 @@ EXCEPT
 SELECT a, b FROM foo
 `
 
-func (q *Queries) SelectExcept(ctx context.Context) ([]Foo, error) {
-	rows, err := q.db.QueryContext(ctx, selectExcept)
+func (q *Queries) SelectExcept(ctx context.Context, aq ...AdditionalQuery) ([]Foo, error) {
+	query := selectExcept
+	queryParams := []interface{}{}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.QueryContext(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}
@@ -44,8 +52,16 @@ INTERSECT
 SELECT a, b FROM foo
 `
 
-func (q *Queries) SelectIntersect(ctx context.Context) ([]Foo, error) {
-	rows, err := q.db.QueryContext(ctx, selectIntersect)
+func (q *Queries) SelectIntersect(ctx context.Context, aq ...AdditionalQuery) ([]Foo, error) {
+	query := selectIntersect
+	queryParams := []interface{}{}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.QueryContext(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}
@@ -73,8 +89,16 @@ UNION
 SELECT a, b FROM foo
 `
 
-func (q *Queries) SelectUnion(ctx context.Context) ([]Foo, error) {
-	rows, err := q.db.QueryContext(ctx, selectUnion)
+func (q *Queries) SelectUnion(ctx context.Context, aq ...AdditionalQuery) ([]Foo, error) {
+	query := selectUnion
+	queryParams := []interface{}{}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.QueryContext(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/endtoend/testdata/selectstatic/mysql/go/db.go
+++ b/internal/endtoend/testdata/selectstatic/mysql/go/db.go
@@ -29,3 +29,8 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/selectstatic/mysql/go/db.go
+++ b/internal/endtoend/testdata/selectstatic/mysql/go/db.go
@@ -32,5 +32,5 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/selectstatic/mysql/go/query.sql.go
+++ b/internal/endtoend/testdata/selectstatic/mysql/go/query.sql.go
@@ -21,8 +21,16 @@ type SelectStaticRow struct {
 	Floater   float64
 }
 
-func (q *Queries) SelectStatic(ctx context.Context) (SelectStaticRow, error) {
-	row := q.db.QueryRowContext(ctx, selectStatic)
+func (q *Queries) SelectStatic(ctx context.Context, aq ...AdditionalQuery) (SelectStaticRow, error) {
+	query := selectStatic
+	queryParams := []interface{}{}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	row := q.db.QueryRowContext(ctx, query, queryParams...)
 	var i SelectStaticRow
 	err := row.Scan(
 		&i.Column1,

--- a/internal/endtoend/testdata/show_warnings/mysql/go/db.go
+++ b/internal/endtoend/testdata/show_warnings/mysql/go/db.go
@@ -29,3 +29,8 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/show_warnings/mysql/go/db.go
+++ b/internal/endtoend/testdata/show_warnings/mysql/go/db.go
@@ -32,5 +32,5 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/show_warnings/mysql/go/query.sql.go
+++ b/internal/endtoend/testdata/show_warnings/mysql/go/query.sql.go
@@ -19,8 +19,16 @@ type ShowWarningsRow struct {
 	Message string
 }
 
-func (q *Queries) ShowWarnings(ctx context.Context) ([]ShowWarningsRow, error) {
-	rows, err := q.db.QueryContext(ctx, showWarnings)
+func (q *Queries) ShowWarnings(ctx context.Context, aq ...AdditionalQuery) ([]ShowWarningsRow, error) {
+	query := showWarnings
+	queryParams := []interface{}{}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.QueryContext(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/endtoend/testdata/single_param_conflict/mysql/go/db.go
+++ b/internal/endtoend/testdata/single_param_conflict/mysql/go/db.go
@@ -29,3 +29,8 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/single_param_conflict/mysql/go/db.go
+++ b/internal/endtoend/testdata/single_param_conflict/mysql/go/db.go
@@ -32,5 +32,5 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/single_param_conflict/mysql/go/query.sql.go
+++ b/internal/endtoend/testdata/single_param_conflict/mysql/go/query.sql.go
@@ -16,8 +16,16 @@ WHERE   id = ?
 LIMIT   1
 `
 
-func (q *Queries) GetAuthorByID(ctx context.Context, id int64) (Author, error) {
-	row := q.db.QueryRowContext(ctx, getAuthorByID, id)
+func (q *Queries) GetAuthorByID(ctx context.Context, id int64, aq ...AdditionalQuery) (Author, error) {
+	query := getAuthorByID
+	queryParams := []interface{}{id}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	row := q.db.QueryRowContext(ctx, query, queryParams...)
 	var i Author
 	err := row.Scan(&i.ID, &i.Name, &i.Bio)
 	return i, err
@@ -30,8 +38,16 @@ WHERE   id = ?
 LIMIT   1
 `
 
-func (q *Queries) GetAuthorIDByID(ctx context.Context, id int64) (int64, error) {
-	row := q.db.QueryRowContext(ctx, getAuthorIDByID, id)
+func (q *Queries) GetAuthorIDByID(ctx context.Context, id int64, aq ...AdditionalQuery) (int64, error) {
+	query := getAuthorIDByID
+	queryParams := []interface{}{id}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	row := q.db.QueryRowContext(ctx, query, queryParams...)
 	err := row.Scan(&id)
 	return id, err
 }
@@ -43,8 +59,16 @@ WHERE   sub = ?
 LIMIT   1
 `
 
-func (q *Queries) GetUser(ctx context.Context, sub string) (string, error) {
-	row := q.db.QueryRowContext(ctx, getUser, sub)
+func (q *Queries) GetUser(ctx context.Context, sub string, aq ...AdditionalQuery) (string, error) {
+	query := getUser
+	queryParams := []interface{}{sub}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	row := q.db.QueryRowContext(ctx, query, queryParams...)
 	err := row.Scan(&sub)
 	return sub, err
 }

--- a/internal/endtoend/testdata/single_param_conflict/postgresql/pgx/v4/go/db.go
+++ b/internal/endtoend/testdata/single_param_conflict/postgresql/pgx/v4/go/db.go
@@ -33,5 +33,5 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/single_param_conflict/postgresql/pgx/v4/go/db.go
+++ b/internal/endtoend/testdata/single_param_conflict/postgresql/pgx/v4/go/db.go
@@ -30,3 +30,8 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/single_param_conflict/postgresql/pgx/v4/go/query.sql.go
+++ b/internal/endtoend/testdata/single_param_conflict/postgresql/pgx/v4/go/query.sql.go
@@ -18,8 +18,10 @@ WHERE   id = $1
 LIMIT   1
 `
 
-func (q *Queries) GetAuthorByID(ctx context.Context, id int64) (Author, error) {
-	row := q.db.QueryRow(ctx, getAuthorByID, id)
+func (q *Queries) GetAuthorByID(ctx context.Context, id int64, aq ...AdditionalQuery) (Author, error) {
+	query := getAuthorByID
+	queryParams := []interface{}{id}
+	row := q.db.QueryRow(ctx, query, queryParams...)
 	var i Author
 	err := row.Scan(&i.ID, &i.Name, &i.Bio)
 	return i, err
@@ -32,8 +34,10 @@ WHERE   id = $1
 LIMIT   1
 `
 
-func (q *Queries) GetAuthorIDByID(ctx context.Context, id int64) (int64, error) {
-	row := q.db.QueryRow(ctx, getAuthorIDByID, id)
+func (q *Queries) GetAuthorIDByID(ctx context.Context, id int64, aq ...AdditionalQuery) (int64, error) {
+	query := getAuthorIDByID
+	queryParams := []interface{}{id}
+	row := q.db.QueryRow(ctx, query, queryParams...)
 	err := row.Scan(&id)
 	return id, err
 }
@@ -45,8 +49,10 @@ WHERE   sub = $1
 LIMIT   1
 `
 
-func (q *Queries) GetUser(ctx context.Context, sub uuid.UUID) (uuid.UUID, error) {
-	row := q.db.QueryRow(ctx, getUser, sub)
+func (q *Queries) GetUser(ctx context.Context, sub uuid.UUID, aq ...AdditionalQuery) (uuid.UUID, error) {
+	query := getUser
+	queryParams := []interface{}{sub}
+	row := q.db.QueryRow(ctx, query, queryParams...)
 	err := row.Scan(&sub)
 	return sub, err
 }
@@ -60,8 +66,10 @@ RETURNING id
 `
 
 // https://github.com/sqlc-dev/sqlc/issues/1235
-func (q *Queries) SetDefaultName(ctx context.Context, id int64) (int64, error) {
-	row := q.db.QueryRow(ctx, setDefaultName, id)
+func (q *Queries) SetDefaultName(ctx context.Context, id int64, aq ...AdditionalQuery) (int64, error) {
+	query := setDefaultName
+	queryParams := []interface{}{id}
+	row := q.db.QueryRow(ctx, query, queryParams...)
 	err := row.Scan(&id)
 	return id, err
 }

--- a/internal/endtoend/testdata/single_param_conflict/postgresql/pgx/v5/go/db.go
+++ b/internal/endtoend/testdata/single_param_conflict/postgresql/pgx/v5/go/db.go
@@ -33,5 +33,5 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/single_param_conflict/postgresql/pgx/v5/go/db.go
+++ b/internal/endtoend/testdata/single_param_conflict/postgresql/pgx/v5/go/db.go
@@ -30,3 +30,8 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/single_param_conflict/postgresql/pgx/v5/go/query.sql.go
+++ b/internal/endtoend/testdata/single_param_conflict/postgresql/pgx/v5/go/query.sql.go
@@ -18,8 +18,10 @@ WHERE   id = $1
 LIMIT   1
 `
 
-func (q *Queries) GetAuthorByID(ctx context.Context, id int64) (Author, error) {
-	row := q.db.QueryRow(ctx, getAuthorByID, id)
+func (q *Queries) GetAuthorByID(ctx context.Context, id int64, aq ...AdditionalQuery) (Author, error) {
+	query := getAuthorByID
+	queryParams := []interface{}{id}
+	row := q.db.QueryRow(ctx, query, queryParams...)
 	var i Author
 	err := row.Scan(&i.ID, &i.Name, &i.Bio)
 	return i, err
@@ -32,8 +34,10 @@ WHERE   id = $1
 LIMIT   1
 `
 
-func (q *Queries) GetAuthorIDByID(ctx context.Context, id int64) (int64, error) {
-	row := q.db.QueryRow(ctx, getAuthorIDByID, id)
+func (q *Queries) GetAuthorIDByID(ctx context.Context, id int64, aq ...AdditionalQuery) (int64, error) {
+	query := getAuthorIDByID
+	queryParams := []interface{}{id}
+	row := q.db.QueryRow(ctx, query, queryParams...)
 	err := row.Scan(&id)
 	return id, err
 }
@@ -45,8 +49,10 @@ WHERE   sub = $1
 LIMIT   1
 `
 
-func (q *Queries) GetUser(ctx context.Context, sub pgtype.UUID) (pgtype.UUID, error) {
-	row := q.db.QueryRow(ctx, getUser, sub)
+func (q *Queries) GetUser(ctx context.Context, sub pgtype.UUID, aq ...AdditionalQuery) (pgtype.UUID, error) {
+	query := getUser
+	queryParams := []interface{}{sub}
+	row := q.db.QueryRow(ctx, query, queryParams...)
 	err := row.Scan(&sub)
 	return sub, err
 }
@@ -60,8 +66,10 @@ RETURNING id
 `
 
 // https://github.com/sqlc-dev/sqlc/issues/1235
-func (q *Queries) SetDefaultName(ctx context.Context, id int64) (int64, error) {
-	row := q.db.QueryRow(ctx, setDefaultName, id)
+func (q *Queries) SetDefaultName(ctx context.Context, id int64, aq ...AdditionalQuery) (int64, error) {
+	query := setDefaultName
+	queryParams := []interface{}{id}
+	row := q.db.QueryRow(ctx, query, queryParams...)
 	err := row.Scan(&id)
 	return id, err
 }

--- a/internal/endtoend/testdata/single_param_conflict/postgresql/stdlib/go/db.go
+++ b/internal/endtoend/testdata/single_param_conflict/postgresql/stdlib/go/db.go
@@ -29,3 +29,8 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/single_param_conflict/postgresql/stdlib/go/db.go
+++ b/internal/endtoend/testdata/single_param_conflict/postgresql/stdlib/go/db.go
@@ -32,5 +32,5 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/single_param_conflict/postgresql/stdlib/go/query.sql.go
+++ b/internal/endtoend/testdata/single_param_conflict/postgresql/stdlib/go/query.sql.go
@@ -18,8 +18,16 @@ WHERE   id = $1
 LIMIT   1
 `
 
-func (q *Queries) GetAuthorByID(ctx context.Context, id int64) (Author, error) {
-	row := q.db.QueryRowContext(ctx, getAuthorByID, id)
+func (q *Queries) GetAuthorByID(ctx context.Context, id int64, aq ...AdditionalQuery) (Author, error) {
+	query := getAuthorByID
+	queryParams := []interface{}{id}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	row := q.db.QueryRowContext(ctx, query, queryParams...)
 	var i Author
 	err := row.Scan(&i.ID, &i.Name, &i.Bio)
 	return i, err
@@ -32,8 +40,16 @@ WHERE   id = $1
 LIMIT   1
 `
 
-func (q *Queries) GetAuthorIDByID(ctx context.Context, id int64) (int64, error) {
-	row := q.db.QueryRowContext(ctx, getAuthorIDByID, id)
+func (q *Queries) GetAuthorIDByID(ctx context.Context, id int64, aq ...AdditionalQuery) (int64, error) {
+	query := getAuthorIDByID
+	queryParams := []interface{}{id}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	row := q.db.QueryRowContext(ctx, query, queryParams...)
 	err := row.Scan(&id)
 	return id, err
 }
@@ -45,8 +61,16 @@ WHERE   sub = $1
 LIMIT   1
 `
 
-func (q *Queries) GetUser(ctx context.Context, sub uuid.UUID) (uuid.UUID, error) {
-	row := q.db.QueryRowContext(ctx, getUser, sub)
+func (q *Queries) GetUser(ctx context.Context, sub uuid.UUID, aq ...AdditionalQuery) (uuid.UUID, error) {
+	query := getUser
+	queryParams := []interface{}{sub}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	row := q.db.QueryRowContext(ctx, query, queryParams...)
 	err := row.Scan(&sub)
 	return sub, err
 }
@@ -60,8 +84,16 @@ RETURNING id
 `
 
 // https://github.com/sqlc-dev/sqlc/issues/1235
-func (q *Queries) SetDefaultName(ctx context.Context, id int64) (int64, error) {
-	row := q.db.QueryRowContext(ctx, setDefaultName, id)
+func (q *Queries) SetDefaultName(ctx context.Context, id int64, aq ...AdditionalQuery) (int64, error) {
+	query := setDefaultName
+	queryParams := []interface{}{id}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	row := q.db.QueryRowContext(ctx, query, queryParams...)
 	err := row.Scan(&id)
 	return id, err
 }

--- a/internal/endtoend/testdata/single_param_conflict/sqlite/go/db.go
+++ b/internal/endtoend/testdata/single_param_conflict/sqlite/go/db.go
@@ -29,3 +29,8 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/single_param_conflict/sqlite/go/db.go
+++ b/internal/endtoend/testdata/single_param_conflict/sqlite/go/db.go
@@ -32,5 +32,5 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/single_param_conflict/sqlite/go/query.sql.go
+++ b/internal/endtoend/testdata/single_param_conflict/sqlite/go/query.sql.go
@@ -16,8 +16,16 @@ WHERE   id = ?
 LIMIT   1
 `
 
-func (q *Queries) GetAuthorByID(ctx context.Context, id int64) (Author, error) {
-	row := q.db.QueryRowContext(ctx, getAuthorByID, id)
+func (q *Queries) GetAuthorByID(ctx context.Context, id int64, aq ...AdditionalQuery) (Author, error) {
+	query := getAuthorByID
+	queryParams := []interface{}{id}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	row := q.db.QueryRowContext(ctx, query, queryParams...)
 	var i Author
 	err := row.Scan(&i.ID, &i.Name, &i.Bio)
 	return i, err
@@ -30,8 +38,16 @@ WHERE   id = ?
 LIMIT   1
 `
 
-func (q *Queries) GetAuthorIDByID(ctx context.Context, id int64) (int64, error) {
-	row := q.db.QueryRowContext(ctx, getAuthorIDByID, id)
+func (q *Queries) GetAuthorIDByID(ctx context.Context, id int64, aq ...AdditionalQuery) (int64, error) {
+	query := getAuthorIDByID
+	queryParams := []interface{}{id}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	row := q.db.QueryRowContext(ctx, query, queryParams...)
 	err := row.Scan(&id)
 	return id, err
 }
@@ -43,8 +59,16 @@ WHERE   sub = ?
 LIMIT   1
 `
 
-func (q *Queries) GetUser(ctx context.Context, sub string) (string, error) {
-	row := q.db.QueryRowContext(ctx, getUser, sub)
+func (q *Queries) GetUser(ctx context.Context, sub string, aq ...AdditionalQuery) (string, error) {
+	query := getUser
+	queryParams := []interface{}{sub}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	row := q.db.QueryRowContext(ctx, query, queryParams...)
 	err := row.Scan(&sub)
 	return sub, err
 }

--- a/internal/endtoend/testdata/sql_syntax_calling_funcs/postgresql/pgx/v4/go/db.go
+++ b/internal/endtoend/testdata/sql_syntax_calling_funcs/postgresql/pgx/v4/go/db.go
@@ -33,5 +33,5 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/sql_syntax_calling_funcs/postgresql/pgx/v4/go/db.go
+++ b/internal/endtoend/testdata/sql_syntax_calling_funcs/postgresql/pgx/v4/go/db.go
@@ -30,3 +30,8 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/sql_syntax_calling_funcs/postgresql/pgx/v4/go/query.sql.go
+++ b/internal/endtoend/testdata/sql_syntax_calling_funcs/postgresql/pgx/v4/go/query.sql.go
@@ -13,8 +13,10 @@ const mixedNotation = `-- name: MixedNotation :one
 SELECT concat_lower_or_upper('Hello', 'World', uppercase => true)
 `
 
-func (q *Queries) MixedNotation(ctx context.Context) (string, error) {
-	row := q.db.QueryRow(ctx, mixedNotation)
+func (q *Queries) MixedNotation(ctx context.Context, aq ...AdditionalQuery) (string, error) {
+	query := mixedNotation
+	queryParams := []interface{}{}
+	row := q.db.QueryRow(ctx, query, queryParams...)
 	var concat_lower_or_upper string
 	err := row.Scan(&concat_lower_or_upper)
 	return concat_lower_or_upper, err
@@ -24,8 +26,10 @@ const namedAnyOrder = `-- name: NamedAnyOrder :one
 SELECT concat_lower_or_upper(a => 'Hello', b => 'World', uppercase => true)
 `
 
-func (q *Queries) NamedAnyOrder(ctx context.Context) (string, error) {
-	row := q.db.QueryRow(ctx, namedAnyOrder)
+func (q *Queries) NamedAnyOrder(ctx context.Context, aq ...AdditionalQuery) (string, error) {
+	query := namedAnyOrder
+	queryParams := []interface{}{}
+	row := q.db.QueryRow(ctx, query, queryParams...)
 	var concat_lower_or_upper string
 	err := row.Scan(&concat_lower_or_upper)
 	return concat_lower_or_upper, err
@@ -35,8 +39,10 @@ const namedNotation = `-- name: NamedNotation :one
 SELECT concat_lower_or_upper(a => 'Hello', b => 'World')
 `
 
-func (q *Queries) NamedNotation(ctx context.Context) (string, error) {
-	row := q.db.QueryRow(ctx, namedNotation)
+func (q *Queries) NamedNotation(ctx context.Context, aq ...AdditionalQuery) (string, error) {
+	query := namedNotation
+	queryParams := []interface{}{}
+	row := q.db.QueryRow(ctx, query, queryParams...)
 	var concat_lower_or_upper string
 	err := row.Scan(&concat_lower_or_upper)
 	return concat_lower_or_upper, err
@@ -46,8 +52,10 @@ const namedOtherOrder = `-- name: NamedOtherOrder :one
 SELECT concat_lower_or_upper(a => 'Hello', uppercase => true, b => 'World')
 `
 
-func (q *Queries) NamedOtherOrder(ctx context.Context) (string, error) {
-	row := q.db.QueryRow(ctx, namedOtherOrder)
+func (q *Queries) NamedOtherOrder(ctx context.Context, aq ...AdditionalQuery) (string, error) {
+	query := namedOtherOrder
+	queryParams := []interface{}{}
+	row := q.db.QueryRow(ctx, query, queryParams...)
 	var concat_lower_or_upper string
 	err := row.Scan(&concat_lower_or_upper)
 	return concat_lower_or_upper, err
@@ -57,8 +65,10 @@ const positionalNoDefaault = `-- name: PositionalNoDefaault :one
 SELECT concat_lower_or_upper('Hello', 'World')
 `
 
-func (q *Queries) PositionalNoDefaault(ctx context.Context) (string, error) {
-	row := q.db.QueryRow(ctx, positionalNoDefaault)
+func (q *Queries) PositionalNoDefaault(ctx context.Context, aq ...AdditionalQuery) (string, error) {
+	query := positionalNoDefaault
+	queryParams := []interface{}{}
+	row := q.db.QueryRow(ctx, query, queryParams...)
 	var concat_lower_or_upper string
 	err := row.Scan(&concat_lower_or_upper)
 	return concat_lower_or_upper, err
@@ -68,8 +78,10 @@ const positionalNotation = `-- name: PositionalNotation :one
 SELECT concat_lower_or_upper('Hello', 'World', true)
 `
 
-func (q *Queries) PositionalNotation(ctx context.Context) (string, error) {
-	row := q.db.QueryRow(ctx, positionalNotation)
+func (q *Queries) PositionalNotation(ctx context.Context, aq ...AdditionalQuery) (string, error) {
+	query := positionalNotation
+	queryParams := []interface{}{}
+	row := q.db.QueryRow(ctx, query, queryParams...)
 	var concat_lower_or_upper string
 	err := row.Scan(&concat_lower_or_upper)
 	return concat_lower_or_upper, err

--- a/internal/endtoend/testdata/sql_syntax_calling_funcs/postgresql/pgx/v5/go/db.go
+++ b/internal/endtoend/testdata/sql_syntax_calling_funcs/postgresql/pgx/v5/go/db.go
@@ -33,5 +33,5 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/sql_syntax_calling_funcs/postgresql/pgx/v5/go/db.go
+++ b/internal/endtoend/testdata/sql_syntax_calling_funcs/postgresql/pgx/v5/go/db.go
@@ -30,3 +30,8 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/sql_syntax_calling_funcs/postgresql/pgx/v5/go/query.sql.go
+++ b/internal/endtoend/testdata/sql_syntax_calling_funcs/postgresql/pgx/v5/go/query.sql.go
@@ -13,8 +13,10 @@ const mixedNotation = `-- name: MixedNotation :one
 SELECT concat_lower_or_upper('Hello', 'World', uppercase => true)
 `
 
-func (q *Queries) MixedNotation(ctx context.Context) (string, error) {
-	row := q.db.QueryRow(ctx, mixedNotation)
+func (q *Queries) MixedNotation(ctx context.Context, aq ...AdditionalQuery) (string, error) {
+	query := mixedNotation
+	queryParams := []interface{}{}
+	row := q.db.QueryRow(ctx, query, queryParams...)
 	var concat_lower_or_upper string
 	err := row.Scan(&concat_lower_or_upper)
 	return concat_lower_or_upper, err
@@ -24,8 +26,10 @@ const namedAnyOrder = `-- name: NamedAnyOrder :one
 SELECT concat_lower_or_upper(a => 'Hello', b => 'World', uppercase => true)
 `
 
-func (q *Queries) NamedAnyOrder(ctx context.Context) (string, error) {
-	row := q.db.QueryRow(ctx, namedAnyOrder)
+func (q *Queries) NamedAnyOrder(ctx context.Context, aq ...AdditionalQuery) (string, error) {
+	query := namedAnyOrder
+	queryParams := []interface{}{}
+	row := q.db.QueryRow(ctx, query, queryParams...)
 	var concat_lower_or_upper string
 	err := row.Scan(&concat_lower_or_upper)
 	return concat_lower_or_upper, err
@@ -35,8 +39,10 @@ const namedNotation = `-- name: NamedNotation :one
 SELECT concat_lower_or_upper(a => 'Hello', b => 'World')
 `
 
-func (q *Queries) NamedNotation(ctx context.Context) (string, error) {
-	row := q.db.QueryRow(ctx, namedNotation)
+func (q *Queries) NamedNotation(ctx context.Context, aq ...AdditionalQuery) (string, error) {
+	query := namedNotation
+	queryParams := []interface{}{}
+	row := q.db.QueryRow(ctx, query, queryParams...)
 	var concat_lower_or_upper string
 	err := row.Scan(&concat_lower_or_upper)
 	return concat_lower_or_upper, err
@@ -46,8 +52,10 @@ const namedOtherOrder = `-- name: NamedOtherOrder :one
 SELECT concat_lower_or_upper(a => 'Hello', uppercase => true, b => 'World')
 `
 
-func (q *Queries) NamedOtherOrder(ctx context.Context) (string, error) {
-	row := q.db.QueryRow(ctx, namedOtherOrder)
+func (q *Queries) NamedOtherOrder(ctx context.Context, aq ...AdditionalQuery) (string, error) {
+	query := namedOtherOrder
+	queryParams := []interface{}{}
+	row := q.db.QueryRow(ctx, query, queryParams...)
 	var concat_lower_or_upper string
 	err := row.Scan(&concat_lower_or_upper)
 	return concat_lower_or_upper, err
@@ -57,8 +65,10 @@ const positionalNoDefaault = `-- name: PositionalNoDefaault :one
 SELECT concat_lower_or_upper('Hello', 'World')
 `
 
-func (q *Queries) PositionalNoDefaault(ctx context.Context) (string, error) {
-	row := q.db.QueryRow(ctx, positionalNoDefaault)
+func (q *Queries) PositionalNoDefaault(ctx context.Context, aq ...AdditionalQuery) (string, error) {
+	query := positionalNoDefaault
+	queryParams := []interface{}{}
+	row := q.db.QueryRow(ctx, query, queryParams...)
 	var concat_lower_or_upper string
 	err := row.Scan(&concat_lower_or_upper)
 	return concat_lower_or_upper, err
@@ -68,8 +78,10 @@ const positionalNotation = `-- name: PositionalNotation :one
 SELECT concat_lower_or_upper('Hello', 'World', true)
 `
 
-func (q *Queries) PositionalNotation(ctx context.Context) (string, error) {
-	row := q.db.QueryRow(ctx, positionalNotation)
+func (q *Queries) PositionalNotation(ctx context.Context, aq ...AdditionalQuery) (string, error) {
+	query := positionalNotation
+	queryParams := []interface{}{}
+	row := q.db.QueryRow(ctx, query, queryParams...)
 	var concat_lower_or_upper string
 	err := row.Scan(&concat_lower_or_upper)
 	return concat_lower_or_upper, err

--- a/internal/endtoend/testdata/sql_syntax_calling_funcs/postgresql/stdlib/go/db.go
+++ b/internal/endtoend/testdata/sql_syntax_calling_funcs/postgresql/stdlib/go/db.go
@@ -29,3 +29,8 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/sql_syntax_calling_funcs/postgresql/stdlib/go/db.go
+++ b/internal/endtoend/testdata/sql_syntax_calling_funcs/postgresql/stdlib/go/db.go
@@ -32,5 +32,5 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/sql_syntax_calling_funcs/postgresql/stdlib/go/query.sql.go
+++ b/internal/endtoend/testdata/sql_syntax_calling_funcs/postgresql/stdlib/go/query.sql.go
@@ -13,8 +13,16 @@ const mixedNotation = `-- name: MixedNotation :one
 SELECT concat_lower_or_upper('Hello', 'World', uppercase => true)
 `
 
-func (q *Queries) MixedNotation(ctx context.Context) (string, error) {
-	row := q.db.QueryRowContext(ctx, mixedNotation)
+func (q *Queries) MixedNotation(ctx context.Context, aq ...AdditionalQuery) (string, error) {
+	query := mixedNotation
+	queryParams := []interface{}{}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	row := q.db.QueryRowContext(ctx, query, queryParams...)
 	var concat_lower_or_upper string
 	err := row.Scan(&concat_lower_or_upper)
 	return concat_lower_or_upper, err
@@ -24,8 +32,16 @@ const namedAnyOrder = `-- name: NamedAnyOrder :one
 SELECT concat_lower_or_upper(a => 'Hello', b => 'World', uppercase => true)
 `
 
-func (q *Queries) NamedAnyOrder(ctx context.Context) (string, error) {
-	row := q.db.QueryRowContext(ctx, namedAnyOrder)
+func (q *Queries) NamedAnyOrder(ctx context.Context, aq ...AdditionalQuery) (string, error) {
+	query := namedAnyOrder
+	queryParams := []interface{}{}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	row := q.db.QueryRowContext(ctx, query, queryParams...)
 	var concat_lower_or_upper string
 	err := row.Scan(&concat_lower_or_upper)
 	return concat_lower_or_upper, err
@@ -35,8 +51,16 @@ const namedNotation = `-- name: NamedNotation :one
 SELECT concat_lower_or_upper(a => 'Hello', b => 'World')
 `
 
-func (q *Queries) NamedNotation(ctx context.Context) (string, error) {
-	row := q.db.QueryRowContext(ctx, namedNotation)
+func (q *Queries) NamedNotation(ctx context.Context, aq ...AdditionalQuery) (string, error) {
+	query := namedNotation
+	queryParams := []interface{}{}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	row := q.db.QueryRowContext(ctx, query, queryParams...)
 	var concat_lower_or_upper string
 	err := row.Scan(&concat_lower_or_upper)
 	return concat_lower_or_upper, err
@@ -46,8 +70,16 @@ const namedOtherOrder = `-- name: NamedOtherOrder :one
 SELECT concat_lower_or_upper(a => 'Hello', uppercase => true, b => 'World')
 `
 
-func (q *Queries) NamedOtherOrder(ctx context.Context) (string, error) {
-	row := q.db.QueryRowContext(ctx, namedOtherOrder)
+func (q *Queries) NamedOtherOrder(ctx context.Context, aq ...AdditionalQuery) (string, error) {
+	query := namedOtherOrder
+	queryParams := []interface{}{}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	row := q.db.QueryRowContext(ctx, query, queryParams...)
 	var concat_lower_or_upper string
 	err := row.Scan(&concat_lower_or_upper)
 	return concat_lower_or_upper, err
@@ -57,8 +89,16 @@ const positionalNoDefaault = `-- name: PositionalNoDefaault :one
 SELECT concat_lower_or_upper('Hello', 'World')
 `
 
-func (q *Queries) PositionalNoDefaault(ctx context.Context) (string, error) {
-	row := q.db.QueryRowContext(ctx, positionalNoDefaault)
+func (q *Queries) PositionalNoDefaault(ctx context.Context, aq ...AdditionalQuery) (string, error) {
+	query := positionalNoDefaault
+	queryParams := []interface{}{}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	row := q.db.QueryRowContext(ctx, query, queryParams...)
 	var concat_lower_or_upper string
 	err := row.Scan(&concat_lower_or_upper)
 	return concat_lower_or_upper, err
@@ -68,8 +108,16 @@ const positionalNotation = `-- name: PositionalNotation :one
 SELECT concat_lower_or_upper('Hello', 'World', true)
 `
 
-func (q *Queries) PositionalNotation(ctx context.Context) (string, error) {
-	row := q.db.QueryRowContext(ctx, positionalNotation)
+func (q *Queries) PositionalNotation(ctx context.Context, aq ...AdditionalQuery) (string, error) {
+	query := positionalNotation
+	queryParams := []interface{}{}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	row := q.db.QueryRowContext(ctx, query, queryParams...)
 	var concat_lower_or_upper string
 	err := row.Scan(&concat_lower_or_upper)
 	return concat_lower_or_upper, err

--- a/internal/endtoend/testdata/sqlc_arg/mysql/go/db.go
+++ b/internal/endtoend/testdata/sqlc_arg/mysql/go/db.go
@@ -29,3 +29,8 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/sqlc_arg/mysql/go/db.go
+++ b/internal/endtoend/testdata/sqlc_arg/mysql/go/db.go
@@ -32,5 +32,5 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/sqlc_arg/mysql/go/query.sql.go
+++ b/internal/endtoend/testdata/sqlc_arg/mysql/go/query.sql.go
@@ -18,8 +18,16 @@ type ComplicatedParams struct {
 	Slug string
 }
 
-func (q *Queries) Complicated(ctx context.Context, arg ComplicatedParams) ([]string, error) {
-	rows, err := q.db.QueryContext(ctx, complicated, arg.Slug, arg.Slug)
+func (q *Queries) Complicated(ctx context.Context, arg ComplicatedParams, aq ...AdditionalQuery) ([]string, error) {
+	query := complicated
+	queryParams := []interface{}{arg.Slug, arg.Slug}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.QueryContext(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}
@@ -45,8 +53,16 @@ const funcParamIdent = `-- name: FuncParamIdent :many
 SELECT name FROM foo WHERE name = ?
 `
 
-func (q *Queries) FuncParamIdent(ctx context.Context, slug string) ([]string, error) {
-	rows, err := q.db.QueryContext(ctx, funcParamIdent, slug)
+func (q *Queries) FuncParamIdent(ctx context.Context, slug string, aq ...AdditionalQuery) ([]string, error) {
+	query := funcParamIdent
+	queryParams := []interface{}{slug}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.QueryContext(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}
@@ -72,8 +88,16 @@ const funcParamString = `-- name: FuncParamString :many
 SELECT name FROM foo WHERE name = ?
 `
 
-func (q *Queries) FuncParamString(ctx context.Context, slug string) ([]string, error) {
-	rows, err := q.db.QueryContext(ctx, funcParamString, slug)
+func (q *Queries) FuncParamString(ctx context.Context, slug string, aq ...AdditionalQuery) ([]string, error) {
+	query := funcParamString
+	queryParams := []interface{}{slug}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.QueryContext(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/endtoend/testdata/sqlc_arg/postgresql/pgx/v4/go/db.go
+++ b/internal/endtoend/testdata/sqlc_arg/postgresql/pgx/v4/go/db.go
@@ -33,5 +33,5 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/sqlc_arg/postgresql/pgx/v4/go/db.go
+++ b/internal/endtoend/testdata/sqlc_arg/postgresql/pgx/v4/go/db.go
@@ -30,3 +30,8 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/sqlc_arg/postgresql/pgx/v4/go/query.sql.go
+++ b/internal/endtoend/testdata/sqlc_arg/postgresql/pgx/v4/go/query.sql.go
@@ -13,8 +13,16 @@ const funcParamIdent = `-- name: FuncParamIdent :many
 SELECT name FROM foo WHERE name = $1
 `
 
-func (q *Queries) FuncParamIdent(ctx context.Context, slug string) ([]string, error) {
-	rows, err := q.db.Query(ctx, funcParamIdent, slug)
+func (q *Queries) FuncParamIdent(ctx context.Context, slug string, aq ...AdditionalQuery) ([]string, error) {
+	query := funcParamIdent
+	queryParams := []interface{}{slug}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.Query(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}
@@ -37,8 +45,16 @@ const funcParamString = `-- name: FuncParamString :many
 SELECT name FROM foo WHERE name = $1
 `
 
-func (q *Queries) FuncParamString(ctx context.Context, slug string) ([]string, error) {
-	rows, err := q.db.Query(ctx, funcParamString, slug)
+func (q *Queries) FuncParamString(ctx context.Context, slug string, aq ...AdditionalQuery) ([]string, error) {
+	query := funcParamString
+	queryParams := []interface{}{slug}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.Query(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/endtoend/testdata/sqlc_arg/postgresql/pgx/v5/go/db.go
+++ b/internal/endtoend/testdata/sqlc_arg/postgresql/pgx/v5/go/db.go
@@ -33,5 +33,5 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/sqlc_arg/postgresql/pgx/v5/go/db.go
+++ b/internal/endtoend/testdata/sqlc_arg/postgresql/pgx/v5/go/db.go
@@ -30,3 +30,8 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/sqlc_arg/postgresql/pgx/v5/go/query.sql.go
+++ b/internal/endtoend/testdata/sqlc_arg/postgresql/pgx/v5/go/query.sql.go
@@ -13,8 +13,16 @@ const funcParamIdent = `-- name: FuncParamIdent :many
 SELECT name FROM foo WHERE name = $1
 `
 
-func (q *Queries) FuncParamIdent(ctx context.Context, slug string) ([]string, error) {
-	rows, err := q.db.Query(ctx, funcParamIdent, slug)
+func (q *Queries) FuncParamIdent(ctx context.Context, slug string, aq ...AdditionalQuery) ([]string, error) {
+	query := funcParamIdent
+	queryParams := []interface{}{slug}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.Query(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}
@@ -37,8 +45,16 @@ const funcParamString = `-- name: FuncParamString :many
 SELECT name FROM foo WHERE name = $1
 `
 
-func (q *Queries) FuncParamString(ctx context.Context, slug string) ([]string, error) {
-	rows, err := q.db.Query(ctx, funcParamString, slug)
+func (q *Queries) FuncParamString(ctx context.Context, slug string, aq ...AdditionalQuery) ([]string, error) {
+	query := funcParamString
+	queryParams := []interface{}{slug}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.Query(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/endtoend/testdata/sqlc_arg/postgresql/stdlib/go/db.go
+++ b/internal/endtoend/testdata/sqlc_arg/postgresql/stdlib/go/db.go
@@ -29,3 +29,8 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/sqlc_arg/postgresql/stdlib/go/db.go
+++ b/internal/endtoend/testdata/sqlc_arg/postgresql/stdlib/go/db.go
@@ -32,5 +32,5 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/sqlc_arg/postgresql/stdlib/go/query.sql.go
+++ b/internal/endtoend/testdata/sqlc_arg/postgresql/stdlib/go/query.sql.go
@@ -13,8 +13,16 @@ const funcParamIdent = `-- name: FuncParamIdent :many
 SELECT name FROM foo WHERE name = $1
 `
 
-func (q *Queries) FuncParamIdent(ctx context.Context, slug string) ([]string, error) {
-	rows, err := q.db.QueryContext(ctx, funcParamIdent, slug)
+func (q *Queries) FuncParamIdent(ctx context.Context, slug string, aq ...AdditionalQuery) ([]string, error) {
+	query := funcParamIdent
+	queryParams := []interface{}{slug}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.QueryContext(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}
@@ -40,8 +48,16 @@ const funcParamString = `-- name: FuncParamString :many
 SELECT name FROM foo WHERE name = $1
 `
 
-func (q *Queries) FuncParamString(ctx context.Context, slug string) ([]string, error) {
-	rows, err := q.db.QueryContext(ctx, funcParamString, slug)
+func (q *Queries) FuncParamString(ctx context.Context, slug string, aq ...AdditionalQuery) ([]string, error) {
+	query := funcParamString
+	queryParams := []interface{}{slug}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.QueryContext(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/endtoend/testdata/sqlc_arg/sqlite/go/db.go
+++ b/internal/endtoend/testdata/sqlc_arg/sqlite/go/db.go
@@ -29,3 +29,8 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/sqlc_arg/sqlite/go/db.go
+++ b/internal/endtoend/testdata/sqlc_arg/sqlite/go/db.go
@@ -32,5 +32,5 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/sqlc_arg/sqlite/go/query.sql.go
+++ b/internal/endtoend/testdata/sqlc_arg/sqlite/go/query.sql.go
@@ -13,8 +13,16 @@ const funcParamIdent = `-- name: FuncParamIdent :many
 SELECT name FROM foo WHERE name = ?1
 `
 
-func (q *Queries) FuncParamIdent(ctx context.Context, slug string) ([]string, error) {
-	rows, err := q.db.QueryContext(ctx, funcParamIdent, slug)
+func (q *Queries) FuncParamIdent(ctx context.Context, slug string, aq ...AdditionalQuery) ([]string, error) {
+	query := funcParamIdent
+	queryParams := []interface{}{slug}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.QueryContext(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}
@@ -40,8 +48,16 @@ const funcParamString = `-- name: FuncParamString :many
 SELECT name FROM foo WHERE name = ?1
 `
 
-func (q *Queries) FuncParamString(ctx context.Context, slug string) ([]string, error) {
-	rows, err := q.db.QueryContext(ctx, funcParamString, slug)
+func (q *Queries) FuncParamString(ctx context.Context, slug string, aq ...AdditionalQuery) ([]string, error) {
+	query := funcParamString
+	queryParams := []interface{}{slug}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.QueryContext(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/endtoend/testdata/sqlc_embed/mysql/go/db.go
+++ b/internal/endtoend/testdata/sqlc_embed/mysql/go/db.go
@@ -29,3 +29,8 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/sqlc_embed/mysql/go/db.go
+++ b/internal/endtoend/testdata/sqlc_embed/mysql/go/db.go
@@ -32,5 +32,5 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/sqlc_embed/mysql/go/query.sql.go
+++ b/internal/endtoend/testdata/sqlc_embed/mysql/go/query.sql.go
@@ -19,8 +19,16 @@ type DuplicateRow struct {
 	User_2 User
 }
 
-func (q *Queries) Duplicate(ctx context.Context) (DuplicateRow, error) {
-	row := q.db.QueryRowContext(ctx, duplicate)
+func (q *Queries) Duplicate(ctx context.Context, aq ...AdditionalQuery) (DuplicateRow, error) {
+	query := duplicate
+	queryParams := []interface{}{}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	row := q.db.QueryRowContext(ctx, query, queryParams...)
 	var i DuplicateRow
 	err := row.Scan(
 		&i.User.ID,
@@ -43,8 +51,16 @@ type JoinRow struct {
 	Post Post
 }
 
-func (q *Queries) Join(ctx context.Context) (JoinRow, error) {
-	row := q.db.QueryRowContext(ctx, join)
+func (q *Queries) Join(ctx context.Context, aq ...AdditionalQuery) (JoinRow, error) {
+	query := join
+	queryParams := []interface{}{}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	row := q.db.QueryRowContext(ctx, query, queryParams...)
 	var i JoinRow
 	err := row.Scan(
 		&i.User.ID,
@@ -64,8 +80,16 @@ type OnlyRow struct {
 	User User
 }
 
-func (q *Queries) Only(ctx context.Context) (OnlyRow, error) {
-	row := q.db.QueryRowContext(ctx, only)
+func (q *Queries) Only(ctx context.Context, aq ...AdditionalQuery) (OnlyRow, error) {
+	query := only
+	queryParams := []interface{}{}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	row := q.db.QueryRowContext(ctx, query, queryParams...)
 	var i OnlyRow
 	err := row.Scan(&i.User.ID, &i.User.Name, &i.User.Age)
 	return i, err
@@ -79,8 +103,16 @@ type WithAliasRow struct {
 	User User
 }
 
-func (q *Queries) WithAlias(ctx context.Context) (WithAliasRow, error) {
-	row := q.db.QueryRowContext(ctx, withAlias)
+func (q *Queries) WithAlias(ctx context.Context, aq ...AdditionalQuery) (WithAliasRow, error) {
+	query := withAlias
+	queryParams := []interface{}{}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	row := q.db.QueryRowContext(ctx, query, queryParams...)
 	var i WithAliasRow
 	err := row.Scan(&i.User.ID, &i.User.Name, &i.User.Age)
 	return i, err
@@ -97,8 +129,16 @@ type WithAsteriskRow struct {
 	Age  sql.NullInt32
 }
 
-func (q *Queries) WithAsterisk(ctx context.Context) (WithAsteriskRow, error) {
-	row := q.db.QueryRowContext(ctx, withAsterisk)
+func (q *Queries) WithAsterisk(ctx context.Context, aq ...AdditionalQuery) (WithAsteriskRow, error) {
+	query := withAsterisk
+	queryParams := []interface{}{}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	row := q.db.QueryRowContext(ctx, query, queryParams...)
 	var i WithAsteriskRow
 	err := row.Scan(
 		&i.User.ID,
@@ -121,8 +161,16 @@ type WithCrossSchemaRow struct {
 	BazUser BazUser
 }
 
-func (q *Queries) WithCrossSchema(ctx context.Context) ([]WithCrossSchemaRow, error) {
-	rows, err := q.db.QueryContext(ctx, withCrossSchema)
+func (q *Queries) WithCrossSchema(ctx context.Context, aq ...AdditionalQuery) ([]WithCrossSchemaRow, error) {
+	query := withCrossSchema
+	queryParams := []interface{}{}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.QueryContext(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}
@@ -158,8 +206,16 @@ type WithSchemaRow struct {
 	BazUser BazUser
 }
 
-func (q *Queries) WithSchema(ctx context.Context) (WithSchemaRow, error) {
-	row := q.db.QueryRowContext(ctx, withSchema)
+func (q *Queries) WithSchema(ctx context.Context, aq ...AdditionalQuery) (WithSchemaRow, error) {
+	query := withSchema
+	queryParams := []interface{}{}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	row := q.db.QueryRowContext(ctx, query, queryParams...)
 	var i WithSchemaRow
 	err := row.Scan(&i.BazUser.ID, &i.BazUser.Name)
 	return i, err
@@ -174,8 +230,16 @@ type WithSubqueryRow struct {
 	TotalCount int64
 }
 
-func (q *Queries) WithSubquery(ctx context.Context) ([]WithSubqueryRow, error) {
-	rows, err := q.db.QueryContext(ctx, withSubquery)
+func (q *Queries) WithSubquery(ctx context.Context, aq ...AdditionalQuery) ([]WithSubqueryRow, error) {
+	query := withSubquery
+	queryParams := []interface{}{}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.QueryContext(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/endtoend/testdata/sqlc_embed/postgresql/pgx/go/db.go
+++ b/internal/endtoend/testdata/sqlc_embed/postgresql/pgx/go/db.go
@@ -33,5 +33,5 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/sqlc_embed/postgresql/pgx/go/db.go
+++ b/internal/endtoend/testdata/sqlc_embed/postgresql/pgx/go/db.go
@@ -30,3 +30,8 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/sqlc_embed/postgresql/pgx/go/query.sql.go
+++ b/internal/endtoend/testdata/sqlc_embed/postgresql/pgx/go/query.sql.go
@@ -19,8 +19,10 @@ type DuplicateRow struct {
 	User_2 User `db:"user_2" json:"user_2"`
 }
 
-func (q *Queries) Duplicate(ctx context.Context) (DuplicateRow, error) {
-	row := q.db.QueryRow(ctx, duplicate)
+func (q *Queries) Duplicate(ctx context.Context, aq ...AdditionalQuery) (DuplicateRow, error) {
+	query := duplicate
+	queryParams := []interface{}{}
+	row := q.db.QueryRow(ctx, query, queryParams...)
 	var i DuplicateRow
 	err := row.Scan(
 		&i.User.ID,
@@ -43,8 +45,10 @@ type JoinRow struct {
 	Post Post `db:"post" json:"post"`
 }
 
-func (q *Queries) Join(ctx context.Context) (JoinRow, error) {
-	row := q.db.QueryRow(ctx, join)
+func (q *Queries) Join(ctx context.Context, aq ...AdditionalQuery) (JoinRow, error) {
+	query := join
+	queryParams := []interface{}{}
+	row := q.db.QueryRow(ctx, query, queryParams...)
 	var i JoinRow
 	err := row.Scan(
 		&i.User.ID,
@@ -64,8 +68,10 @@ type OnlyRow struct {
 	User User `db:"user" json:"user"`
 }
 
-func (q *Queries) Only(ctx context.Context) (OnlyRow, error) {
-	row := q.db.QueryRow(ctx, only)
+func (q *Queries) Only(ctx context.Context, aq ...AdditionalQuery) (OnlyRow, error) {
+	query := only
+	queryParams := []interface{}{}
+	row := q.db.QueryRow(ctx, query, queryParams...)
 	var i OnlyRow
 	err := row.Scan(&i.User.ID, &i.User.Name, &i.User.Age)
 	return i, err
@@ -79,8 +85,10 @@ type WithAliasRow struct {
 	User User `db:"user" json:"user"`
 }
 
-func (q *Queries) WithAlias(ctx context.Context) (WithAliasRow, error) {
-	row := q.db.QueryRow(ctx, withAlias)
+func (q *Queries) WithAlias(ctx context.Context, aq ...AdditionalQuery) (WithAliasRow, error) {
+	query := withAlias
+	queryParams := []interface{}{}
+	row := q.db.QueryRow(ctx, query, queryParams...)
 	var i WithAliasRow
 	err := row.Scan(&i.User.ID, &i.User.Name, &i.User.Age)
 	return i, err
@@ -97,8 +105,10 @@ type WithAsteriskRow struct {
 	Age  sql.NullInt32 `db:"age" json:"age"`
 }
 
-func (q *Queries) WithAsterisk(ctx context.Context) (WithAsteriskRow, error) {
-	row := q.db.QueryRow(ctx, withAsterisk)
+func (q *Queries) WithAsterisk(ctx context.Context, aq ...AdditionalQuery) (WithAsteriskRow, error) {
+	query := withAsterisk
+	queryParams := []interface{}{}
+	row := q.db.QueryRow(ctx, query, queryParams...)
 	var i WithAsteriskRow
 	err := row.Scan(
 		&i.User.ID,
@@ -121,8 +131,16 @@ type WithCrossSchemaRow struct {
 	BazUser BazUser `db:"baz_user" json:"baz_user"`
 }
 
-func (q *Queries) WithCrossSchema(ctx context.Context) ([]WithCrossSchemaRow, error) {
-	rows, err := q.db.Query(ctx, withCrossSchema)
+func (q *Queries) WithCrossSchema(ctx context.Context, aq ...AdditionalQuery) ([]WithCrossSchemaRow, error) {
+	query := withCrossSchema
+	queryParams := []interface{}{}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.Query(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}
@@ -155,8 +173,10 @@ type WithSchemaRow struct {
 	BazUser BazUser `db:"baz_user" json:"baz_user"`
 }
 
-func (q *Queries) WithSchema(ctx context.Context) (WithSchemaRow, error) {
-	row := q.db.QueryRow(ctx, withSchema)
+func (q *Queries) WithSchema(ctx context.Context, aq ...AdditionalQuery) (WithSchemaRow, error) {
+	query := withSchema
+	queryParams := []interface{}{}
+	row := q.db.QueryRow(ctx, query, queryParams...)
 	var i WithSchemaRow
 	err := row.Scan(&i.BazUser.ID, &i.BazUser.Name)
 	return i, err
@@ -171,8 +191,16 @@ type WithSubqueryRow struct {
 	TotalCount int64 `db:"total_count" json:"total_count"`
 }
 
-func (q *Queries) WithSubquery(ctx context.Context) ([]WithSubqueryRow, error) {
-	rows, err := q.db.Query(ctx, withSubquery)
+func (q *Queries) WithSubquery(ctx context.Context, aq ...AdditionalQuery) ([]WithSubqueryRow, error) {
+	query := withSubquery
+	queryParams := []interface{}{}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.Query(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/endtoend/testdata/sqlc_embed/postgresql/stdlib/go/db.go
+++ b/internal/endtoend/testdata/sqlc_embed/postgresql/stdlib/go/db.go
@@ -29,3 +29,8 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/sqlc_embed/postgresql/stdlib/go/db.go
+++ b/internal/endtoend/testdata/sqlc_embed/postgresql/stdlib/go/db.go
@@ -32,5 +32,5 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/sqlc_embed/postgresql/stdlib/go/query.sql.go
+++ b/internal/endtoend/testdata/sqlc_embed/postgresql/stdlib/go/query.sql.go
@@ -21,8 +21,16 @@ type DuplicateRow struct {
 	User_2 User
 }
 
-func (q *Queries) Duplicate(ctx context.Context) (DuplicateRow, error) {
-	row := q.db.QueryRowContext(ctx, duplicate)
+func (q *Queries) Duplicate(ctx context.Context, aq ...AdditionalQuery) (DuplicateRow, error) {
+	query := duplicate
+	queryParams := []interface{}{}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	row := q.db.QueryRowContext(ctx, query, queryParams...)
 	var i DuplicateRow
 	err := row.Scan(
 		&i.User.ID,
@@ -45,8 +53,16 @@ type JoinRow struct {
 	Post Post
 }
 
-func (q *Queries) Join(ctx context.Context) (JoinRow, error) {
-	row := q.db.QueryRowContext(ctx, join)
+func (q *Queries) Join(ctx context.Context, aq ...AdditionalQuery) (JoinRow, error) {
+	query := join
+	queryParams := []interface{}{}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	row := q.db.QueryRowContext(ctx, query, queryParams...)
 	var i JoinRow
 	err := row.Scan(
 		&i.User.ID,
@@ -67,8 +83,16 @@ type OnlyRow struct {
 	User User
 }
 
-func (q *Queries) Only(ctx context.Context) (OnlyRow, error) {
-	row := q.db.QueryRowContext(ctx, only)
+func (q *Queries) Only(ctx context.Context, aq ...AdditionalQuery) (OnlyRow, error) {
+	query := only
+	queryParams := []interface{}{}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	row := q.db.QueryRowContext(ctx, query, queryParams...)
 	var i OnlyRow
 	err := row.Scan(&i.User.ID, &i.User.Name, &i.User.Age)
 	return i, err
@@ -82,8 +106,16 @@ type WithAliasRow struct {
 	User User
 }
 
-func (q *Queries) WithAlias(ctx context.Context) (WithAliasRow, error) {
-	row := q.db.QueryRowContext(ctx, withAlias)
+func (q *Queries) WithAlias(ctx context.Context, aq ...AdditionalQuery) (WithAliasRow, error) {
+	query := withAlias
+	queryParams := []interface{}{}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	row := q.db.QueryRowContext(ctx, query, queryParams...)
 	var i WithAliasRow
 	err := row.Scan(&i.User.ID, &i.User.Name, &i.User.Age)
 	return i, err
@@ -100,8 +132,16 @@ type WithAsteriskRow struct {
 	Age  sql.NullInt32
 }
 
-func (q *Queries) WithAsterisk(ctx context.Context) (WithAsteriskRow, error) {
-	row := q.db.QueryRowContext(ctx, withAsterisk)
+func (q *Queries) WithAsterisk(ctx context.Context, aq ...AdditionalQuery) (WithAsteriskRow, error) {
+	query := withAsterisk
+	queryParams := []interface{}{}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	row := q.db.QueryRowContext(ctx, query, queryParams...)
 	var i WithAsteriskRow
 	err := row.Scan(
 		&i.User.ID,
@@ -124,8 +164,16 @@ type WithCrossSchemaRow struct {
 	BazUser BazUser
 }
 
-func (q *Queries) WithCrossSchema(ctx context.Context) ([]WithCrossSchemaRow, error) {
-	rows, err := q.db.QueryContext(ctx, withCrossSchema)
+func (q *Queries) WithCrossSchema(ctx context.Context, aq ...AdditionalQuery) ([]WithCrossSchemaRow, error) {
+	query := withCrossSchema
+	queryParams := []interface{}{}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.QueryContext(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}
@@ -161,8 +209,16 @@ type WithSchemaRow struct {
 	BazUser BazUser
 }
 
-func (q *Queries) WithSchema(ctx context.Context) (WithSchemaRow, error) {
-	row := q.db.QueryRowContext(ctx, withSchema)
+func (q *Queries) WithSchema(ctx context.Context, aq ...AdditionalQuery) (WithSchemaRow, error) {
+	query := withSchema
+	queryParams := []interface{}{}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	row := q.db.QueryRowContext(ctx, query, queryParams...)
 	var i WithSchemaRow
 	err := row.Scan(&i.BazUser.ID, &i.BazUser.Name)
 	return i, err
@@ -177,8 +233,16 @@ type WithSubqueryRow struct {
 	TotalCount int64
 }
 
-func (q *Queries) WithSubquery(ctx context.Context) ([]WithSubqueryRow, error) {
-	rows, err := q.db.QueryContext(ctx, withSubquery)
+func (q *Queries) WithSubquery(ctx context.Context, aq ...AdditionalQuery) ([]WithSubqueryRow, error) {
+	query := withSubquery
+	queryParams := []interface{}{}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.QueryContext(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/endtoend/testdata/sqlc_embed/sqlite/go/db.go
+++ b/internal/endtoend/testdata/sqlc_embed/sqlite/go/db.go
@@ -29,3 +29,8 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/sqlc_embed/sqlite/go/db.go
+++ b/internal/endtoend/testdata/sqlc_embed/sqlite/go/db.go
@@ -32,5 +32,5 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/sqlc_embed/sqlite/go/query.sql.go
+++ b/internal/endtoend/testdata/sqlc_embed/sqlite/go/query.sql.go
@@ -19,8 +19,16 @@ type DuplicateRow struct {
 	User_2 User
 }
 
-func (q *Queries) Duplicate(ctx context.Context) (DuplicateRow, error) {
-	row := q.db.QueryRowContext(ctx, duplicate)
+func (q *Queries) Duplicate(ctx context.Context, aq ...AdditionalQuery) (DuplicateRow, error) {
+	query := duplicate
+	queryParams := []interface{}{}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	row := q.db.QueryRowContext(ctx, query, queryParams...)
 	var i DuplicateRow
 	err := row.Scan(
 		&i.User.ID,
@@ -43,8 +51,16 @@ type JoinRow struct {
 	Post Post
 }
 
-func (q *Queries) Join(ctx context.Context) (JoinRow, error) {
-	row := q.db.QueryRowContext(ctx, join)
+func (q *Queries) Join(ctx context.Context, aq ...AdditionalQuery) (JoinRow, error) {
+	query := join
+	queryParams := []interface{}{}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	row := q.db.QueryRowContext(ctx, query, queryParams...)
 	var i JoinRow
 	err := row.Scan(
 		&i.User.ID,
@@ -64,8 +80,16 @@ type OnlyRow struct {
 	User User
 }
 
-func (q *Queries) Only(ctx context.Context) (OnlyRow, error) {
-	row := q.db.QueryRowContext(ctx, only)
+func (q *Queries) Only(ctx context.Context, aq ...AdditionalQuery) (OnlyRow, error) {
+	query := only
+	queryParams := []interface{}{}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	row := q.db.QueryRowContext(ctx, query, queryParams...)
 	var i OnlyRow
 	err := row.Scan(&i.User.ID, &i.User.Name, &i.User.Age)
 	return i, err
@@ -79,8 +103,16 @@ type WithAliasRow struct {
 	User User
 }
 
-func (q *Queries) WithAlias(ctx context.Context) (WithAliasRow, error) {
-	row := q.db.QueryRowContext(ctx, withAlias)
+func (q *Queries) WithAlias(ctx context.Context, aq ...AdditionalQuery) (WithAliasRow, error) {
+	query := withAlias
+	queryParams := []interface{}{}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	row := q.db.QueryRowContext(ctx, query, queryParams...)
 	var i WithAliasRow
 	err := row.Scan(&i.User.ID, &i.User.Name, &i.User.Age)
 	return i, err
@@ -97,8 +129,16 @@ type WithAsteriskRow struct {
 	Age  sql.NullInt64
 }
 
-func (q *Queries) WithAsterisk(ctx context.Context) (WithAsteriskRow, error) {
-	row := q.db.QueryRowContext(ctx, withAsterisk)
+func (q *Queries) WithAsterisk(ctx context.Context, aq ...AdditionalQuery) (WithAsteriskRow, error) {
+	query := withAsterisk
+	queryParams := []interface{}{}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	row := q.db.QueryRowContext(ctx, query, queryParams...)
 	var i WithAsteriskRow
 	err := row.Scan(
 		&i.User.ID,
@@ -121,8 +161,16 @@ type WithCrossSchemaRow struct {
 	BazUser BazUser
 }
 
-func (q *Queries) WithCrossSchema(ctx context.Context) ([]WithCrossSchemaRow, error) {
-	rows, err := q.db.QueryContext(ctx, withCrossSchema)
+func (q *Queries) WithCrossSchema(ctx context.Context, aq ...AdditionalQuery) ([]WithCrossSchemaRow, error) {
+	query := withCrossSchema
+	queryParams := []interface{}{}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.QueryContext(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}
@@ -158,8 +206,16 @@ type WithSchemaRow struct {
 	BazUser BazUser
 }
 
-func (q *Queries) WithSchema(ctx context.Context) (WithSchemaRow, error) {
-	row := q.db.QueryRowContext(ctx, withSchema)
+func (q *Queries) WithSchema(ctx context.Context, aq ...AdditionalQuery) (WithSchemaRow, error) {
+	query := withSchema
+	queryParams := []interface{}{}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	row := q.db.QueryRowContext(ctx, query, queryParams...)
 	var i WithSchemaRow
 	err := row.Scan(&i.BazUser.ID, &i.BazUser.Name)
 	return i, err
@@ -174,8 +230,16 @@ type WithSubqueryRow struct {
 	TotalCount int64
 }
 
-func (q *Queries) WithSubquery(ctx context.Context) ([]WithSubqueryRow, error) {
-	rows, err := q.db.QueryContext(ctx, withSubquery)
+func (q *Queries) WithSubquery(ctx context.Context, aq ...AdditionalQuery) ([]WithSubqueryRow, error) {
+	query := withSubquery
+	queryParams := []interface{}{}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.QueryContext(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/endtoend/testdata/sqlc_narg/mysql/go/db.go
+++ b/internal/endtoend/testdata/sqlc_narg/mysql/go/db.go
@@ -29,3 +29,8 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/sqlc_narg/mysql/go/db.go
+++ b/internal/endtoend/testdata/sqlc_narg/mysql/go/db.go
@@ -32,5 +32,5 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/sqlc_narg/mysql/go/query.sql.go
+++ b/internal/endtoend/testdata/sqlc_narg/mysql/go/query.sql.go
@@ -14,8 +14,16 @@ const identOnNonNullable = `-- name: IdentOnNonNullable :many
 SELECT bar FROM foo WHERE bar = ?
 `
 
-func (q *Queries) IdentOnNonNullable(ctx context.Context, bar sql.NullString) ([]string, error) {
-	rows, err := q.db.QueryContext(ctx, identOnNonNullable, bar)
+func (q *Queries) IdentOnNonNullable(ctx context.Context, bar sql.NullString, aq ...AdditionalQuery) ([]string, error) {
+	query := identOnNonNullable
+	queryParams := []interface{}{bar}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.QueryContext(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}
@@ -41,8 +49,16 @@ const identOnNullable = `-- name: IdentOnNullable :many
 SELECT maybe_bar FROM foo WHERE maybe_bar = ?
 `
 
-func (q *Queries) IdentOnNullable(ctx context.Context, maybeBar sql.NullString) ([]sql.NullString, error) {
-	rows, err := q.db.QueryContext(ctx, identOnNullable, maybeBar)
+func (q *Queries) IdentOnNullable(ctx context.Context, maybeBar sql.NullString, aq ...AdditionalQuery) ([]sql.NullString, error) {
+	query := identOnNullable
+	queryParams := []interface{}{maybeBar}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.QueryContext(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}
@@ -68,8 +84,16 @@ const stringOnNonNullable = `-- name: StringOnNonNullable :many
 SELECT bar FROM foo WHERE bar = ?
 `
 
-func (q *Queries) StringOnNonNullable(ctx context.Context, bar sql.NullString) ([]string, error) {
-	rows, err := q.db.QueryContext(ctx, stringOnNonNullable, bar)
+func (q *Queries) StringOnNonNullable(ctx context.Context, bar sql.NullString, aq ...AdditionalQuery) ([]string, error) {
+	query := stringOnNonNullable
+	queryParams := []interface{}{bar}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.QueryContext(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}
@@ -95,8 +119,16 @@ const stringOnNullable = `-- name: StringOnNullable :many
 SELECT maybe_bar FROM foo WHERE maybe_bar = ?
 `
 
-func (q *Queries) StringOnNullable(ctx context.Context, maybeBar sql.NullString) ([]sql.NullString, error) {
-	rows, err := q.db.QueryContext(ctx, stringOnNullable, maybeBar)
+func (q *Queries) StringOnNullable(ctx context.Context, maybeBar sql.NullString, aq ...AdditionalQuery) ([]sql.NullString, error) {
+	query := stringOnNullable
+	queryParams := []interface{}{maybeBar}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.QueryContext(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/endtoend/testdata/sqlc_narg/postgresql/pgx/v4/go/db.go
+++ b/internal/endtoend/testdata/sqlc_narg/postgresql/pgx/v4/go/db.go
@@ -33,5 +33,5 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/sqlc_narg/postgresql/pgx/v4/go/db.go
+++ b/internal/endtoend/testdata/sqlc_narg/postgresql/pgx/v4/go/db.go
@@ -30,3 +30,8 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/sqlc_narg/postgresql/pgx/v4/go/query.sql.go
+++ b/internal/endtoend/testdata/sqlc_narg/postgresql/pgx/v4/go/query.sql.go
@@ -14,8 +14,16 @@ const identOnNonNullable = `-- name: IdentOnNonNullable :many
 SELECT bar FROM foo WHERE bar = $1
 `
 
-func (q *Queries) IdentOnNonNullable(ctx context.Context, bar sql.NullString) ([]string, error) {
-	rows, err := q.db.Query(ctx, identOnNonNullable, bar)
+func (q *Queries) IdentOnNonNullable(ctx context.Context, bar sql.NullString, aq ...AdditionalQuery) ([]string, error) {
+	query := identOnNonNullable
+	queryParams := []interface{}{bar}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.Query(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}
@@ -38,8 +46,16 @@ const identOnNullable = `-- name: IdentOnNullable :many
 SELECT maybe_bar FROM foo WHERE maybe_bar = $1
 `
 
-func (q *Queries) IdentOnNullable(ctx context.Context, maybeBar sql.NullString) ([]sql.NullString, error) {
-	rows, err := q.db.Query(ctx, identOnNullable, maybeBar)
+func (q *Queries) IdentOnNullable(ctx context.Context, maybeBar sql.NullString, aq ...AdditionalQuery) ([]sql.NullString, error) {
+	query := identOnNullable
+	queryParams := []interface{}{maybeBar}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.Query(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}
@@ -62,8 +78,16 @@ const stringOnNonNullable = `-- name: StringOnNonNullable :many
 SELECT bar FROM foo WHERE bar = $1
 `
 
-func (q *Queries) StringOnNonNullable(ctx context.Context, bar sql.NullString) ([]string, error) {
-	rows, err := q.db.Query(ctx, stringOnNonNullable, bar)
+func (q *Queries) StringOnNonNullable(ctx context.Context, bar sql.NullString, aq ...AdditionalQuery) ([]string, error) {
+	query := stringOnNonNullable
+	queryParams := []interface{}{bar}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.Query(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}
@@ -86,8 +110,16 @@ const stringOnNullable = `-- name: StringOnNullable :many
 SELECT maybe_bar FROM foo WHERE maybe_bar = $1
 `
 
-func (q *Queries) StringOnNullable(ctx context.Context, maybeBar sql.NullString) ([]sql.NullString, error) {
-	rows, err := q.db.Query(ctx, stringOnNullable, maybeBar)
+func (q *Queries) StringOnNullable(ctx context.Context, maybeBar sql.NullString, aq ...AdditionalQuery) ([]sql.NullString, error) {
+	query := stringOnNullable
+	queryParams := []interface{}{maybeBar}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.Query(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/endtoend/testdata/sqlc_narg/postgresql/pgx/v5/go/db.go
+++ b/internal/endtoend/testdata/sqlc_narg/postgresql/pgx/v5/go/db.go
@@ -33,5 +33,5 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/sqlc_narg/postgresql/pgx/v5/go/db.go
+++ b/internal/endtoend/testdata/sqlc_narg/postgresql/pgx/v5/go/db.go
@@ -30,3 +30,8 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/sqlc_narg/postgresql/pgx/v5/go/query.sql.go
+++ b/internal/endtoend/testdata/sqlc_narg/postgresql/pgx/v5/go/query.sql.go
@@ -15,8 +15,16 @@ const identOnNonNullable = `-- name: IdentOnNonNullable :many
 SELECT bar FROM foo WHERE bar = $1
 `
 
-func (q *Queries) IdentOnNonNullable(ctx context.Context, bar pgtype.Text) ([]string, error) {
-	rows, err := q.db.Query(ctx, identOnNonNullable, bar)
+func (q *Queries) IdentOnNonNullable(ctx context.Context, bar pgtype.Text, aq ...AdditionalQuery) ([]string, error) {
+	query := identOnNonNullable
+	queryParams := []interface{}{bar}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.Query(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}
@@ -39,8 +47,16 @@ const identOnNullable = `-- name: IdentOnNullable :many
 SELECT maybe_bar FROM foo WHERE maybe_bar = $1
 `
 
-func (q *Queries) IdentOnNullable(ctx context.Context, maybeBar pgtype.Text) ([]pgtype.Text, error) {
-	rows, err := q.db.Query(ctx, identOnNullable, maybeBar)
+func (q *Queries) IdentOnNullable(ctx context.Context, maybeBar pgtype.Text, aq ...AdditionalQuery) ([]pgtype.Text, error) {
+	query := identOnNullable
+	queryParams := []interface{}{maybeBar}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.Query(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}
@@ -63,8 +79,16 @@ const stringOnNonNullable = `-- name: StringOnNonNullable :many
 SELECT bar FROM foo WHERE bar = $1
 `
 
-func (q *Queries) StringOnNonNullable(ctx context.Context, bar pgtype.Text) ([]string, error) {
-	rows, err := q.db.Query(ctx, stringOnNonNullable, bar)
+func (q *Queries) StringOnNonNullable(ctx context.Context, bar pgtype.Text, aq ...AdditionalQuery) ([]string, error) {
+	query := stringOnNonNullable
+	queryParams := []interface{}{bar}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.Query(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}
@@ -87,8 +111,16 @@ const stringOnNullable = `-- name: StringOnNullable :many
 SELECT maybe_bar FROM foo WHERE maybe_bar = $1
 `
 
-func (q *Queries) StringOnNullable(ctx context.Context, maybeBar pgtype.Text) ([]pgtype.Text, error) {
-	rows, err := q.db.Query(ctx, stringOnNullable, maybeBar)
+func (q *Queries) StringOnNullable(ctx context.Context, maybeBar pgtype.Text, aq ...AdditionalQuery) ([]pgtype.Text, error) {
+	query := stringOnNullable
+	queryParams := []interface{}{maybeBar}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.Query(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/endtoend/testdata/sqlc_narg/postgresql/stdlib/go/db.go
+++ b/internal/endtoend/testdata/sqlc_narg/postgresql/stdlib/go/db.go
@@ -29,3 +29,8 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/sqlc_narg/postgresql/stdlib/go/db.go
+++ b/internal/endtoend/testdata/sqlc_narg/postgresql/stdlib/go/db.go
@@ -32,5 +32,5 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/sqlc_narg/postgresql/stdlib/go/query.sql.go
+++ b/internal/endtoend/testdata/sqlc_narg/postgresql/stdlib/go/query.sql.go
@@ -14,8 +14,16 @@ const identOnNonNullable = `-- name: IdentOnNonNullable :many
 SELECT bar FROM foo WHERE bar = $1
 `
 
-func (q *Queries) IdentOnNonNullable(ctx context.Context, bar sql.NullString) ([]string, error) {
-	rows, err := q.db.QueryContext(ctx, identOnNonNullable, bar)
+func (q *Queries) IdentOnNonNullable(ctx context.Context, bar sql.NullString, aq ...AdditionalQuery) ([]string, error) {
+	query := identOnNonNullable
+	queryParams := []interface{}{bar}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.QueryContext(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}
@@ -41,8 +49,16 @@ const identOnNullable = `-- name: IdentOnNullable :many
 SELECT maybe_bar FROM foo WHERE maybe_bar = $1
 `
 
-func (q *Queries) IdentOnNullable(ctx context.Context, maybeBar sql.NullString) ([]sql.NullString, error) {
-	rows, err := q.db.QueryContext(ctx, identOnNullable, maybeBar)
+func (q *Queries) IdentOnNullable(ctx context.Context, maybeBar sql.NullString, aq ...AdditionalQuery) ([]sql.NullString, error) {
+	query := identOnNullable
+	queryParams := []interface{}{maybeBar}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.QueryContext(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}
@@ -68,8 +84,16 @@ const stringOnNonNullable = `-- name: StringOnNonNullable :many
 SELECT bar FROM foo WHERE bar = $1
 `
 
-func (q *Queries) StringOnNonNullable(ctx context.Context, bar sql.NullString) ([]string, error) {
-	rows, err := q.db.QueryContext(ctx, stringOnNonNullable, bar)
+func (q *Queries) StringOnNonNullable(ctx context.Context, bar sql.NullString, aq ...AdditionalQuery) ([]string, error) {
+	query := stringOnNonNullable
+	queryParams := []interface{}{bar}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.QueryContext(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}
@@ -95,8 +119,16 @@ const stringOnNullable = `-- name: StringOnNullable :many
 SELECT maybe_bar FROM foo WHERE maybe_bar = $1
 `
 
-func (q *Queries) StringOnNullable(ctx context.Context, maybeBar sql.NullString) ([]sql.NullString, error) {
-	rows, err := q.db.QueryContext(ctx, stringOnNullable, maybeBar)
+func (q *Queries) StringOnNullable(ctx context.Context, maybeBar sql.NullString, aq ...AdditionalQuery) ([]sql.NullString, error) {
+	query := stringOnNullable
+	queryParams := []interface{}{maybeBar}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.QueryContext(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/endtoend/testdata/sqlc_narg/postgresql/stdlib/go_strict/db.go
+++ b/internal/endtoend/testdata/sqlc_narg/postgresql/stdlib/go_strict/db.go
@@ -29,3 +29,8 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/sqlc_narg/postgresql/stdlib/go_strict/db.go
+++ b/internal/endtoend/testdata/sqlc_narg/postgresql/stdlib/go_strict/db.go
@@ -32,5 +32,5 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/sqlc_narg/postgresql/stdlib/go_strict/query.sql.go
+++ b/internal/endtoend/testdata/sqlc_narg/postgresql/stdlib/go_strict/query.sql.go
@@ -14,8 +14,16 @@ const identOnNonNullable = `-- name: IdentOnNonNullable :many
 SELECT bar FROM foo WHERE bar = $1
 `
 
-func (q *Queries) IdentOnNonNullable(ctx context.Context, bar sql.NullString) ([]string, error) {
-	rows, err := q.db.QueryContext(ctx, identOnNonNullable, bar)
+func (q *Queries) IdentOnNonNullable(ctx context.Context, bar sql.NullString, aq ...AdditionalQuery) ([]string, error) {
+	query := identOnNonNullable
+	queryParams := []interface{}{bar}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.QueryContext(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}
@@ -41,8 +49,16 @@ const identOnNullable = `-- name: IdentOnNullable :many
 SELECT maybe_bar FROM foo WHERE maybe_bar = $1
 `
 
-func (q *Queries) IdentOnNullable(ctx context.Context, maybeBar sql.NullString) ([]sql.NullString, error) {
-	rows, err := q.db.QueryContext(ctx, identOnNullable, maybeBar)
+func (q *Queries) IdentOnNullable(ctx context.Context, maybeBar sql.NullString, aq ...AdditionalQuery) ([]sql.NullString, error) {
+	query := identOnNullable
+	queryParams := []interface{}{maybeBar}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.QueryContext(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}
@@ -68,8 +84,16 @@ const stringOnNonNullable = `-- name: StringOnNonNullable :many
 SELECT bar FROM foo WHERE bar = $1
 `
 
-func (q *Queries) StringOnNonNullable(ctx context.Context, bar sql.NullString) ([]string, error) {
-	rows, err := q.db.QueryContext(ctx, stringOnNonNullable, bar)
+func (q *Queries) StringOnNonNullable(ctx context.Context, bar sql.NullString, aq ...AdditionalQuery) ([]string, error) {
+	query := stringOnNonNullable
+	queryParams := []interface{}{bar}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.QueryContext(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}
@@ -95,8 +119,16 @@ const stringOnNullable = `-- name: StringOnNullable :many
 SELECT maybe_bar FROM foo WHERE maybe_bar = $1
 `
 
-func (q *Queries) StringOnNullable(ctx context.Context, maybeBar sql.NullString) ([]sql.NullString, error) {
-	rows, err := q.db.QueryContext(ctx, stringOnNullable, maybeBar)
+func (q *Queries) StringOnNullable(ctx context.Context, maybeBar sql.NullString, aq ...AdditionalQuery) ([]sql.NullString, error) {
+	query := stringOnNullable
+	queryParams := []interface{}{maybeBar}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.QueryContext(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/endtoend/testdata/sqlc_narg/sqlite/go/db.go
+++ b/internal/endtoend/testdata/sqlc_narg/sqlite/go/db.go
@@ -29,3 +29,8 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/sqlc_narg/sqlite/go/db.go
+++ b/internal/endtoend/testdata/sqlc_narg/sqlite/go/db.go
@@ -32,5 +32,5 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/sqlc_narg/sqlite/go/query.sql.go
+++ b/internal/endtoend/testdata/sqlc_narg/sqlite/go/query.sql.go
@@ -14,8 +14,16 @@ const identOnNonNullable = `-- name: IdentOnNonNullable :many
 SELECT bar FROM foo WHERE bar = ?1
 `
 
-func (q *Queries) IdentOnNonNullable(ctx context.Context, bar sql.NullString) ([]string, error) {
-	rows, err := q.db.QueryContext(ctx, identOnNonNullable, bar)
+func (q *Queries) IdentOnNonNullable(ctx context.Context, bar sql.NullString, aq ...AdditionalQuery) ([]string, error) {
+	query := identOnNonNullable
+	queryParams := []interface{}{bar}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.QueryContext(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}
@@ -41,8 +49,16 @@ const identOnNullable = `-- name: IdentOnNullable :many
 SELECT maybe_bar FROM foo WHERE maybe_bar = ?1
 `
 
-func (q *Queries) IdentOnNullable(ctx context.Context, maybeBar sql.NullString) ([]sql.NullString, error) {
-	rows, err := q.db.QueryContext(ctx, identOnNullable, maybeBar)
+func (q *Queries) IdentOnNullable(ctx context.Context, maybeBar sql.NullString, aq ...AdditionalQuery) ([]sql.NullString, error) {
+	query := identOnNullable
+	queryParams := []interface{}{maybeBar}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.QueryContext(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}
@@ -68,8 +84,16 @@ const stringOnNonNullable = `-- name: StringOnNonNullable :many
 SELECT bar FROM foo WHERE bar = ?1
 `
 
-func (q *Queries) StringOnNonNullable(ctx context.Context, bar sql.NullString) ([]string, error) {
-	rows, err := q.db.QueryContext(ctx, stringOnNonNullable, bar)
+func (q *Queries) StringOnNonNullable(ctx context.Context, bar sql.NullString, aq ...AdditionalQuery) ([]string, error) {
+	query := stringOnNonNullable
+	queryParams := []interface{}{bar}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.QueryContext(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}
@@ -95,8 +119,16 @@ const stringOnNullable = `-- name: StringOnNullable :many
 SELECT maybe_bar FROM foo WHERE maybe_bar = ?1
 `
 
-func (q *Queries) StringOnNullable(ctx context.Context, maybeBar sql.NullString) ([]sql.NullString, error) {
-	rows, err := q.db.QueryContext(ctx, stringOnNullable, maybeBar)
+func (q *Queries) StringOnNullable(ctx context.Context, maybeBar sql.NullString, aq ...AdditionalQuery) ([]sql.NullString, error) {
+	query := stringOnNullable
+	queryParams := []interface{}{maybeBar}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.QueryContext(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/endtoend/testdata/sqlc_slice/mysql/go/db.go
+++ b/internal/endtoend/testdata/sqlc_slice/mysql/go/db.go
@@ -29,3 +29,8 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/sqlc_slice/mysql/go/db.go
+++ b/internal/endtoend/testdata/sqlc_slice/mysql/go/db.go
@@ -32,5 +32,5 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/sqlc_slice/mysql/go/query.sql.go
+++ b/internal/endtoend/testdata/sqlc_slice/mysql/go/query.sql.go
@@ -18,7 +18,7 @@ SELECT bar FROM foo
 WHERE id IN (/*SLICE:favourites*/?)
 `
 
-func (q *Queries) FuncNullable(ctx context.Context, favourites []int32) ([]sql.NullString, error) {
+func (q *Queries) FuncNullable(ctx context.Context, favourites []int32, aq ...AdditionalQuery) ([]sql.NullString, error) {
 	query := funcNullable
 	var queryParams []interface{}
 	if len(favourites) > 0 {
@@ -29,6 +29,12 @@ func (q *Queries) FuncNullable(ctx context.Context, favourites []int32) ([]sql.N
 	} else {
 		query = strings.Replace(query, "/*SLICE:favourites*/?", "NULL", 1)
 	}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
 	rows, err := q.db.QueryContext(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
@@ -62,7 +68,7 @@ type FuncParamIdentParams struct {
 	Favourites []int32
 }
 
-func (q *Queries) FuncParamIdent(ctx context.Context, arg FuncParamIdentParams) ([]string, error) {
+func (q *Queries) FuncParamIdent(ctx context.Context, arg FuncParamIdentParams, aq ...AdditionalQuery) ([]string, error) {
 	query := funcParamIdent
 	var queryParams []interface{}
 	queryParams = append(queryParams, arg.Slug)
@@ -74,6 +80,12 @@ func (q *Queries) FuncParamIdent(ctx context.Context, arg FuncParamIdentParams) 
 	} else {
 		query = strings.Replace(query, "/*SLICE:favourites*/?", "NULL", 1)
 	}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
 	rows, err := q.db.QueryContext(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
@@ -101,7 +113,7 @@ SELECT name FROM foo
 WHERE id IN (/*SLICE:favourites*/?)
 `
 
-func (q *Queries) FuncParamSoloArg(ctx context.Context, favourites []int32) ([]string, error) {
+func (q *Queries) FuncParamSoloArg(ctx context.Context, favourites []int32, aq ...AdditionalQuery) ([]string, error) {
 	query := funcParamSoloArg
 	var queryParams []interface{}
 	if len(favourites) > 0 {
@@ -112,6 +124,12 @@ func (q *Queries) FuncParamSoloArg(ctx context.Context, favourites []int32) ([]s
 	} else {
 		query = strings.Replace(query, "/*SLICE:favourites*/?", "NULL", 1)
 	}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
 	rows, err := q.db.QueryContext(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
@@ -145,7 +163,7 @@ type FuncParamStringParams struct {
 	Favourites []int32
 }
 
-func (q *Queries) FuncParamString(ctx context.Context, arg FuncParamStringParams) ([]string, error) {
+func (q *Queries) FuncParamString(ctx context.Context, arg FuncParamStringParams, aq ...AdditionalQuery) ([]string, error) {
 	query := funcParamString
 	var queryParams []interface{}
 	queryParams = append(queryParams, arg.Slug)
@@ -157,6 +175,12 @@ func (q *Queries) FuncParamString(ctx context.Context, arg FuncParamStringParams
 	} else {
 		query = strings.Replace(query, "/*SLICE:favourites*/?", "NULL", 1)
 	}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
 	rows, err := q.db.QueryContext(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
@@ -201,6 +225,7 @@ func (q *Queries) SliceExec(ctx context.Context, arg SliceExecParams) error {
 	} else {
 		query = strings.Replace(query, "/*SLICE:favourites*/?", "NULL", 1)
 	}
+
 	_, err := q.db.ExecContext(ctx, query, queryParams...)
 	return err
 }
@@ -210,7 +235,7 @@ SELECT bar FROM foo
 WHERE mystr IN (/*SLICE:mystr*/?)
 `
 
-func (q *Queries) TypedMyStr(ctx context.Context, mystr []mysql.ID) ([]sql.NullString, error) {
+func (q *Queries) TypedMyStr(ctx context.Context, mystr []mysql.ID, aq ...AdditionalQuery) ([]sql.NullString, error) {
 	query := typedMyStr
 	var queryParams []interface{}
 	if len(mystr) > 0 {
@@ -221,6 +246,12 @@ func (q *Queries) TypedMyStr(ctx context.Context, mystr []mysql.ID) ([]sql.NullS
 	} else {
 		query = strings.Replace(query, "/*SLICE:mystr*/?", "NULL", 1)
 	}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
 	rows, err := q.db.QueryContext(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err

--- a/internal/endtoend/testdata/sqlc_slice/postgresql/pgx/go/db.go
+++ b/internal/endtoend/testdata/sqlc_slice/postgresql/pgx/go/db.go
@@ -33,5 +33,5 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/sqlc_slice/postgresql/pgx/go/db.go
+++ b/internal/endtoend/testdata/sqlc_slice/postgresql/pgx/go/db.go
@@ -30,3 +30,8 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/sqlc_slice/postgresql/pgx/go/query.sql.go
+++ b/internal/endtoend/testdata/sqlc_slice/postgresql/pgx/go/query.sql.go
@@ -13,8 +13,16 @@ const funcParamIdent = `-- name: FuncParamIdent :many
 SELECT name FROM foo WHERE name = $1
 `
 
-func (q *Queries) FuncParamIdent(ctx context.Context, slug string) ([]string, error) {
-	rows, err := q.db.Query(ctx, funcParamIdent, slug)
+func (q *Queries) FuncParamIdent(ctx context.Context, slug string, aq ...AdditionalQuery) ([]string, error) {
+	query := funcParamIdent
+	queryParams := []interface{}{slug}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.Query(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}
@@ -37,8 +45,16 @@ const funcParamString = `-- name: FuncParamString :many
 SELECT name FROM foo WHERE name = $1
 `
 
-func (q *Queries) FuncParamString(ctx context.Context, slug string) ([]string, error) {
-	rows, err := q.db.Query(ctx, funcParamString, slug)
+func (q *Queries) FuncParamString(ctx context.Context, slug string, aq ...AdditionalQuery) ([]string, error) {
+	query := funcParamString
+	queryParams := []interface{}{slug}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.Query(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/endtoend/testdata/sqlc_slice/postgresql/stdlib/go/db.go
+++ b/internal/endtoend/testdata/sqlc_slice/postgresql/stdlib/go/db.go
@@ -29,3 +29,8 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/sqlc_slice/postgresql/stdlib/go/db.go
+++ b/internal/endtoend/testdata/sqlc_slice/postgresql/stdlib/go/db.go
@@ -32,5 +32,5 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/sqlc_slice/postgresql/stdlib/go/query.sql.go
+++ b/internal/endtoend/testdata/sqlc_slice/postgresql/stdlib/go/query.sql.go
@@ -21,7 +21,7 @@ type FuncParamIdentParams struct {
 	Favourites []int32
 }
 
-func (q *Queries) FuncParamIdent(ctx context.Context, arg FuncParamIdentParams) ([]string, error) {
+func (q *Queries) FuncParamIdent(ctx context.Context, arg FuncParamIdentParams, aq ...AdditionalQuery) ([]string, error) {
 	query := funcParamIdent
 	var queryParams []interface{}
 	queryParams = append(queryParams, arg.Slug)
@@ -33,6 +33,12 @@ func (q *Queries) FuncParamIdent(ctx context.Context, arg FuncParamIdentParams) 
 	} else {
 		query = strings.Replace(query, "/*SLICE:favourites*/?", "NULL", 1)
 	}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
 	rows, err := q.db.QueryContext(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
@@ -66,7 +72,7 @@ type FuncParamStringParams struct {
 	Favourites []int32
 }
 
-func (q *Queries) FuncParamString(ctx context.Context, arg FuncParamStringParams) ([]string, error) {
+func (q *Queries) FuncParamString(ctx context.Context, arg FuncParamStringParams, aq ...AdditionalQuery) ([]string, error) {
 	query := funcParamString
 	var queryParams []interface{}
 	queryParams = append(queryParams, arg.Slug)
@@ -78,6 +84,12 @@ func (q *Queries) FuncParamString(ctx context.Context, arg FuncParamStringParams
 	} else {
 		query = strings.Replace(query, "/*SLICE:favourites*/?", "NULL", 1)
 	}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
 	rows, err := q.db.QueryContext(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err

--- a/internal/endtoend/testdata/sqlc_slice/sqlite/go/db.go
+++ b/internal/endtoend/testdata/sqlc_slice/sqlite/go/db.go
@@ -29,3 +29,8 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/sqlc_slice/sqlite/go/db.go
+++ b/internal/endtoend/testdata/sqlc_slice/sqlite/go/db.go
@@ -32,5 +32,5 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/sqlc_slice/sqlite/go/query.sql.go
+++ b/internal/endtoend/testdata/sqlc_slice/sqlite/go/query.sql.go
@@ -16,7 +16,7 @@ SELECT bar FROM foo
 WHERE id IN (/*SLICE:favourites*/?)
 `
 
-func (q *Queries) FuncNullable(ctx context.Context, favourites []int64) ([]sql.NullString, error) {
+func (q *Queries) FuncNullable(ctx context.Context, favourites []int64, aq ...AdditionalQuery) ([]sql.NullString, error) {
 	query := funcNullable
 	var queryParams []interface{}
 	if len(favourites) > 0 {
@@ -27,6 +27,12 @@ func (q *Queries) FuncNullable(ctx context.Context, favourites []int64) ([]sql.N
 	} else {
 		query = strings.Replace(query, "/*SLICE:favourites*/?", "NULL", 1)
 	}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
 	rows, err := q.db.QueryContext(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
@@ -60,7 +66,7 @@ type FuncParamIdentParams struct {
 	Favourites []int64
 }
 
-func (q *Queries) FuncParamIdent(ctx context.Context, arg FuncParamIdentParams) ([]string, error) {
+func (q *Queries) FuncParamIdent(ctx context.Context, arg FuncParamIdentParams, aq ...AdditionalQuery) ([]string, error) {
 	query := funcParamIdent
 	var queryParams []interface{}
 	queryParams = append(queryParams, arg.Slug)
@@ -72,6 +78,12 @@ func (q *Queries) FuncParamIdent(ctx context.Context, arg FuncParamIdentParams) 
 	} else {
 		query = strings.Replace(query, "/*SLICE:favourites*/?", "NULL", 1)
 	}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
 	rows, err := q.db.QueryContext(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
@@ -99,7 +111,7 @@ SELECT name FROM foo
 WHERE id IN (/*SLICE:favourites*/?)
 `
 
-func (q *Queries) FuncParamSoloArg(ctx context.Context, favourites []int64) ([]string, error) {
+func (q *Queries) FuncParamSoloArg(ctx context.Context, favourites []int64, aq ...AdditionalQuery) ([]string, error) {
 	query := funcParamSoloArg
 	var queryParams []interface{}
 	if len(favourites) > 0 {
@@ -110,6 +122,12 @@ func (q *Queries) FuncParamSoloArg(ctx context.Context, favourites []int64) ([]s
 	} else {
 		query = strings.Replace(query, "/*SLICE:favourites*/?", "NULL", 1)
 	}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
 	rows, err := q.db.QueryContext(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
@@ -143,7 +161,7 @@ type FuncParamStringParams struct {
 	Favourites []int64
 }
 
-func (q *Queries) FuncParamString(ctx context.Context, arg FuncParamStringParams) ([]string, error) {
+func (q *Queries) FuncParamString(ctx context.Context, arg FuncParamStringParams, aq ...AdditionalQuery) ([]string, error) {
 	query := funcParamString
 	var queryParams []interface{}
 	queryParams = append(queryParams, arg.Slug)
@@ -155,6 +173,12 @@ func (q *Queries) FuncParamString(ctx context.Context, arg FuncParamStringParams
 	} else {
 		query = strings.Replace(query, "/*SLICE:favourites*/?", "NULL", 1)
 	}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
 	rows, err := q.db.QueryContext(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
@@ -199,6 +223,7 @@ func (q *Queries) SliceExec(ctx context.Context, arg SliceExecParams) error {
 	} else {
 		query = strings.Replace(query, "/*SLICE:favourites*/?", "NULL", 1)
 	}
+
 	_, err := q.db.ExecContext(ctx, query, queryParams...)
 	return err
 }

--- a/internal/endtoend/testdata/sqlc_slice_prepared/sqlite/go/db.go
+++ b/internal/endtoend/testdata/sqlc_slice_prepared/sqlite/go/db.go
@@ -86,3 +86,8 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 		funcParamIdentStmt: q.funcParamIdentStmt,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/sqlc_slice_prepared/sqlite/go/db.go
+++ b/internal/endtoend/testdata/sqlc_slice_prepared/sqlite/go/db.go
@@ -89,5 +89,5 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/sqlc_slice_prepared/sqlite/go/query.sql.go
+++ b/internal/endtoend/testdata/sqlc_slice_prepared/sqlite/go/query.sql.go
@@ -21,7 +21,7 @@ type FuncParamIdentParams struct {
 	Favourites []int64
 }
 
-func (q *Queries) FuncParamIdent(ctx context.Context, arg FuncParamIdentParams) ([]string, error) {
+func (q *Queries) FuncParamIdent(ctx context.Context, arg FuncParamIdentParams, aq ...AdditionalQuery) ([]string, error) {
 	query := funcParamIdent
 	var queryParams []interface{}
 	queryParams = append(queryParams, arg.Slug)
@@ -33,6 +33,12 @@ func (q *Queries) FuncParamIdent(ctx context.Context, arg FuncParamIdentParams) 
 	} else {
 		query = strings.Replace(query, "/*SLICE:favourites*/?", "NULL", 1)
 	}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
 	rows, err := q.query(ctx, nil, query, queryParams...)
 	if err != nil {
 		return nil, err

--- a/internal/endtoend/testdata/sqlite_table_options/sqlite/go/db.go
+++ b/internal/endtoend/testdata/sqlite_table_options/sqlite/go/db.go
@@ -29,3 +29,8 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/sqlite_table_options/sqlite/go/db.go
+++ b/internal/endtoend/testdata/sqlite_table_options/sqlite/go/db.go
@@ -32,5 +32,5 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/sqlite_table_options/sqlite/go/query.sql.go
+++ b/internal/endtoend/testdata/sqlite_table_options/sqlite/go/query.sql.go
@@ -14,8 +14,16 @@ SELECT id, name, bio FROM authors1
 WHERE id = ?1 LIMIT 1
 `
 
-func (q *Queries) GetAuthor(ctx context.Context, id int64) (Authors1, error) {
-	row := q.db.QueryRowContext(ctx, getAuthor, id)
+func (q *Queries) GetAuthor(ctx context.Context, id int64, aq ...AdditionalQuery) (Authors1, error) {
+	query := getAuthor
+	queryParams := []interface{}{id}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	row := q.db.QueryRowContext(ctx, query, queryParams...)
 	var i Authors1
 	err := row.Scan(&i.ID, &i.Name, &i.Bio)
 	return i, err

--- a/internal/endtoend/testdata/star_expansion/mysql/go/db.go
+++ b/internal/endtoend/testdata/star_expansion/mysql/go/db.go
@@ -29,3 +29,8 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/star_expansion/mysql/go/db.go
+++ b/internal/endtoend/testdata/star_expansion/mysql/go/db.go
@@ -32,5 +32,5 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/star_expansion/mysql/go/query.sql.go
+++ b/internal/endtoend/testdata/star_expansion/mysql/go/query.sql.go
@@ -23,8 +23,16 @@ type StarExpansionRow struct {
 	B_3 sql.NullString
 }
 
-func (q *Queries) StarExpansion(ctx context.Context) ([]StarExpansionRow, error) {
-	rows, err := q.db.QueryContext(ctx, starExpansion)
+func (q *Queries) StarExpansion(ctx context.Context, aq ...AdditionalQuery) ([]StarExpansionRow, error) {
+	query := starExpansion
+	queryParams := []interface{}{}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.QueryContext(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/endtoend/testdata/star_expansion/postgresql/pgx/v4/go/db.go
+++ b/internal/endtoend/testdata/star_expansion/postgresql/pgx/v4/go/db.go
@@ -33,5 +33,5 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/star_expansion/postgresql/pgx/v4/go/db.go
+++ b/internal/endtoend/testdata/star_expansion/postgresql/pgx/v4/go/db.go
@@ -30,3 +30,8 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/star_expansion/postgresql/pgx/v4/go/query.sql.go
+++ b/internal/endtoend/testdata/star_expansion/postgresql/pgx/v4/go/query.sql.go
@@ -23,8 +23,16 @@ type StarExpansionRow struct {
 	B_3 sql.NullString
 }
 
-func (q *Queries) StarExpansion(ctx context.Context) ([]StarExpansionRow, error) {
-	rows, err := q.db.Query(ctx, starExpansion)
+func (q *Queries) StarExpansion(ctx context.Context, aq ...AdditionalQuery) ([]StarExpansionRow, error) {
+	query := starExpansion
+	queryParams := []interface{}{}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.Query(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/endtoend/testdata/star_expansion/postgresql/pgx/v5/go/db.go
+++ b/internal/endtoend/testdata/star_expansion/postgresql/pgx/v5/go/db.go
@@ -33,5 +33,5 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/star_expansion/postgresql/pgx/v5/go/db.go
+++ b/internal/endtoend/testdata/star_expansion/postgresql/pgx/v5/go/db.go
@@ -30,3 +30,8 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/star_expansion/postgresql/pgx/v5/go/query.sql.go
+++ b/internal/endtoend/testdata/star_expansion/postgresql/pgx/v5/go/query.sql.go
@@ -24,8 +24,16 @@ type StarExpansionRow struct {
 	B_3 pgtype.Text
 }
 
-func (q *Queries) StarExpansion(ctx context.Context) ([]StarExpansionRow, error) {
-	rows, err := q.db.Query(ctx, starExpansion)
+func (q *Queries) StarExpansion(ctx context.Context, aq ...AdditionalQuery) ([]StarExpansionRow, error) {
+	query := starExpansion
+	queryParams := []interface{}{}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.Query(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/endtoend/testdata/star_expansion/postgresql/stdlib/go/db.go
+++ b/internal/endtoend/testdata/star_expansion/postgresql/stdlib/go/db.go
@@ -29,3 +29,8 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/star_expansion/postgresql/stdlib/go/db.go
+++ b/internal/endtoend/testdata/star_expansion/postgresql/stdlib/go/db.go
@@ -32,5 +32,5 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/star_expansion/postgresql/stdlib/go/query.sql.go
+++ b/internal/endtoend/testdata/star_expansion/postgresql/stdlib/go/query.sql.go
@@ -23,8 +23,16 @@ type StarExpansionRow struct {
 	B_3 sql.NullString
 }
 
-func (q *Queries) StarExpansion(ctx context.Context) ([]StarExpansionRow, error) {
-	rows, err := q.db.QueryContext(ctx, starExpansion)
+func (q *Queries) StarExpansion(ctx context.Context, aq ...AdditionalQuery) ([]StarExpansionRow, error) {
+	query := starExpansion
+	queryParams := []interface{}{}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.QueryContext(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/endtoend/testdata/star_expansion_cte/pgx/v4/go/db.go
+++ b/internal/endtoend/testdata/star_expansion_cte/pgx/v4/go/db.go
@@ -33,5 +33,5 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/star_expansion_cte/pgx/v4/go/db.go
+++ b/internal/endtoend/testdata/star_expansion_cte/pgx/v4/go/db.go
@@ -30,3 +30,8 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/star_expansion_cte/pgx/v4/go/query.sql.go
+++ b/internal/endtoend/testdata/star_expansion_cte/pgx/v4/go/query.sql.go
@@ -14,8 +14,16 @@ const starExpansionCTE = `-- name: StarExpansionCTE :many
 WITH cte AS (SELECT a, b FROM foo) SELECT c, d FROM bar
 `
 
-func (q *Queries) StarExpansionCTE(ctx context.Context) ([]Bar, error) {
-	rows, err := q.db.Query(ctx, starExpansionCTE)
+func (q *Queries) StarExpansionCTE(ctx context.Context, aq ...AdditionalQuery) ([]Bar, error) {
+	query := starExpansionCTE
+	queryParams := []interface{}{}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.Query(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}
@@ -47,8 +55,16 @@ type StarExpansionTwoCTERow struct {
 	B   sql.NullString
 }
 
-func (q *Queries) StarExpansionTwoCTE(ctx context.Context) ([]StarExpansionTwoCTERow, error) {
-	rows, err := q.db.Query(ctx, starExpansionTwoCTE)
+func (q *Queries) StarExpansionTwoCTE(ctx context.Context, aq ...AdditionalQuery) ([]StarExpansionTwoCTERow, error) {
+	query := starExpansionTwoCTE
+	queryParams := []interface{}{}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.Query(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/endtoend/testdata/star_expansion_cte/pgx/v5/go/db.go
+++ b/internal/endtoend/testdata/star_expansion_cte/pgx/v5/go/db.go
@@ -33,5 +33,5 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/star_expansion_cte/pgx/v5/go/db.go
+++ b/internal/endtoend/testdata/star_expansion_cte/pgx/v5/go/db.go
@@ -30,3 +30,8 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/star_expansion_cte/pgx/v5/go/query.sql.go
+++ b/internal/endtoend/testdata/star_expansion_cte/pgx/v5/go/query.sql.go
@@ -15,8 +15,16 @@ const starExpansionCTE = `-- name: StarExpansionCTE :many
 WITH cte AS (SELECT a, b FROM foo) SELECT c, d FROM bar
 `
 
-func (q *Queries) StarExpansionCTE(ctx context.Context) ([]Bar, error) {
-	rows, err := q.db.Query(ctx, starExpansionCTE)
+func (q *Queries) StarExpansionCTE(ctx context.Context, aq ...AdditionalQuery) ([]Bar, error) {
+	query := starExpansionCTE
+	queryParams := []interface{}{}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.Query(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}
@@ -48,8 +56,16 @@ type StarExpansionTwoCTERow struct {
 	B   pgtype.Text
 }
 
-func (q *Queries) StarExpansionTwoCTE(ctx context.Context) ([]StarExpansionTwoCTERow, error) {
-	rows, err := q.db.Query(ctx, starExpansionTwoCTE)
+func (q *Queries) StarExpansionTwoCTE(ctx context.Context, aq ...AdditionalQuery) ([]StarExpansionTwoCTERow, error) {
+	query := starExpansionTwoCTE
+	queryParams := []interface{}{}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.Query(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/endtoend/testdata/star_expansion_cte/stdlib/go/db.go
+++ b/internal/endtoend/testdata/star_expansion_cte/stdlib/go/db.go
@@ -29,3 +29,8 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/star_expansion_cte/stdlib/go/db.go
+++ b/internal/endtoend/testdata/star_expansion_cte/stdlib/go/db.go
@@ -32,5 +32,5 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/star_expansion_cte/stdlib/go/query.sql.go
+++ b/internal/endtoend/testdata/star_expansion_cte/stdlib/go/query.sql.go
@@ -14,8 +14,16 @@ const starExpansionCTE = `-- name: StarExpansionCTE :many
 WITH cte AS (SELECT a, b FROM foo) SELECT c, d FROM bar
 `
 
-func (q *Queries) StarExpansionCTE(ctx context.Context) ([]Bar, error) {
-	rows, err := q.db.QueryContext(ctx, starExpansionCTE)
+func (q *Queries) StarExpansionCTE(ctx context.Context, aq ...AdditionalQuery) ([]Bar, error) {
+	query := starExpansionCTE
+	queryParams := []interface{}{}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.QueryContext(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}
@@ -50,8 +58,16 @@ type StarExpansionTwoCTERow struct {
 	B   sql.NullString
 }
 
-func (q *Queries) StarExpansionTwoCTE(ctx context.Context) ([]StarExpansionTwoCTERow, error) {
-	rows, err := q.db.QueryContext(ctx, starExpansionTwoCTE)
+func (q *Queries) StarExpansionTwoCTE(ctx context.Context, aq ...AdditionalQuery) ([]StarExpansionTwoCTERow, error) {
+	query := starExpansionTwoCTE
+	queryParams := []interface{}{}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.QueryContext(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/endtoend/testdata/star_expansion_from_cte/pgx/v4/go/db.go
+++ b/internal/endtoend/testdata/star_expansion_from_cte/pgx/v4/go/db.go
@@ -33,5 +33,5 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/star_expansion_from_cte/pgx/v4/go/db.go
+++ b/internal/endtoend/testdata/star_expansion_from_cte/pgx/v4/go/db.go
@@ -30,3 +30,8 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/star_expansion_from_cte/pgx/v4/go/query.sql.go
+++ b/internal/endtoend/testdata/star_expansion_from_cte/pgx/v4/go/query.sql.go
@@ -19,8 +19,16 @@ type StarExpansionCTERow struct {
 	B sql.NullString
 }
 
-func (q *Queries) StarExpansionCTE(ctx context.Context) ([]StarExpansionCTERow, error) {
-	rows, err := q.db.Query(ctx, starExpansionCTE)
+func (q *Queries) StarExpansionCTE(ctx context.Context, aq ...AdditionalQuery) ([]StarExpansionCTERow, error) {
+	query := starExpansionCTE
+	queryParams := []interface{}{}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.Query(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/endtoend/testdata/star_expansion_from_cte/pgx/v5/go/db.go
+++ b/internal/endtoend/testdata/star_expansion_from_cte/pgx/v5/go/db.go
@@ -33,5 +33,5 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/star_expansion_from_cte/pgx/v5/go/db.go
+++ b/internal/endtoend/testdata/star_expansion_from_cte/pgx/v5/go/db.go
@@ -30,3 +30,8 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/star_expansion_from_cte/pgx/v5/go/query.sql.go
+++ b/internal/endtoend/testdata/star_expansion_from_cte/pgx/v5/go/query.sql.go
@@ -20,8 +20,16 @@ type StarExpansionCTERow struct {
 	B pgtype.Text
 }
 
-func (q *Queries) StarExpansionCTE(ctx context.Context) ([]StarExpansionCTERow, error) {
-	rows, err := q.db.Query(ctx, starExpansionCTE)
+func (q *Queries) StarExpansionCTE(ctx context.Context, aq ...AdditionalQuery) ([]StarExpansionCTERow, error) {
+	query := starExpansionCTE
+	queryParams := []interface{}{}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.Query(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/endtoend/testdata/star_expansion_from_cte/stdlib/go/db.go
+++ b/internal/endtoend/testdata/star_expansion_from_cte/stdlib/go/db.go
@@ -29,3 +29,8 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/star_expansion_from_cte/stdlib/go/db.go
+++ b/internal/endtoend/testdata/star_expansion_from_cte/stdlib/go/db.go
@@ -32,5 +32,5 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/star_expansion_from_cte/stdlib/go/query.sql.go
+++ b/internal/endtoend/testdata/star_expansion_from_cte/stdlib/go/query.sql.go
@@ -19,8 +19,16 @@ type StarExpansionCTERow struct {
 	B sql.NullString
 }
 
-func (q *Queries) StarExpansionCTE(ctx context.Context) ([]StarExpansionCTERow, error) {
-	rows, err := q.db.QueryContext(ctx, starExpansionCTE)
+func (q *Queries) StarExpansionCTE(ctx context.Context, aq ...AdditionalQuery) ([]StarExpansionCTERow, error) {
+	query := starExpansionCTE
+	queryParams := []interface{}{}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.QueryContext(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/endtoend/testdata/star_expansion_join/mysql/go/db.go
+++ b/internal/endtoend/testdata/star_expansion_join/mysql/go/db.go
@@ -29,3 +29,8 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/star_expansion_join/mysql/go/db.go
+++ b/internal/endtoend/testdata/star_expansion_join/mysql/go/db.go
@@ -32,5 +32,5 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/star_expansion_join/mysql/go/query.sql.go
+++ b/internal/endtoend/testdata/star_expansion_join/mysql/go/query.sql.go
@@ -21,8 +21,16 @@ type StarExpansionJoinRow struct {
 	D sql.NullString
 }
 
-func (q *Queries) StarExpansionJoin(ctx context.Context) ([]StarExpansionJoinRow, error) {
-	rows, err := q.db.QueryContext(ctx, starExpansionJoin)
+func (q *Queries) StarExpansionJoin(ctx context.Context, aq ...AdditionalQuery) ([]StarExpansionJoinRow, error) {
+	query := starExpansionJoin
+	queryParams := []interface{}{}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.QueryContext(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/endtoend/testdata/star_expansion_join/postgresql/pgx/v4/go/db.go
+++ b/internal/endtoend/testdata/star_expansion_join/postgresql/pgx/v4/go/db.go
@@ -33,5 +33,5 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/star_expansion_join/postgresql/pgx/v4/go/db.go
+++ b/internal/endtoend/testdata/star_expansion_join/postgresql/pgx/v4/go/db.go
@@ -30,3 +30,8 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/star_expansion_join/postgresql/pgx/v4/go/query.sql.go
+++ b/internal/endtoend/testdata/star_expansion_join/postgresql/pgx/v4/go/query.sql.go
@@ -21,8 +21,16 @@ type StarExpansionJoinRow struct {
 	D sql.NullString
 }
 
-func (q *Queries) StarExpansionJoin(ctx context.Context) ([]StarExpansionJoinRow, error) {
-	rows, err := q.db.Query(ctx, starExpansionJoin)
+func (q *Queries) StarExpansionJoin(ctx context.Context, aq ...AdditionalQuery) ([]StarExpansionJoinRow, error) {
+	query := starExpansionJoin
+	queryParams := []interface{}{}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.Query(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/endtoend/testdata/star_expansion_join/postgresql/pgx/v5/go/db.go
+++ b/internal/endtoend/testdata/star_expansion_join/postgresql/pgx/v5/go/db.go
@@ -33,5 +33,5 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/star_expansion_join/postgresql/pgx/v5/go/db.go
+++ b/internal/endtoend/testdata/star_expansion_join/postgresql/pgx/v5/go/db.go
@@ -30,3 +30,8 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/star_expansion_join/postgresql/pgx/v5/go/query.sql.go
+++ b/internal/endtoend/testdata/star_expansion_join/postgresql/pgx/v5/go/query.sql.go
@@ -22,8 +22,16 @@ type StarExpansionJoinRow struct {
 	D pgtype.Text
 }
 
-func (q *Queries) StarExpansionJoin(ctx context.Context) ([]StarExpansionJoinRow, error) {
-	rows, err := q.db.Query(ctx, starExpansionJoin)
+func (q *Queries) StarExpansionJoin(ctx context.Context, aq ...AdditionalQuery) ([]StarExpansionJoinRow, error) {
+	query := starExpansionJoin
+	queryParams := []interface{}{}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.Query(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/endtoend/testdata/star_expansion_join/postgresql/stdlib/go/db.go
+++ b/internal/endtoend/testdata/star_expansion_join/postgresql/stdlib/go/db.go
@@ -29,3 +29,8 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/star_expansion_join/postgresql/stdlib/go/db.go
+++ b/internal/endtoend/testdata/star_expansion_join/postgresql/stdlib/go/db.go
@@ -32,5 +32,5 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/star_expansion_join/postgresql/stdlib/go/query.sql.go
+++ b/internal/endtoend/testdata/star_expansion_join/postgresql/stdlib/go/query.sql.go
@@ -21,8 +21,16 @@ type StarExpansionJoinRow struct {
 	D sql.NullString
 }
 
-func (q *Queries) StarExpansionJoin(ctx context.Context) ([]StarExpansionJoinRow, error) {
-	rows, err := q.db.QueryContext(ctx, starExpansionJoin)
+func (q *Queries) StarExpansionJoin(ctx context.Context, aq ...AdditionalQuery) ([]StarExpansionJoinRow, error) {
+	query := starExpansionJoin
+	queryParams := []interface{}{}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.QueryContext(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/endtoend/testdata/star_expansion_reserved/mysql/go/db.go
+++ b/internal/endtoend/testdata/star_expansion_reserved/mysql/go/db.go
@@ -29,3 +29,8 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/star_expansion_reserved/mysql/go/db.go
+++ b/internal/endtoend/testdata/star_expansion_reserved/mysql/go/db.go
@@ -32,5 +32,5 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/star_expansion_reserved/mysql/go/query.sql.go
+++ b/internal/endtoend/testdata/star_expansion_reserved/mysql/go/query.sql.go
@@ -13,8 +13,16 @@ const starExpansionReserved = `-- name: StarExpansionReserved :many
 SELECT ` + "`" + `group` + "`" + `, ` + "`" + `key` + "`" + ` FROM foo
 `
 
-func (q *Queries) StarExpansionReserved(ctx context.Context) ([]Foo, error) {
-	rows, err := q.db.QueryContext(ctx, starExpansionReserved)
+func (q *Queries) StarExpansionReserved(ctx context.Context, aq ...AdditionalQuery) ([]Foo, error) {
+	query := starExpansionReserved
+	queryParams := []interface{}{}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.QueryContext(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/endtoend/testdata/star_expansion_reserved/postgresql/pgx/v4/go/db.go
+++ b/internal/endtoend/testdata/star_expansion_reserved/postgresql/pgx/v4/go/db.go
@@ -33,5 +33,5 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/star_expansion_reserved/postgresql/pgx/v4/go/db.go
+++ b/internal/endtoend/testdata/star_expansion_reserved/postgresql/pgx/v4/go/db.go
@@ -30,3 +30,8 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/star_expansion_reserved/postgresql/pgx/v4/go/query.sql.go
+++ b/internal/endtoend/testdata/star_expansion_reserved/postgresql/pgx/v4/go/query.sql.go
@@ -13,8 +13,16 @@ const starExpansionReserved = `-- name: StarExpansionReserved :many
 SELECT "group", key FROM foo
 `
 
-func (q *Queries) StarExpansionReserved(ctx context.Context) ([]Foo, error) {
-	rows, err := q.db.Query(ctx, starExpansionReserved)
+func (q *Queries) StarExpansionReserved(ctx context.Context, aq ...AdditionalQuery) ([]Foo, error) {
+	query := starExpansionReserved
+	queryParams := []interface{}{}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.Query(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/endtoend/testdata/star_expansion_reserved/postgresql/pgx/v5/go/db.go
+++ b/internal/endtoend/testdata/star_expansion_reserved/postgresql/pgx/v5/go/db.go
@@ -33,5 +33,5 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/star_expansion_reserved/postgresql/pgx/v5/go/db.go
+++ b/internal/endtoend/testdata/star_expansion_reserved/postgresql/pgx/v5/go/db.go
@@ -30,3 +30,8 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/star_expansion_reserved/postgresql/pgx/v5/go/query.sql.go
+++ b/internal/endtoend/testdata/star_expansion_reserved/postgresql/pgx/v5/go/query.sql.go
@@ -13,8 +13,16 @@ const starExpansionReserved = `-- name: StarExpansionReserved :many
 SELECT "group", key FROM foo
 `
 
-func (q *Queries) StarExpansionReserved(ctx context.Context) ([]Foo, error) {
-	rows, err := q.db.Query(ctx, starExpansionReserved)
+func (q *Queries) StarExpansionReserved(ctx context.Context, aq ...AdditionalQuery) ([]Foo, error) {
+	query := starExpansionReserved
+	queryParams := []interface{}{}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.Query(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/endtoend/testdata/star_expansion_reserved/postgresql/stdlib/go/db.go
+++ b/internal/endtoend/testdata/star_expansion_reserved/postgresql/stdlib/go/db.go
@@ -29,3 +29,8 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/star_expansion_reserved/postgresql/stdlib/go/db.go
+++ b/internal/endtoend/testdata/star_expansion_reserved/postgresql/stdlib/go/db.go
@@ -32,5 +32,5 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/star_expansion_reserved/postgresql/stdlib/go/query.sql.go
+++ b/internal/endtoend/testdata/star_expansion_reserved/postgresql/stdlib/go/query.sql.go
@@ -13,8 +13,16 @@ const starExpansionReserved = `-- name: StarExpansionReserved :many
 SELECT "group", key FROM foo
 `
 
-func (q *Queries) StarExpansionReserved(ctx context.Context) ([]Foo, error) {
-	rows, err := q.db.QueryContext(ctx, starExpansionReserved)
+func (q *Queries) StarExpansionReserved(ctx context.Context, aq ...AdditionalQuery) ([]Foo, error) {
+	query := starExpansionReserved
+	queryParams := []interface{}{}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.QueryContext(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/endtoend/testdata/star_expansion_subquery/mysql/go/db.go
+++ b/internal/endtoend/testdata/star_expansion_subquery/mysql/go/db.go
@@ -29,3 +29,8 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/star_expansion_subquery/mysql/go/db.go
+++ b/internal/endtoend/testdata/star_expansion_subquery/mysql/go/db.go
@@ -32,5 +32,5 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/star_expansion_subquery/mysql/go/query.sql.go
+++ b/internal/endtoend/testdata/star_expansion_subquery/mysql/go/query.sql.go
@@ -13,8 +13,16 @@ const starExpansionSubquery = `-- name: StarExpansionSubquery :many
 SELECT a, b FROM foo WHERE EXISTS (SELECT a, b FROM foo)
 `
 
-func (q *Queries) StarExpansionSubquery(ctx context.Context) ([]Foo, error) {
-	rows, err := q.db.QueryContext(ctx, starExpansionSubquery)
+func (q *Queries) StarExpansionSubquery(ctx context.Context, aq ...AdditionalQuery) ([]Foo, error) {
+	query := starExpansionSubquery
+	queryParams := []interface{}{}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.QueryContext(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/endtoend/testdata/star_expansion_subquery/postgresql/pgx/v4/go/db.go
+++ b/internal/endtoend/testdata/star_expansion_subquery/postgresql/pgx/v4/go/db.go
@@ -33,5 +33,5 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/star_expansion_subquery/postgresql/pgx/v4/go/db.go
+++ b/internal/endtoend/testdata/star_expansion_subquery/postgresql/pgx/v4/go/db.go
@@ -30,3 +30,8 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/star_expansion_subquery/postgresql/pgx/v4/go/query.sql.go
+++ b/internal/endtoend/testdata/star_expansion_subquery/postgresql/pgx/v4/go/query.sql.go
@@ -13,8 +13,16 @@ const starExpansionSubquery = `-- name: StarExpansionSubquery :many
 SELECT a, b FROM foo WHERE EXISTS (SELECT a, b FROM foo)
 `
 
-func (q *Queries) StarExpansionSubquery(ctx context.Context) ([]Foo, error) {
-	rows, err := q.db.Query(ctx, starExpansionSubquery)
+func (q *Queries) StarExpansionSubquery(ctx context.Context, aq ...AdditionalQuery) ([]Foo, error) {
+	query := starExpansionSubquery
+	queryParams := []interface{}{}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.Query(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/endtoend/testdata/star_expansion_subquery/postgresql/pgx/v5/go/db.go
+++ b/internal/endtoend/testdata/star_expansion_subquery/postgresql/pgx/v5/go/db.go
@@ -33,5 +33,5 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/star_expansion_subquery/postgresql/pgx/v5/go/db.go
+++ b/internal/endtoend/testdata/star_expansion_subquery/postgresql/pgx/v5/go/db.go
@@ -30,3 +30,8 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/star_expansion_subquery/postgresql/pgx/v5/go/query.sql.go
+++ b/internal/endtoend/testdata/star_expansion_subquery/postgresql/pgx/v5/go/query.sql.go
@@ -13,8 +13,16 @@ const starExpansionSubquery = `-- name: StarExpansionSubquery :many
 SELECT a, b FROM foo WHERE EXISTS (SELECT a, b FROM foo)
 `
 
-func (q *Queries) StarExpansionSubquery(ctx context.Context) ([]Foo, error) {
-	rows, err := q.db.Query(ctx, starExpansionSubquery)
+func (q *Queries) StarExpansionSubquery(ctx context.Context, aq ...AdditionalQuery) ([]Foo, error) {
+	query := starExpansionSubquery
+	queryParams := []interface{}{}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.Query(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/endtoend/testdata/star_expansion_subquery/postgresql/stdlib/go/db.go
+++ b/internal/endtoend/testdata/star_expansion_subquery/postgresql/stdlib/go/db.go
@@ -29,3 +29,8 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/star_expansion_subquery/postgresql/stdlib/go/db.go
+++ b/internal/endtoend/testdata/star_expansion_subquery/postgresql/stdlib/go/db.go
@@ -32,5 +32,5 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/star_expansion_subquery/postgresql/stdlib/go/query.sql.go
+++ b/internal/endtoend/testdata/star_expansion_subquery/postgresql/stdlib/go/query.sql.go
@@ -13,8 +13,16 @@ const starExpansionSubquery = `-- name: StarExpansionSubquery :many
 SELECT a, b FROM foo WHERE EXISTS (SELECT a, b FROM foo)
 `
 
-func (q *Queries) StarExpansionSubquery(ctx context.Context) ([]Foo, error) {
-	rows, err := q.db.QueryContext(ctx, starExpansionSubquery)
+func (q *Queries) StarExpansionSubquery(ctx context.Context, aq ...AdditionalQuery) ([]Foo, error) {
+	query := starExpansionSubquery
+	queryParams := []interface{}{}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.QueryContext(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/endtoend/testdata/subquery_calculated_column/mysql/go/db.go
+++ b/internal/endtoend/testdata/subquery_calculated_column/mysql/go/db.go
@@ -29,3 +29,8 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/subquery_calculated_column/mysql/go/db.go
+++ b/internal/endtoend/testdata/subquery_calculated_column/mysql/go/db.go
@@ -32,5 +32,5 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/subquery_calculated_column/mysql/go/query.sql.go
+++ b/internal/endtoend/testdata/subquery_calculated_column/mysql/go/query.sql.go
@@ -13,8 +13,16 @@ const subqueryCalcColumn = `-- name: SubqueryCalcColumn :many
 SELECT sum FROM (SELECT a + b AS sum FROM foo) AS f
 `
 
-func (q *Queries) SubqueryCalcColumn(ctx context.Context) ([]int32, error) {
-	rows, err := q.db.QueryContext(ctx, subqueryCalcColumn)
+func (q *Queries) SubqueryCalcColumn(ctx context.Context, aq ...AdditionalQuery) ([]int32, error) {
+	query := subqueryCalcColumn
+	queryParams := []interface{}{}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.QueryContext(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/endtoend/testdata/subquery_calculated_column/postgresql/pgx/v4/go/db.go
+++ b/internal/endtoend/testdata/subquery_calculated_column/postgresql/pgx/v4/go/db.go
@@ -33,5 +33,5 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/subquery_calculated_column/postgresql/pgx/v4/go/db.go
+++ b/internal/endtoend/testdata/subquery_calculated_column/postgresql/pgx/v4/go/db.go
@@ -30,3 +30,8 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/subquery_calculated_column/postgresql/pgx/v4/go/query.sql.go
+++ b/internal/endtoend/testdata/subquery_calculated_column/postgresql/pgx/v4/go/query.sql.go
@@ -13,8 +13,16 @@ const subqueryCalcColumn = `-- name: SubqueryCalcColumn :many
 SELECT sum FROM (SELECT a + b AS sum FROM foo) AS f
 `
 
-func (q *Queries) SubqueryCalcColumn(ctx context.Context) ([]int32, error) {
-	rows, err := q.db.Query(ctx, subqueryCalcColumn)
+func (q *Queries) SubqueryCalcColumn(ctx context.Context, aq ...AdditionalQuery) ([]int32, error) {
+	query := subqueryCalcColumn
+	queryParams := []interface{}{}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.Query(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/endtoend/testdata/subquery_calculated_column/postgresql/pgx/v5/go/db.go
+++ b/internal/endtoend/testdata/subquery_calculated_column/postgresql/pgx/v5/go/db.go
@@ -33,5 +33,5 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/subquery_calculated_column/postgresql/pgx/v5/go/db.go
+++ b/internal/endtoend/testdata/subquery_calculated_column/postgresql/pgx/v5/go/db.go
@@ -30,3 +30,8 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/subquery_calculated_column/postgresql/pgx/v5/go/query.sql.go
+++ b/internal/endtoend/testdata/subquery_calculated_column/postgresql/pgx/v5/go/query.sql.go
@@ -13,8 +13,16 @@ const subqueryCalcColumn = `-- name: SubqueryCalcColumn :many
 SELECT sum FROM (SELECT a + b AS sum FROM foo) AS f
 `
 
-func (q *Queries) SubqueryCalcColumn(ctx context.Context) ([]int32, error) {
-	rows, err := q.db.Query(ctx, subqueryCalcColumn)
+func (q *Queries) SubqueryCalcColumn(ctx context.Context, aq ...AdditionalQuery) ([]int32, error) {
+	query := subqueryCalcColumn
+	queryParams := []interface{}{}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.Query(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/endtoend/testdata/subquery_calculated_column/postgresql/stdlib/go/db.go
+++ b/internal/endtoend/testdata/subquery_calculated_column/postgresql/stdlib/go/db.go
@@ -29,3 +29,8 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/subquery_calculated_column/postgresql/stdlib/go/db.go
+++ b/internal/endtoend/testdata/subquery_calculated_column/postgresql/stdlib/go/db.go
@@ -32,5 +32,5 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/subquery_calculated_column/postgresql/stdlib/go/query.sql.go
+++ b/internal/endtoend/testdata/subquery_calculated_column/postgresql/stdlib/go/query.sql.go
@@ -13,8 +13,16 @@ const subqueryCalcColumn = `-- name: SubqueryCalcColumn :many
 SELECT sum FROM (SELECT a + b AS sum FROM foo) AS f
 `
 
-func (q *Queries) SubqueryCalcColumn(ctx context.Context) ([]int32, error) {
-	rows, err := q.db.QueryContext(ctx, subqueryCalcColumn)
+func (q *Queries) SubqueryCalcColumn(ctx context.Context, aq ...AdditionalQuery) ([]int32, error) {
+	query := subqueryCalcColumn
+	queryParams := []interface{}{}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.QueryContext(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/endtoend/testdata/subquery_calculated_column/sqlite/go/db.go
+++ b/internal/endtoend/testdata/subquery_calculated_column/sqlite/go/db.go
@@ -29,3 +29,8 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/subquery_calculated_column/sqlite/go/db.go
+++ b/internal/endtoend/testdata/subquery_calculated_column/sqlite/go/db.go
@@ -32,5 +32,5 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/subquery_calculated_column/sqlite/go/query.sql.go
+++ b/internal/endtoend/testdata/subquery_calculated_column/sqlite/go/query.sql.go
@@ -13,8 +13,16 @@ const subqueryCalcColumn = `-- name: SubqueryCalcColumn :many
 SELECT sum FROM (SELECT a + b AS sum FROM foo) AS f
 `
 
-func (q *Queries) SubqueryCalcColumn(ctx context.Context) ([]int64, error) {
-	rows, err := q.db.QueryContext(ctx, subqueryCalcColumn)
+func (q *Queries) SubqueryCalcColumn(ctx context.Context, aq ...AdditionalQuery) ([]int64, error) {
+	query := subqueryCalcColumn
+	queryParams := []interface{}{}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.QueryContext(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/endtoend/testdata/table_function/postgresql/pgx/v4/go/db.go
+++ b/internal/endtoend/testdata/table_function/postgresql/pgx/v4/go/db.go
@@ -33,5 +33,5 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/table_function/postgresql/pgx/v4/go/db.go
+++ b/internal/endtoend/testdata/table_function/postgresql/pgx/v4/go/db.go
@@ -30,3 +30,8 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/table_function/postgresql/pgx/v4/go/query.sql.go
+++ b/internal/endtoend/testdata/table_function/postgresql/pgx/v4/go/query.sql.go
@@ -35,8 +35,16 @@ type GetTransactionRow struct {
 	JsonGroupArray interface{}
 }
 
-func (q *Queries) GetTransaction(ctx context.Context, arg GetTransactionParams) ([]GetTransactionRow, error) {
-	rows, err := q.db.Query(ctx, getTransaction, arg.ProgramID, arg.Data, arg.Limit)
+func (q *Queries) GetTransaction(ctx context.Context, arg GetTransactionParams, aq ...AdditionalQuery) ([]GetTransactionRow, error) {
+	query := getTransaction
+	queryParams := []interface{}{arg.ProgramID, arg.Data, arg.Limit}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.Query(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/endtoend/testdata/table_function/postgresql/pgx/v5/go/db.go
+++ b/internal/endtoend/testdata/table_function/postgresql/pgx/v5/go/db.go
@@ -33,5 +33,5 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/table_function/postgresql/pgx/v5/go/db.go
+++ b/internal/endtoend/testdata/table_function/postgresql/pgx/v5/go/db.go
@@ -30,3 +30,8 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/table_function/postgresql/pgx/v5/go/query.sql.go
+++ b/internal/endtoend/testdata/table_function/postgresql/pgx/v5/go/query.sql.go
@@ -35,8 +35,16 @@ type GetTransactionRow struct {
 	JsonGroupArray interface{}
 }
 
-func (q *Queries) GetTransaction(ctx context.Context, arg GetTransactionParams) ([]GetTransactionRow, error) {
-	rows, err := q.db.Query(ctx, getTransaction, arg.ProgramID, arg.Data, arg.Limit)
+func (q *Queries) GetTransaction(ctx context.Context, arg GetTransactionParams, aq ...AdditionalQuery) ([]GetTransactionRow, error) {
+	query := getTransaction
+	queryParams := []interface{}{arg.ProgramID, arg.Data, arg.Limit}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.Query(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/endtoend/testdata/table_function/postgresql/stdlib/go/db.go
+++ b/internal/endtoend/testdata/table_function/postgresql/stdlib/go/db.go
@@ -29,3 +29,8 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/table_function/postgresql/stdlib/go/db.go
+++ b/internal/endtoend/testdata/table_function/postgresql/stdlib/go/db.go
@@ -32,5 +32,5 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/table_function/postgresql/stdlib/go/query.sql.go
+++ b/internal/endtoend/testdata/table_function/postgresql/stdlib/go/query.sql.go
@@ -35,8 +35,16 @@ type GetTransactionRow struct {
 	JsonGroupArray interface{}
 }
 
-func (q *Queries) GetTransaction(ctx context.Context, arg GetTransactionParams) ([]GetTransactionRow, error) {
-	rows, err := q.db.QueryContext(ctx, getTransaction, arg.ProgramID, arg.Data, arg.Limit)
+func (q *Queries) GetTransaction(ctx context.Context, arg GetTransactionParams, aq ...AdditionalQuery) ([]GetTransactionRow, error) {
+	query := getTransaction
+	queryParams := []interface{}{arg.ProgramID, arg.Data, arg.Limit}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.QueryContext(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/endtoend/testdata/table_function/sqlite/go/db.go
+++ b/internal/endtoend/testdata/table_function/sqlite/go/db.go
@@ -29,3 +29,8 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/table_function/sqlite/go/db.go
+++ b/internal/endtoend/testdata/table_function/sqlite/go/db.go
@@ -32,5 +32,5 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/table_function/sqlite/go/query.sql.go
+++ b/internal/endtoend/testdata/table_function/sqlite/go/query.sql.go
@@ -35,8 +35,16 @@ type GetTransactionRow struct {
 	JsonGroupArray interface{}
 }
 
-func (q *Queries) GetTransaction(ctx context.Context, arg GetTransactionParams) ([]GetTransactionRow, error) {
-	rows, err := q.db.QueryContext(ctx, getTransaction, arg.ProgramID, arg.Data, arg.Limit)
+func (q *Queries) GetTransaction(ctx context.Context, arg GetTransactionParams, aq ...AdditionalQuery) ([]GetTransactionRow, error) {
+	query := getTransaction
+	queryParams := []interface{}{arg.ProgramID, arg.Data, arg.Limit}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.QueryContext(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/endtoend/testdata/truncate/mysql/go/db.go
+++ b/internal/endtoend/testdata/truncate/mysql/go/db.go
@@ -29,3 +29,8 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/truncate/mysql/go/db.go
+++ b/internal/endtoend/testdata/truncate/mysql/go/db.go
@@ -32,5 +32,5 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/truncate/mysql/go/query.sql.go
+++ b/internal/endtoend/testdata/truncate/mysql/go/query.sql.go
@@ -14,6 +14,9 @@ TRUNCATE bar
 `
 
 func (q *Queries) Truncate(ctx context.Context) error {
-	_, err := q.db.ExecContext(ctx, truncate)
+	query := truncate
+	queryParams := []interface{}{}
+
+	_, err := q.db.ExecContext(ctx, query, queryParams...)
 	return err
 }

--- a/internal/endtoend/testdata/truncate/postgresql/pgx/v4/go/db.go
+++ b/internal/endtoend/testdata/truncate/postgresql/pgx/v4/go/db.go
@@ -33,5 +33,5 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/truncate/postgresql/pgx/v4/go/db.go
+++ b/internal/endtoend/testdata/truncate/postgresql/pgx/v4/go/db.go
@@ -30,3 +30,8 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/truncate/postgresql/pgx/v5/go/db.go
+++ b/internal/endtoend/testdata/truncate/postgresql/pgx/v5/go/db.go
@@ -33,5 +33,5 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/truncate/postgresql/pgx/v5/go/db.go
+++ b/internal/endtoend/testdata/truncate/postgresql/pgx/v5/go/db.go
@@ -30,3 +30,8 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/truncate/postgresql/stdlib/go/db.go
+++ b/internal/endtoend/testdata/truncate/postgresql/stdlib/go/db.go
@@ -29,3 +29,8 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/truncate/postgresql/stdlib/go/db.go
+++ b/internal/endtoend/testdata/truncate/postgresql/stdlib/go/db.go
@@ -32,5 +32,5 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/truncate/postgresql/stdlib/go/query.sql.go
+++ b/internal/endtoend/testdata/truncate/postgresql/stdlib/go/query.sql.go
@@ -14,6 +14,9 @@ TRUNCATE bar
 `
 
 func (q *Queries) Truncate(ctx context.Context) error {
-	_, err := q.db.ExecContext(ctx, truncate)
+	query := truncate
+	queryParams := []interface{}{}
+
+	_, err := q.db.ExecContext(ctx, query, queryParams...)
 	return err
 }

--- a/internal/endtoend/testdata/types_uuid/postgresql/stdlib/go/db.go
+++ b/internal/endtoend/testdata/types_uuid/postgresql/stdlib/go/db.go
@@ -29,3 +29,8 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/types_uuid/postgresql/stdlib/go/db.go
+++ b/internal/endtoend/testdata/types_uuid/postgresql/stdlib/go/db.go
@@ -32,5 +32,5 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/unknown_func/pgx/v4/go/db.go
+++ b/internal/endtoend/testdata/unknown_func/pgx/v4/go/db.go
@@ -33,5 +33,5 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/unknown_func/pgx/v4/go/db.go
+++ b/internal/endtoend/testdata/unknown_func/pgx/v4/go/db.go
@@ -30,3 +30,8 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/unknown_func/pgx/v4/go/query.sql.go
+++ b/internal/endtoend/testdata/unknown_func/pgx/v4/go/query.sql.go
@@ -13,8 +13,10 @@ const listFoos = `-- name: ListFoos :one
 SELECT id FROM foo WHERE id = frobnicate($1)
 `
 
-func (q *Queries) ListFoos(ctx context.Context, frobnicate interface{}) (string, error) {
-	row := q.db.QueryRow(ctx, listFoos, frobnicate)
+func (q *Queries) ListFoos(ctx context.Context, frobnicate interface{}, aq ...AdditionalQuery) (string, error) {
+	query := listFoos
+	queryParams := []interface{}{frobnicate}
+	row := q.db.QueryRow(ctx, query, queryParams...)
 	var id string
 	err := row.Scan(&id)
 	return id, err

--- a/internal/endtoend/testdata/unknown_func/pgx/v5/go/db.go
+++ b/internal/endtoend/testdata/unknown_func/pgx/v5/go/db.go
@@ -33,5 +33,5 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/unknown_func/pgx/v5/go/db.go
+++ b/internal/endtoend/testdata/unknown_func/pgx/v5/go/db.go
@@ -30,3 +30,8 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/unknown_func/pgx/v5/go/query.sql.go
+++ b/internal/endtoend/testdata/unknown_func/pgx/v5/go/query.sql.go
@@ -13,8 +13,10 @@ const listFoos = `-- name: ListFoos :one
 SELECT id FROM foo WHERE id = frobnicate($1)
 `
 
-func (q *Queries) ListFoos(ctx context.Context, frobnicate interface{}) (string, error) {
-	row := q.db.QueryRow(ctx, listFoos, frobnicate)
+func (q *Queries) ListFoos(ctx context.Context, frobnicate interface{}, aq ...AdditionalQuery) (string, error) {
+	query := listFoos
+	queryParams := []interface{}{frobnicate}
+	row := q.db.QueryRow(ctx, query, queryParams...)
 	var id string
 	err := row.Scan(&id)
 	return id, err

--- a/internal/endtoend/testdata/unknown_func/stdlib/go/db.go
+++ b/internal/endtoend/testdata/unknown_func/stdlib/go/db.go
@@ -29,3 +29,8 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/unknown_func/stdlib/go/db.go
+++ b/internal/endtoend/testdata/unknown_func/stdlib/go/db.go
@@ -32,5 +32,5 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/unknown_func/stdlib/go/query.sql.go
+++ b/internal/endtoend/testdata/unknown_func/stdlib/go/query.sql.go
@@ -13,8 +13,16 @@ const listFoos = `-- name: ListFoos :one
 SELECT id FROM foo WHERE id = frobnicate($1)
 `
 
-func (q *Queries) ListFoos(ctx context.Context, frobnicate interface{}) (string, error) {
-	row := q.db.QueryRowContext(ctx, listFoos, frobnicate)
+func (q *Queries) ListFoos(ctx context.Context, frobnicate interface{}, aq ...AdditionalQuery) (string, error) {
+	query := listFoos
+	queryParams := []interface{}{frobnicate}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	row := q.db.QueryRowContext(ctx, query, queryParams...)
 	var id string
 	err := row.Scan(&id)
 	return id, err

--- a/internal/endtoend/testdata/unnest/postgresql/pgx/v4/go/db.go
+++ b/internal/endtoend/testdata/unnest/postgresql/pgx/v4/go/db.go
@@ -33,5 +33,5 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/unnest/postgresql/pgx/v4/go/db.go
+++ b/internal/endtoend/testdata/unnest/postgresql/pgx/v4/go/db.go
@@ -30,3 +30,8 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/unnest/postgresql/pgx/v4/go/querier.go
+++ b/internal/endtoend/testdata/unnest/postgresql/pgx/v4/go/querier.go
@@ -11,8 +11,8 @@ import (
 )
 
 type Querier interface {
-	CreateMemories(ctx context.Context, vampireID []uuid.UUID) ([]Memory, error)
-	GetVampireIDs(ctx context.Context, vampireID []uuid.UUID) ([]uuid.UUID, error)
+	CreateMemories(ctx context.Context, vampireID []uuid.UUID, aq ...AdditionalQuery) ([]Memory, error)
+	GetVampireIDs(ctx context.Context, vampireID []uuid.UUID, aq ...AdditionalQuery) ([]uuid.UUID, error)
 }
 
 var _ Querier = (*Queries)(nil)

--- a/internal/endtoend/testdata/unnest/postgresql/pgx/v4/go/query.sql.go
+++ b/internal/endtoend/testdata/unnest/postgresql/pgx/v4/go/query.sql.go
@@ -19,8 +19,16 @@ RETURNING
     id, vampire_id, created_at, updated_at
 `
 
-func (q *Queries) CreateMemories(ctx context.Context, vampireID []uuid.UUID) ([]Memory, error) {
-	rows, err := q.db.Query(ctx, createMemories, vampireID)
+func (q *Queries) CreateMemories(ctx context.Context, vampireID []uuid.UUID, aq ...AdditionalQuery) ([]Memory, error) {
+	query := createMemories
+	queryParams := []interface{}{vampireID}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.Query(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}
@@ -48,8 +56,16 @@ const getVampireIDs = `-- name: GetVampireIDs :many
 SELECT vampires.id::uuid FROM unnest($1::uuid[]) AS vampires (id)
 `
 
-func (q *Queries) GetVampireIDs(ctx context.Context, vampireID []uuid.UUID) ([]uuid.UUID, error) {
-	rows, err := q.db.Query(ctx, getVampireIDs, vampireID)
+func (q *Queries) GetVampireIDs(ctx context.Context, vampireID []uuid.UUID, aq ...AdditionalQuery) ([]uuid.UUID, error) {
+	query := getVampireIDs
+	queryParams := []interface{}{vampireID}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.Query(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/endtoend/testdata/unnest/postgresql/pgx/v5/go/db.go
+++ b/internal/endtoend/testdata/unnest/postgresql/pgx/v5/go/db.go
@@ -33,5 +33,5 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/unnest/postgresql/pgx/v5/go/db.go
+++ b/internal/endtoend/testdata/unnest/postgresql/pgx/v5/go/db.go
@@ -30,3 +30,8 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/unnest/postgresql/pgx/v5/go/querier.go
+++ b/internal/endtoend/testdata/unnest/postgresql/pgx/v5/go/querier.go
@@ -11,8 +11,8 @@ import (
 )
 
 type Querier interface {
-	CreateMemories(ctx context.Context, vampireID []pgtype.UUID) ([]Memory, error)
-	GetVampireIDs(ctx context.Context, vampireID []pgtype.UUID) ([]pgtype.UUID, error)
+	CreateMemories(ctx context.Context, vampireID []pgtype.UUID, aq ...AdditionalQuery) ([]Memory, error)
+	GetVampireIDs(ctx context.Context, vampireID []pgtype.UUID, aq ...AdditionalQuery) ([]pgtype.UUID, error)
 }
 
 var _ Querier = (*Queries)(nil)

--- a/internal/endtoend/testdata/unnest/postgresql/pgx/v5/go/query.sql.go
+++ b/internal/endtoend/testdata/unnest/postgresql/pgx/v5/go/query.sql.go
@@ -19,8 +19,16 @@ RETURNING
     id, vampire_id, created_at, updated_at
 `
 
-func (q *Queries) CreateMemories(ctx context.Context, vampireID []pgtype.UUID) ([]Memory, error) {
-	rows, err := q.db.Query(ctx, createMemories, vampireID)
+func (q *Queries) CreateMemories(ctx context.Context, vampireID []pgtype.UUID, aq ...AdditionalQuery) ([]Memory, error) {
+	query := createMemories
+	queryParams := []interface{}{vampireID}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.Query(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}
@@ -48,8 +56,16 @@ const getVampireIDs = `-- name: GetVampireIDs :many
 SELECT vampires.id::uuid FROM unnest($1::uuid[]) AS vampires (id)
 `
 
-func (q *Queries) GetVampireIDs(ctx context.Context, vampireID []pgtype.UUID) ([]pgtype.UUID, error) {
-	rows, err := q.db.Query(ctx, getVampireIDs, vampireID)
+func (q *Queries) GetVampireIDs(ctx context.Context, vampireID []pgtype.UUID, aq ...AdditionalQuery) ([]pgtype.UUID, error) {
+	query := getVampireIDs
+	queryParams := []interface{}{vampireID}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.Query(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/endtoend/testdata/unnest/postgresql/stdlib/go/db.go
+++ b/internal/endtoend/testdata/unnest/postgresql/stdlib/go/db.go
@@ -29,3 +29,8 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/unnest/postgresql/stdlib/go/db.go
+++ b/internal/endtoend/testdata/unnest/postgresql/stdlib/go/db.go
@@ -32,5 +32,5 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/unnest/postgresql/stdlib/go/querier.go
+++ b/internal/endtoend/testdata/unnest/postgresql/stdlib/go/querier.go
@@ -11,8 +11,8 @@ import (
 )
 
 type Querier interface {
-	CreateMemories(ctx context.Context, vampireID []uuid.UUID) ([]Memory, error)
-	GetVampireIDs(ctx context.Context, vampireID []uuid.UUID) ([]uuid.UUID, error)
+	CreateMemories(ctx context.Context, vampireID []uuid.UUID, aq ...AdditionalQuery) ([]Memory, error)
+	GetVampireIDs(ctx context.Context, vampireID []uuid.UUID, aq ...AdditionalQuery) ([]uuid.UUID, error)
 }
 
 var _ Querier = (*Queries)(nil)

--- a/internal/endtoend/testdata/unnest/postgresql/stdlib/go/query.sql.go
+++ b/internal/endtoend/testdata/unnest/postgresql/stdlib/go/query.sql.go
@@ -20,8 +20,16 @@ RETURNING
     id, vampire_id, created_at, updated_at
 `
 
-func (q *Queries) CreateMemories(ctx context.Context, vampireID []uuid.UUID) ([]Memory, error) {
-	rows, err := q.db.QueryContext(ctx, createMemories, pq.Array(vampireID))
+func (q *Queries) CreateMemories(ctx context.Context, vampireID []uuid.UUID, aq ...AdditionalQuery) ([]Memory, error) {
+	query := createMemories
+	queryParams := []interface{}{pq.Array(vampireID)}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.QueryContext(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}
@@ -52,8 +60,16 @@ const getVampireIDs = `-- name: GetVampireIDs :many
 SELECT vampires.id::uuid FROM unnest($1::uuid[]) AS vampires (id)
 `
 
-func (q *Queries) GetVampireIDs(ctx context.Context, vampireID []uuid.UUID) ([]uuid.UUID, error) {
-	rows, err := q.db.QueryContext(ctx, getVampireIDs, pq.Array(vampireID))
+func (q *Queries) GetVampireIDs(ctx context.Context, vampireID []uuid.UUID, aq ...AdditionalQuery) ([]uuid.UUID, error) {
+	query := getVampireIDs
+	queryParams := []interface{}{pq.Array(vampireID)}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.QueryContext(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/endtoend/testdata/unnest_with_ordinality/postgresql/pgx/v4/go/db.go
+++ b/internal/endtoend/testdata/unnest_with_ordinality/postgresql/pgx/v4/go/db.go
@@ -33,5 +33,5 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/unnest_with_ordinality/postgresql/pgx/v4/go/db.go
+++ b/internal/endtoend/testdata/unnest_with_ordinality/postgresql/pgx/v4/go/db.go
@@ -30,3 +30,8 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/unnest_with_ordinality/postgresql/pgx/v4/go/querier.go
+++ b/internal/endtoend/testdata/unnest_with_ordinality/postgresql/pgx/v4/go/querier.go
@@ -9,7 +9,7 @@ import (
 )
 
 type Querier interface {
-	GetValues(ctx context.Context) ([]GetValuesRow, error)
+	GetValues(ctx context.Context, aq ...AdditionalQuery) ([]GetValuesRow, error)
 }
 
 var _ Querier = (*Queries)(nil)

--- a/internal/endtoend/testdata/unnest_with_ordinality/postgresql/pgx/v4/go/query.sql.go
+++ b/internal/endtoend/testdata/unnest_with_ordinality/postgresql/pgx/v4/go/query.sql.go
@@ -20,8 +20,16 @@ type GetValuesRow struct {
 	Value string
 }
 
-func (q *Queries) GetValues(ctx context.Context) ([]GetValuesRow, error) {
-	rows, err := q.db.Query(ctx, getValues)
+func (q *Queries) GetValues(ctx context.Context, aq ...AdditionalQuery) ([]GetValuesRow, error) {
+	query := getValues
+	queryParams := []interface{}{}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.Query(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/endtoend/testdata/unnest_with_ordinality/postgresql/pgx/v5/go/db.go
+++ b/internal/endtoend/testdata/unnest_with_ordinality/postgresql/pgx/v5/go/db.go
@@ -33,5 +33,5 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/unnest_with_ordinality/postgresql/pgx/v5/go/db.go
+++ b/internal/endtoend/testdata/unnest_with_ordinality/postgresql/pgx/v5/go/db.go
@@ -30,3 +30,8 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/unnest_with_ordinality/postgresql/pgx/v5/go/querier.go
+++ b/internal/endtoend/testdata/unnest_with_ordinality/postgresql/pgx/v5/go/querier.go
@@ -9,7 +9,7 @@ import (
 )
 
 type Querier interface {
-	GetValues(ctx context.Context) ([]GetValuesRow, error)
+	GetValues(ctx context.Context, aq ...AdditionalQuery) ([]GetValuesRow, error)
 }
 
 var _ Querier = (*Queries)(nil)

--- a/internal/endtoend/testdata/unnest_with_ordinality/postgresql/pgx/v5/go/query.sql.go
+++ b/internal/endtoend/testdata/unnest_with_ordinality/postgresql/pgx/v5/go/query.sql.go
@@ -20,8 +20,16 @@ type GetValuesRow struct {
 	Value string
 }
 
-func (q *Queries) GetValues(ctx context.Context) ([]GetValuesRow, error) {
-	rows, err := q.db.Query(ctx, getValues)
+func (q *Queries) GetValues(ctx context.Context, aq ...AdditionalQuery) ([]GetValuesRow, error) {
+	query := getValues
+	queryParams := []interface{}{}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.Query(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/endtoend/testdata/unnest_with_ordinality/postgresql/stdlib/go/db.go
+++ b/internal/endtoend/testdata/unnest_with_ordinality/postgresql/stdlib/go/db.go
@@ -29,3 +29,8 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/unnest_with_ordinality/postgresql/stdlib/go/db.go
+++ b/internal/endtoend/testdata/unnest_with_ordinality/postgresql/stdlib/go/db.go
@@ -32,5 +32,5 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/unnest_with_ordinality/postgresql/stdlib/go/querier.go
+++ b/internal/endtoend/testdata/unnest_with_ordinality/postgresql/stdlib/go/querier.go
@@ -9,7 +9,7 @@ import (
 )
 
 type Querier interface {
-	GetValues(ctx context.Context) ([]GetValuesRow, error)
+	GetValues(ctx context.Context, aq ...AdditionalQuery) ([]GetValuesRow, error)
 }
 
 var _ Querier = (*Queries)(nil)

--- a/internal/endtoend/testdata/unnest_with_ordinality/postgresql/stdlib/go/query.sql.go
+++ b/internal/endtoend/testdata/unnest_with_ordinality/postgresql/stdlib/go/query.sql.go
@@ -20,8 +20,16 @@ type GetValuesRow struct {
 	Value string
 }
 
-func (q *Queries) GetValues(ctx context.Context) ([]GetValuesRow, error) {
-	rows, err := q.db.QueryContext(ctx, getValues)
+func (q *Queries) GetValues(ctx context.Context, aq ...AdditionalQuery) ([]GetValuesRow, error) {
+	query := getValues
+	queryParams := []interface{}{}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.QueryContext(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/endtoend/testdata/unsigned_params/mysql/go/db.go
+++ b/internal/endtoend/testdata/unsigned_params/mysql/go/db.go
@@ -29,3 +29,8 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/unsigned_params/mysql/go/db.go
+++ b/internal/endtoend/testdata/unsigned_params/mysql/go/db.go
@@ -32,5 +32,5 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/unsigned_params/mysql/go/query.sql.go
+++ b/internal/endtoend/testdata/unsigned_params/mysql/go/query.sql.go
@@ -14,6 +14,9 @@ INSERT INTO foo (id) VALUES (?)
 `
 
 func (q *Queries) CreateFoo(ctx context.Context, id uint32) error {
-	_, err := q.db.ExecContext(ctx, createFoo, id)
+	query := createFoo
+	queryParams := []interface{}{id}
+
+	_, err := q.db.ExecContext(ctx, query, queryParams...)
 	return err
 }

--- a/internal/endtoend/testdata/untyped_columns/sqlite/stdlib/db/db.go
+++ b/internal/endtoend/testdata/untyped_columns/sqlite/stdlib/db/db.go
@@ -29,3 +29,8 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/untyped_columns/sqlite/stdlib/db/db.go
+++ b/internal/endtoend/testdata/untyped_columns/sqlite/stdlib/db/db.go
@@ -32,5 +32,5 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/untyped_columns/sqlite/stdlib/db/query.sql.go
+++ b/internal/endtoend/testdata/untyped_columns/sqlite/stdlib/db/query.sql.go
@@ -13,8 +13,16 @@ const getRepro = `-- name: GetRepro :one
 select id, name, seq from repro where id = ? limit 1
 `
 
-func (q *Queries) GetRepro(ctx context.Context, id interface{}) (Repro, error) {
-	row := q.db.QueryRowContext(ctx, getRepro, id)
+func (q *Queries) GetRepro(ctx context.Context, id interface{}, aq ...AdditionalQuery) (Repro, error) {
+	query := getRepro
+	queryParams := []interface{}{id}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	row := q.db.QueryRowContext(ctx, query, queryParams...)
 	var i Repro
 	err := row.Scan(&i.ID, &i.Name, &i.Seq)
 	return i, err

--- a/internal/endtoend/testdata/update_cte/pgx/v4/go/db.go
+++ b/internal/endtoend/testdata/update_cte/pgx/v4/go/db.go
@@ -33,5 +33,5 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/update_cte/pgx/v4/go/db.go
+++ b/internal/endtoend/testdata/update_cte/pgx/v4/go/db.go
@@ -30,3 +30,8 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/update_cte/pgx/v4/go/query.sql.go
+++ b/internal/endtoend/testdata/update_cte/pgx/v4/go/query.sql.go
@@ -52,13 +52,15 @@ type UpdateCodeRow struct {
 }
 
 // FILE: query.sql
-func (q *Queries) UpdateCode(ctx context.Context, arg UpdateCodeParams) (UpdateCodeRow, error) {
-	row := q.db.QueryRow(ctx, updateCode,
+func (q *Queries) UpdateCode(ctx context.Context, arg UpdateCodeParams, aq ...AdditionalQuery) (UpdateCodeRow, error) {
+	query := updateCode
+	queryParams := []interface{}{
 		arg.CreatedBy,
 		arg.Code,
 		arg.Hash,
 		arg.TestID,
-	)
+	}
+	row := q.db.QueryRow(ctx, query, queryParams...)
 	var i UpdateCodeRow
 	err := row.Scan(
 		&i.Hash,

--- a/internal/endtoend/testdata/update_cte/pgx/v5/go/db.go
+++ b/internal/endtoend/testdata/update_cte/pgx/v5/go/db.go
@@ -33,5 +33,5 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/update_cte/pgx/v5/go/db.go
+++ b/internal/endtoend/testdata/update_cte/pgx/v5/go/db.go
@@ -30,3 +30,8 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/update_cte/pgx/v5/go/query.sql.go
+++ b/internal/endtoend/testdata/update_cte/pgx/v5/go/query.sql.go
@@ -52,13 +52,15 @@ type UpdateCodeRow struct {
 }
 
 // FILE: query.sql
-func (q *Queries) UpdateCode(ctx context.Context, arg UpdateCodeParams) (UpdateCodeRow, error) {
-	row := q.db.QueryRow(ctx, updateCode,
+func (q *Queries) UpdateCode(ctx context.Context, arg UpdateCodeParams, aq ...AdditionalQuery) (UpdateCodeRow, error) {
+	query := updateCode
+	queryParams := []interface{}{
 		arg.CreatedBy,
 		arg.Code,
 		arg.Hash,
 		arg.TestID,
-	)
+	}
+	row := q.db.QueryRow(ctx, query, queryParams...)
 	var i UpdateCodeRow
 	err := row.Scan(
 		&i.Hash,

--- a/internal/endtoend/testdata/update_cte/stdlib/go/db.go
+++ b/internal/endtoend/testdata/update_cte/stdlib/go/db.go
@@ -29,3 +29,8 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/update_cte/stdlib/go/db.go
+++ b/internal/endtoend/testdata/update_cte/stdlib/go/db.go
@@ -32,5 +32,5 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/update_cte/stdlib/go/query.sql.go
+++ b/internal/endtoend/testdata/update_cte/stdlib/go/query.sql.go
@@ -52,13 +52,21 @@ type UpdateCodeRow struct {
 }
 
 // FILE: query.sql
-func (q *Queries) UpdateCode(ctx context.Context, arg UpdateCodeParams) (UpdateCodeRow, error) {
-	row := q.db.QueryRowContext(ctx, updateCode,
+func (q *Queries) UpdateCode(ctx context.Context, arg UpdateCodeParams, aq ...AdditionalQuery) (UpdateCodeRow, error) {
+	query := updateCode
+	queryParams := []interface{}{
 		arg.CreatedBy,
 		arg.Code,
 		arg.Hash,
 		arg.TestID,
-	)
+	}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	row := q.db.QueryRowContext(ctx, query, queryParams...)
 	var i UpdateCodeRow
 	err := row.Scan(
 		&i.Hash,

--- a/internal/endtoend/testdata/update_inner_join/db/db.go
+++ b/internal/endtoend/testdata/update_inner_join/db/db.go
@@ -29,3 +29,8 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/update_inner_join/db/db.go
+++ b/internal/endtoend/testdata/update_inner_join/db/db.go
@@ -32,5 +32,5 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/update_inner_join/db/query.sql.go
+++ b/internal/endtoend/testdata/update_inner_join/db/query.sql.go
@@ -14,6 +14,9 @@ UPDATE x INNER JOIN y ON y.a = x.a SET x.b = y.b
 `
 
 func (q *Queries) UpdateXWithY(ctx context.Context) error {
-	_, err := q.db.ExecContext(ctx, updateXWithY)
+	query := updateXWithY
+	queryParams := []interface{}{}
+
+	_, err := q.db.ExecContext(ctx, query, queryParams...)
 	return err
 }

--- a/internal/endtoend/testdata/update_join/mysql/db/db.go
+++ b/internal/endtoend/testdata/update_join/mysql/db/db.go
@@ -29,3 +29,8 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/update_join/mysql/db/db.go
+++ b/internal/endtoend/testdata/update_join/mysql/db/db.go
@@ -32,5 +32,5 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/update_join/mysql/db/query.sql.go
+++ b/internal/endtoend/testdata/update_join/mysql/db/query.sql.go
@@ -25,7 +25,10 @@ type UpdateJoinParams struct {
 }
 
 func (q *Queries) UpdateJoin(ctx context.Context, arg UpdateJoinParams) error {
-	_, err := q.db.ExecContext(ctx, updateJoin, arg.IsActive, arg.ID, arg.UserID)
+	query := updateJoin
+	queryParams := []interface{}{arg.IsActive, arg.ID, arg.UserID}
+
+	_, err := q.db.ExecContext(ctx, query, queryParams...)
 	return err
 }
 
@@ -45,7 +48,10 @@ type UpdateLeftJoinParams struct {
 }
 
 func (q *Queries) UpdateLeftJoin(ctx context.Context, arg UpdateLeftJoinParams) error {
-	_, err := q.db.ExecContext(ctx, updateLeftJoin, arg.IsActive, arg.ID, arg.UserID)
+	query := updateLeftJoin
+	queryParams := []interface{}{arg.IsActive, arg.ID, arg.UserID}
+
+	_, err := q.db.ExecContext(ctx, query, queryParams...)
 	return err
 }
 
@@ -65,6 +71,9 @@ type UpdateRightJoinParams struct {
 }
 
 func (q *Queries) UpdateRightJoin(ctx context.Context, arg UpdateRightJoinParams) error {
-	_, err := q.db.ExecContext(ctx, updateRightJoin, arg.IsActive, arg.ID, arg.UserID)
+	query := updateRightJoin
+	queryParams := []interface{}{arg.IsActive, arg.ID, arg.UserID}
+
+	_, err := q.db.ExecContext(ctx, query, queryParams...)
 	return err
 }

--- a/internal/endtoend/testdata/update_join/postgresql/db/db.go
+++ b/internal/endtoend/testdata/update_join/postgresql/db/db.go
@@ -29,3 +29,8 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/update_join/postgresql/db/db.go
+++ b/internal/endtoend/testdata/update_join/postgresql/db/db.go
@@ -32,5 +32,5 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/update_join/postgresql/db/query.sql.go
+++ b/internal/endtoend/testdata/update_join/postgresql/db/query.sql.go
@@ -25,6 +25,9 @@ type UpdateJoinParams struct {
 }
 
 func (q *Queries) UpdateJoin(ctx context.Context, arg UpdateJoinParams) error {
-	_, err := q.db.ExecContext(ctx, updateJoin, arg.IsActive, arg.ID, arg.UserID)
+	query := updateJoin
+	queryParams := []interface{}{arg.IsActive, arg.ID, arg.UserID}
+
+	_, err := q.db.ExecContext(ctx, query, queryParams...)
 	return err
 }

--- a/internal/endtoend/testdata/update_set/myql/go/db.go
+++ b/internal/endtoend/testdata/update_set/myql/go/db.go
@@ -29,3 +29,8 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/update_set/myql/go/db.go
+++ b/internal/endtoend/testdata/update_set/myql/go/db.go
@@ -32,5 +32,5 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/update_set/myql/go/query.sql.go
+++ b/internal/endtoend/testdata/update_set/myql/go/query.sql.go
@@ -19,6 +19,9 @@ type UpdateSetParams struct {
 }
 
 func (q *Queries) UpdateSet(ctx context.Context, arg UpdateSetParams) error {
-	_, err := q.db.ExecContext(ctx, updateSet, arg.Name, arg.Slug)
+	query := updateSet
+	queryParams := []interface{}{arg.Name, arg.Slug}
+
+	_, err := q.db.ExecContext(ctx, query, queryParams...)
 	return err
 }

--- a/internal/endtoend/testdata/update_set/postgresql/pgx/v4/go/db.go
+++ b/internal/endtoend/testdata/update_set/postgresql/pgx/v4/go/db.go
@@ -33,5 +33,5 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/update_set/postgresql/pgx/v4/go/db.go
+++ b/internal/endtoend/testdata/update_set/postgresql/pgx/v4/go/db.go
@@ -30,3 +30,8 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/update_set/postgresql/pgx/v5/go/db.go
+++ b/internal/endtoend/testdata/update_set/postgresql/pgx/v5/go/db.go
@@ -33,5 +33,5 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/update_set/postgresql/pgx/v5/go/db.go
+++ b/internal/endtoend/testdata/update_set/postgresql/pgx/v5/go/db.go
@@ -30,3 +30,8 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/update_set/postgresql/stdlib/go/db.go
+++ b/internal/endtoend/testdata/update_set/postgresql/stdlib/go/db.go
@@ -29,3 +29,8 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/update_set/postgresql/stdlib/go/db.go
+++ b/internal/endtoend/testdata/update_set/postgresql/stdlib/go/db.go
@@ -32,5 +32,5 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/update_set/postgresql/stdlib/go/query.sql.go
+++ b/internal/endtoend/testdata/update_set/postgresql/stdlib/go/query.sql.go
@@ -19,6 +19,9 @@ type UpdateSetParams struct {
 }
 
 func (q *Queries) UpdateSet(ctx context.Context, arg UpdateSetParams) error {
-	_, err := q.db.ExecContext(ctx, updateSet, arg.Slug, arg.Name)
+	query := updateSet
+	queryParams := []interface{}{arg.Slug, arg.Name}
+
+	_, err := q.db.ExecContext(ctx, query, queryParams...)
 	return err
 }

--- a/internal/endtoend/testdata/update_set/sqlite/go/db.go
+++ b/internal/endtoend/testdata/update_set/sqlite/go/db.go
@@ -29,3 +29,8 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/update_set/sqlite/go/db.go
+++ b/internal/endtoend/testdata/update_set/sqlite/go/db.go
@@ -32,5 +32,5 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/update_set/sqlite/go/query.sql.go
+++ b/internal/endtoend/testdata/update_set/sqlite/go/query.sql.go
@@ -19,6 +19,9 @@ type UpdateSetParams struct {
 }
 
 func (q *Queries) UpdateSet(ctx context.Context, arg UpdateSetParams) error {
-	_, err := q.db.ExecContext(ctx, updateSet, arg.Name, arg.Slug)
+	query := updateSet
+	queryParams := []interface{}{arg.Name, arg.Slug}
+
+	_, err := q.db.ExecContext(ctx, query, queryParams...)
 	return err
 }

--- a/internal/endtoend/testdata/update_set_multiple/mysql/go/db.go
+++ b/internal/endtoend/testdata/update_set_multiple/mysql/go/db.go
@@ -29,3 +29,8 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/update_set_multiple/mysql/go/db.go
+++ b/internal/endtoend/testdata/update_set_multiple/mysql/go/db.go
@@ -32,5 +32,5 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/update_set_multiple/mysql/go/query.sql.go
+++ b/internal/endtoend/testdata/update_set_multiple/mysql/go/query.sql.go
@@ -19,6 +19,9 @@ type UpdateSetMultipleParams struct {
 }
 
 func (q *Queries) UpdateSetMultiple(ctx context.Context, arg UpdateSetMultipleParams) error {
-	_, err := q.db.ExecContext(ctx, updateSetMultiple, arg.Name, arg.Slug)
+	query := updateSetMultiple
+	queryParams := []interface{}{arg.Name, arg.Slug}
+
+	_, err := q.db.ExecContext(ctx, query, queryParams...)
 	return err
 }

--- a/internal/endtoend/testdata/update_set_multiple/postgresql/pgx/v4/go/db.go
+++ b/internal/endtoend/testdata/update_set_multiple/postgresql/pgx/v4/go/db.go
@@ -33,5 +33,5 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/update_set_multiple/postgresql/pgx/v4/go/db.go
+++ b/internal/endtoend/testdata/update_set_multiple/postgresql/pgx/v4/go/db.go
@@ -30,3 +30,8 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/update_set_multiple/postgresql/pgx/v5/go/db.go
+++ b/internal/endtoend/testdata/update_set_multiple/postgresql/pgx/v5/go/db.go
@@ -33,5 +33,5 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/update_set_multiple/postgresql/pgx/v5/go/db.go
+++ b/internal/endtoend/testdata/update_set_multiple/postgresql/pgx/v5/go/db.go
@@ -30,3 +30,8 @@ func (q *Queries) WithTx(tx pgx.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/update_set_multiple/postgresql/stdlib/go/db.go
+++ b/internal/endtoend/testdata/update_set_multiple/postgresql/stdlib/go/db.go
@@ -29,3 +29,8 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/update_set_multiple/postgresql/stdlib/go/db.go
+++ b/internal/endtoend/testdata/update_set_multiple/postgresql/stdlib/go/db.go
@@ -32,5 +32,5 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/update_set_multiple/postgresql/stdlib/go/query.sql.go
+++ b/internal/endtoend/testdata/update_set_multiple/postgresql/stdlib/go/query.sql.go
@@ -19,6 +19,9 @@ type UpdateSetMultipleParams struct {
 }
 
 func (q *Queries) UpdateSetMultiple(ctx context.Context, arg UpdateSetMultipleParams) error {
-	_, err := q.db.ExecContext(ctx, updateSetMultiple, arg.Slug, arg.Name)
+	query := updateSetMultiple
+	queryParams := []interface{}{arg.Slug, arg.Name}
+
+	_, err := q.db.ExecContext(ctx, query, queryParams...)
 	return err
 }

--- a/internal/endtoend/testdata/update_set_multiple/sqlite/go/db.go
+++ b/internal/endtoend/testdata/update_set_multiple/sqlite/go/db.go
@@ -29,3 +29,8 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/update_set_multiple/sqlite/go/db.go
+++ b/internal/endtoend/testdata/update_set_multiple/sqlite/go/db.go
@@ -32,5 +32,5 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/update_set_multiple/sqlite/go/query.sql.go
+++ b/internal/endtoend/testdata/update_set_multiple/sqlite/go/query.sql.go
@@ -19,6 +19,9 @@ type UpdateSetMultipleParams struct {
 }
 
 func (q *Queries) UpdateSetMultiple(ctx context.Context, arg UpdateSetMultipleParams) error {
-	_, err := q.db.ExecContext(ctx, updateSetMultiple, arg.Name, arg.Slug)
+	query := updateSetMultiple
+	queryParams := []interface{}{arg.Name, arg.Slug}
+
+	_, err := q.db.ExecContext(ctx, query, queryParams...)
 	return err
 }

--- a/internal/endtoend/testdata/update_two_table/mysql/go/db.go
+++ b/internal/endtoend/testdata/update_two_table/mysql/go/db.go
@@ -29,3 +29,8 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/update_two_table/mysql/go/db.go
+++ b/internal/endtoend/testdata/update_two_table/mysql/go/db.go
@@ -32,5 +32,5 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/update_two_table/mysql/go/query.sql.go
+++ b/internal/endtoend/testdata/update_two_table/mysql/go/query.sql.go
@@ -22,6 +22,9 @@ WHERE
 `
 
 func (q *Queries) DeleteAuthor(ctx context.Context, name string) error {
-	_, err := q.db.ExecContext(ctx, deleteAuthor, name)
+	query := deleteAuthor
+	queryParams := []interface{}{name}
+
+	_, err := q.db.ExecContext(ctx, query, queryParams...)
 	return err
 }

--- a/internal/endtoend/testdata/upsert/sqlite/go/db.go
+++ b/internal/endtoend/testdata/upsert/sqlite/go/db.go
@@ -29,3 +29,8 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/upsert/sqlite/go/db.go
+++ b/internal/endtoend/testdata/upsert/sqlite/go/db.go
@@ -32,5 +32,5 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/upsert/sqlite/go/query.sql.go
+++ b/internal/endtoend/testdata/upsert/sqlite/go/query.sql.go
@@ -35,12 +35,15 @@ type UpsertLocationParams struct {
 }
 
 func (q *Queries) UpsertLocation(ctx context.Context, arg UpsertLocationParams) error {
-	_, err := q.db.ExecContext(ctx, upsertLocation,
+	query := upsertLocation
+	queryParams := []interface{}{
 		arg.Name,
 		arg.Address,
 		arg.ZipCode,
 		arg.Latitude,
 		arg.Longitude,
-	)
+	}
+
+	_, err := q.db.ExecContext(ctx, query, queryParams...)
 	return err
 }

--- a/internal/endtoend/testdata/valid_group_by_reference/mysql/go/db.go
+++ b/internal/endtoend/testdata/valid_group_by_reference/mysql/go/db.go
@@ -29,3 +29,8 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/valid_group_by_reference/mysql/go/db.go
+++ b/internal/endtoend/testdata/valid_group_by_reference/mysql/go/db.go
@@ -32,5 +32,5 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/valid_group_by_reference/mysql/go/query.sql.go
+++ b/internal/endtoend/testdata/valid_group_by_reference/mysql/go/query.sql.go
@@ -22,8 +22,16 @@ type ListAuthorsRow struct {
 	Bio      sql.NullString
 }
 
-func (q *Queries) ListAuthors(ctx context.Context) ([]ListAuthorsRow, error) {
-	rows, err := q.db.QueryContext(ctx, listAuthors)
+func (q *Queries) ListAuthors(ctx context.Context, aq ...AdditionalQuery) ([]ListAuthorsRow, error) {
+	query := listAuthors
+	queryParams := []interface{}{}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.QueryContext(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}
@@ -51,8 +59,16 @@ FROM     authors
 GROUP BY name
 `
 
-func (q *Queries) ListAuthorsIdenticalAlias(ctx context.Context) ([]Author, error) {
-	rows, err := q.db.QueryContext(ctx, listAuthorsIdenticalAlias)
+func (q *Queries) ListAuthorsIdenticalAlias(ctx context.Context, aq ...AdditionalQuery) ([]Author, error) {
+	query := listAuthorsIdenticalAlias
+	queryParams := []interface{}{}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.QueryContext(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}
@@ -88,8 +104,16 @@ type ListMetricsRow struct {
 	Avg      interface{}
 }
 
-func (q *Queries) ListMetrics(ctx context.Context) ([]ListMetricsRow, error) {
-	rows, err := q.db.QueryContext(ctx, listMetrics)
+func (q *Queries) ListMetrics(ctx context.Context, aq ...AdditionalQuery) ([]ListMetricsRow, error) {
+	query := listMetrics
+	queryParams := []interface{}{}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.QueryContext(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/endtoend/testdata/valid_group_by_reference/postgresql/go/db.go
+++ b/internal/endtoend/testdata/valid_group_by_reference/postgresql/go/db.go
@@ -29,3 +29,8 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/valid_group_by_reference/postgresql/go/db.go
+++ b/internal/endtoend/testdata/valid_group_by_reference/postgresql/go/db.go
@@ -32,5 +32,5 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/valid_group_by_reference/postgresql/go/query.sql.go
+++ b/internal/endtoend/testdata/valid_group_by_reference/postgresql/go/query.sql.go
@@ -16,8 +16,16 @@ FROM     authors
 GROUP BY name
 `
 
-func (q *Queries) ListAuthors(ctx context.Context) ([]Author, error) {
-	rows, err := q.db.QueryContext(ctx, listAuthors)
+func (q *Queries) ListAuthors(ctx context.Context, aq ...AdditionalQuery) ([]Author, error) {
+	query := listAuthors
+	queryParams := []interface{}{}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.QueryContext(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}
@@ -45,8 +53,16 @@ FROM     authors
 GROUP BY name
 `
 
-func (q *Queries) ListAuthorsIdenticalAlias(ctx context.Context) ([]Author, error) {
-	rows, err := q.db.QueryContext(ctx, listAuthorsIdenticalAlias)
+func (q *Queries) ListAuthorsIdenticalAlias(ctx context.Context, aq ...AdditionalQuery) ([]Author, error) {
+	query := listAuthorsIdenticalAlias
+	queryParams := []interface{}{}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.QueryContext(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}
@@ -82,8 +98,16 @@ type ListMetricsRow struct {
 	Avg      float64
 }
 
-func (q *Queries) ListMetrics(ctx context.Context) ([]ListMetricsRow, error) {
-	rows, err := q.db.QueryContext(ctx, listMetrics)
+func (q *Queries) ListMetrics(ctx context.Context, aq ...AdditionalQuery) ([]ListMetricsRow, error) {
+	query := listMetrics
+	queryParams := []interface{}{}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.QueryContext(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/endtoend/testdata/vet_explain/mysql/db/db.go
+++ b/internal/endtoend/testdata/vet_explain/mysql/db/db.go
@@ -29,3 +29,8 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/vet_explain/mysql/db/db.go
+++ b/internal/endtoend/testdata/vet_explain/mysql/db/db.go
@@ -32,5 +32,5 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/vet_explain/mysql/db/query.sql.go
+++ b/internal/endtoend/testdata/vet_explain/mysql/db/query.sql.go
@@ -16,8 +16,16 @@ SELECT id FROM debug
 WHERE Cbinary = ? LIMIT 1
 `
 
-func (q *Queries) SelectByCbinary(ctx context.Context, cbinary []byte) (int64, error) {
-	row := q.db.QueryRowContext(ctx, selectByCbinary, cbinary)
+func (q *Queries) SelectByCbinary(ctx context.Context, cbinary []byte, aq ...AdditionalQuery) (int64, error) {
+	query := selectByCbinary
+	queryParams := []interface{}{cbinary}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	row := q.db.QueryRowContext(ctx, query, queryParams...)
 	var id int64
 	err := row.Scan(&id)
 	return id, err
@@ -28,8 +36,16 @@ SELECT id FROM debug
 WHERE Cbit = ? LIMIT 1
 `
 
-func (q *Queries) SelectByCbit(ctx context.Context, cbit interface{}) (int64, error) {
-	row := q.db.QueryRowContext(ctx, selectByCbit, cbit)
+func (q *Queries) SelectByCbit(ctx context.Context, cbit interface{}, aq ...AdditionalQuery) (int64, error) {
+	query := selectByCbit
+	queryParams := []interface{}{cbit}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	row := q.db.QueryRowContext(ctx, query, queryParams...)
 	var id int64
 	err := row.Scan(&id)
 	return id, err
@@ -40,8 +56,16 @@ SELECT id FROM debug
 WHERE Cblob = ? LIMIT 1
 `
 
-func (q *Queries) SelectByCblob(ctx context.Context, cblob []byte) (int64, error) {
-	row := q.db.QueryRowContext(ctx, selectByCblob, cblob)
+func (q *Queries) SelectByCblob(ctx context.Context, cblob []byte, aq ...AdditionalQuery) (int64, error) {
+	query := selectByCblob
+	queryParams := []interface{}{cblob}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	row := q.db.QueryRowContext(ctx, query, queryParams...)
 	var id int64
 	err := row.Scan(&id)
 	return id, err
@@ -52,8 +76,16 @@ SELECT id FROM debug
 WHERE Cbool = ? LIMIT 1
 `
 
-func (q *Queries) SelectByCbool(ctx context.Context, cbool bool) (int64, error) {
-	row := q.db.QueryRowContext(ctx, selectByCbool, cbool)
+func (q *Queries) SelectByCbool(ctx context.Context, cbool bool, aq ...AdditionalQuery) (int64, error) {
+	query := selectByCbool
+	queryParams := []interface{}{cbool}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	row := q.db.QueryRowContext(ctx, query, queryParams...)
 	var id int64
 	err := row.Scan(&id)
 	return id, err
@@ -64,8 +96,16 @@ SELECT id FROM debug
 WHERE Cchar = ? LIMIT 1
 `
 
-func (q *Queries) SelectByCchar(ctx context.Context, cchar string) (int64, error) {
-	row := q.db.QueryRowContext(ctx, selectByCchar, cchar)
+func (q *Queries) SelectByCchar(ctx context.Context, cchar string, aq ...AdditionalQuery) (int64, error) {
+	query := selectByCchar
+	queryParams := []interface{}{cchar}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	row := q.db.QueryRowContext(ctx, query, queryParams...)
 	var id int64
 	err := row.Scan(&id)
 	return id, err
@@ -76,8 +116,16 @@ SELECT id FROM debug
 WHERE Cdate = ? LIMIT 1
 `
 
-func (q *Queries) SelectByCdate(ctx context.Context, cdate time.Time) (int64, error) {
-	row := q.db.QueryRowContext(ctx, selectByCdate, cdate)
+func (q *Queries) SelectByCdate(ctx context.Context, cdate time.Time, aq ...AdditionalQuery) (int64, error) {
+	query := selectByCdate
+	queryParams := []interface{}{cdate}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	row := q.db.QueryRowContext(ctx, query, queryParams...)
 	var id int64
 	err := row.Scan(&id)
 	return id, err
@@ -88,8 +136,16 @@ SELECT id FROM debug
 WHERE Cdatetime = ? LIMIT 1
 `
 
-func (q *Queries) SelectByCdatetime(ctx context.Context, cdatetime time.Time) (int64, error) {
-	row := q.db.QueryRowContext(ctx, selectByCdatetime, cdatetime)
+func (q *Queries) SelectByCdatetime(ctx context.Context, cdatetime time.Time, aq ...AdditionalQuery) (int64, error) {
+	query := selectByCdatetime
+	queryParams := []interface{}{cdatetime}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	row := q.db.QueryRowContext(ctx, query, queryParams...)
 	var id int64
 	err := row.Scan(&id)
 	return id, err
@@ -100,8 +156,16 @@ SELECT id FROM debug
 WHERE Cdec = ? LIMIT 1
 `
 
-func (q *Queries) SelectByCdec(ctx context.Context, cdec string) (int64, error) {
-	row := q.db.QueryRowContext(ctx, selectByCdec, cdec)
+func (q *Queries) SelectByCdec(ctx context.Context, cdec string, aq ...AdditionalQuery) (int64, error) {
+	query := selectByCdec
+	queryParams := []interface{}{cdec}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	row := q.db.QueryRowContext(ctx, query, queryParams...)
 	var id int64
 	err := row.Scan(&id)
 	return id, err
@@ -112,8 +176,16 @@ SELECT id FROM debug
 WHERE Cdecimal = ? LIMIT 1
 `
 
-func (q *Queries) SelectByCdecimal(ctx context.Context, cdecimal string) (int64, error) {
-	row := q.db.QueryRowContext(ctx, selectByCdecimal, cdecimal)
+func (q *Queries) SelectByCdecimal(ctx context.Context, cdecimal string, aq ...AdditionalQuery) (int64, error) {
+	query := selectByCdecimal
+	queryParams := []interface{}{cdecimal}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	row := q.db.QueryRowContext(ctx, query, queryParams...)
 	var id int64
 	err := row.Scan(&id)
 	return id, err
@@ -124,8 +196,16 @@ SELECT id FROM debug
 WHERE Cdouble = ? LIMIT 1
 `
 
-func (q *Queries) SelectByCdouble(ctx context.Context, cdouble float64) (int64, error) {
-	row := q.db.QueryRowContext(ctx, selectByCdouble, cdouble)
+func (q *Queries) SelectByCdouble(ctx context.Context, cdouble float64, aq ...AdditionalQuery) (int64, error) {
+	query := selectByCdouble
+	queryParams := []interface{}{cdouble}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	row := q.db.QueryRowContext(ctx, query, queryParams...)
 	var id int64
 	err := row.Scan(&id)
 	return id, err
@@ -136,8 +216,16 @@ SELECT id FROM debug
 WHERE Cdoubleprecision = ? LIMIT 1
 `
 
-func (q *Queries) SelectByCdoubleprecision(ctx context.Context, cdoubleprecision float64) (int64, error) {
-	row := q.db.QueryRowContext(ctx, selectByCdoubleprecision, cdoubleprecision)
+func (q *Queries) SelectByCdoubleprecision(ctx context.Context, cdoubleprecision float64, aq ...AdditionalQuery) (int64, error) {
+	query := selectByCdoubleprecision
+	queryParams := []interface{}{cdoubleprecision}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	row := q.db.QueryRowContext(ctx, query, queryParams...)
 	var id int64
 	err := row.Scan(&id)
 	return id, err
@@ -148,8 +236,16 @@ SELECT id FROM debug
 WHERE Cenum = ? LIMIT 1
 `
 
-func (q *Queries) SelectByCenum(ctx context.Context, cenum NullDebugCenum) (int64, error) {
-	row := q.db.QueryRowContext(ctx, selectByCenum, cenum)
+func (q *Queries) SelectByCenum(ctx context.Context, cenum NullDebugCenum, aq ...AdditionalQuery) (int64, error) {
+	query := selectByCenum
+	queryParams := []interface{}{cenum}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	row := q.db.QueryRowContext(ctx, query, queryParams...)
 	var id int64
 	err := row.Scan(&id)
 	return id, err
@@ -160,8 +256,16 @@ SELECT id FROM debug
 WHERE Cfixed = ? LIMIT 1
 `
 
-func (q *Queries) SelectByCfixed(ctx context.Context, cfixed string) (int64, error) {
-	row := q.db.QueryRowContext(ctx, selectByCfixed, cfixed)
+func (q *Queries) SelectByCfixed(ctx context.Context, cfixed string, aq ...AdditionalQuery) (int64, error) {
+	query := selectByCfixed
+	queryParams := []interface{}{cfixed}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	row := q.db.QueryRowContext(ctx, query, queryParams...)
 	var id int64
 	err := row.Scan(&id)
 	return id, err
@@ -172,8 +276,16 @@ SELECT id FROM debug
 WHERE Cfloat = ? LIMIT 1
 `
 
-func (q *Queries) SelectByCfloat(ctx context.Context, cfloat float64) (int64, error) {
-	row := q.db.QueryRowContext(ctx, selectByCfloat, cfloat)
+func (q *Queries) SelectByCfloat(ctx context.Context, cfloat float64, aq ...AdditionalQuery) (int64, error) {
+	query := selectByCfloat
+	queryParams := []interface{}{cfloat}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	row := q.db.QueryRowContext(ctx, query, queryParams...)
 	var id int64
 	err := row.Scan(&id)
 	return id, err
@@ -184,8 +296,16 @@ SELECT id FROM debug
 WHERE Cint = ? LIMIT 1
 `
 
-func (q *Queries) SelectByCint(ctx context.Context, cint int32) (int64, error) {
-	row := q.db.QueryRowContext(ctx, selectByCint, cint)
+func (q *Queries) SelectByCint(ctx context.Context, cint int32, aq ...AdditionalQuery) (int64, error) {
+	query := selectByCint
+	queryParams := []interface{}{cint}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	row := q.db.QueryRowContext(ctx, query, queryParams...)
 	var id int64
 	err := row.Scan(&id)
 	return id, err
@@ -196,8 +316,16 @@ SELECT id FROM debug
 WHERE Cinteger = ? LIMIT 1
 `
 
-func (q *Queries) SelectByCinteger(ctx context.Context, cinteger int32) (int64, error) {
-	row := q.db.QueryRowContext(ctx, selectByCinteger, cinteger)
+func (q *Queries) SelectByCinteger(ctx context.Context, cinteger int32, aq ...AdditionalQuery) (int64, error) {
+	query := selectByCinteger
+	queryParams := []interface{}{cinteger}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	row := q.db.QueryRowContext(ctx, query, queryParams...)
 	var id int64
 	err := row.Scan(&id)
 	return id, err
@@ -208,8 +336,16 @@ SELECT id FROM debug
 WHERE Cjson = ? LIMIT 1
 `
 
-func (q *Queries) SelectByCjson(ctx context.Context, cjson json.RawMessage) (int64, error) {
-	row := q.db.QueryRowContext(ctx, selectByCjson, cjson)
+func (q *Queries) SelectByCjson(ctx context.Context, cjson json.RawMessage, aq ...AdditionalQuery) (int64, error) {
+	query := selectByCjson
+	queryParams := []interface{}{cjson}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	row := q.db.QueryRowContext(ctx, query, queryParams...)
 	var id int64
 	err := row.Scan(&id)
 	return id, err
@@ -220,8 +356,16 @@ SELECT id FROM debug
 WHERE Clongblob = ? LIMIT 1
 `
 
-func (q *Queries) SelectByClongblob(ctx context.Context, clongblob []byte) (int64, error) {
-	row := q.db.QueryRowContext(ctx, selectByClongblob, clongblob)
+func (q *Queries) SelectByClongblob(ctx context.Context, clongblob []byte, aq ...AdditionalQuery) (int64, error) {
+	query := selectByClongblob
+	queryParams := []interface{}{clongblob}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	row := q.db.QueryRowContext(ctx, query, queryParams...)
 	var id int64
 	err := row.Scan(&id)
 	return id, err
@@ -232,8 +376,16 @@ SELECT id FROM debug
 WHERE Clongtext = ? LIMIT 1
 `
 
-func (q *Queries) SelectByClongtext(ctx context.Context, clongtext string) (int64, error) {
-	row := q.db.QueryRowContext(ctx, selectByClongtext, clongtext)
+func (q *Queries) SelectByClongtext(ctx context.Context, clongtext string, aq ...AdditionalQuery) (int64, error) {
+	query := selectByClongtext
+	queryParams := []interface{}{clongtext}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	row := q.db.QueryRowContext(ctx, query, queryParams...)
 	var id int64
 	err := row.Scan(&id)
 	return id, err
@@ -244,8 +396,16 @@ SELECT id FROM debug
 WHERE Cmediumblob = ? LIMIT 1
 `
 
-func (q *Queries) SelectByCmediumblob(ctx context.Context, cmediumblob []byte) (int64, error) {
-	row := q.db.QueryRowContext(ctx, selectByCmediumblob, cmediumblob)
+func (q *Queries) SelectByCmediumblob(ctx context.Context, cmediumblob []byte, aq ...AdditionalQuery) (int64, error) {
+	query := selectByCmediumblob
+	queryParams := []interface{}{cmediumblob}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	row := q.db.QueryRowContext(ctx, query, queryParams...)
 	var id int64
 	err := row.Scan(&id)
 	return id, err
@@ -256,8 +416,16 @@ SELECT id FROM debug
 WHERE Cmediumint = ? LIMIT 1
 `
 
-func (q *Queries) SelectByCmediumint(ctx context.Context, cmediumint int32) (int64, error) {
-	row := q.db.QueryRowContext(ctx, selectByCmediumint, cmediumint)
+func (q *Queries) SelectByCmediumint(ctx context.Context, cmediumint int32, aq ...AdditionalQuery) (int64, error) {
+	query := selectByCmediumint
+	queryParams := []interface{}{cmediumint}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	row := q.db.QueryRowContext(ctx, query, queryParams...)
 	var id int64
 	err := row.Scan(&id)
 	return id, err
@@ -268,8 +436,16 @@ SELECT id FROM debug
 WHERE Cmediumtext = ? LIMIT 1
 `
 
-func (q *Queries) SelectByCmediumtext(ctx context.Context, cmediumtext string) (int64, error) {
-	row := q.db.QueryRowContext(ctx, selectByCmediumtext, cmediumtext)
+func (q *Queries) SelectByCmediumtext(ctx context.Context, cmediumtext string, aq ...AdditionalQuery) (int64, error) {
+	query := selectByCmediumtext
+	queryParams := []interface{}{cmediumtext}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	row := q.db.QueryRowContext(ctx, query, queryParams...)
 	var id int64
 	err := row.Scan(&id)
 	return id, err
@@ -280,8 +456,16 @@ SELECT id FROM debug
 WHERE Cnumeric = ? LIMIT 1
 `
 
-func (q *Queries) SelectByCnumeric(ctx context.Context, cnumeric string) (int64, error) {
-	row := q.db.QueryRowContext(ctx, selectByCnumeric, cnumeric)
+func (q *Queries) SelectByCnumeric(ctx context.Context, cnumeric string, aq ...AdditionalQuery) (int64, error) {
+	query := selectByCnumeric
+	queryParams := []interface{}{cnumeric}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	row := q.db.QueryRowContext(ctx, query, queryParams...)
 	var id int64
 	err := row.Scan(&id)
 	return id, err
@@ -292,8 +476,16 @@ SELECT id FROM debug
 WHERE Creal = ? LIMIT 1
 `
 
-func (q *Queries) SelectByCreal(ctx context.Context, creal float64) (int64, error) {
-	row := q.db.QueryRowContext(ctx, selectByCreal, creal)
+func (q *Queries) SelectByCreal(ctx context.Context, creal float64, aq ...AdditionalQuery) (int64, error) {
+	query := selectByCreal
+	queryParams := []interface{}{creal}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	row := q.db.QueryRowContext(ctx, query, queryParams...)
 	var id int64
 	err := row.Scan(&id)
 	return id, err
@@ -304,8 +496,16 @@ SELECT id FROM debug
 WHERE Cset = ? LIMIT 1
 `
 
-func (q *Queries) SelectByCset(ctx context.Context, cset DebugCset) (int64, error) {
-	row := q.db.QueryRowContext(ctx, selectByCset, cset)
+func (q *Queries) SelectByCset(ctx context.Context, cset DebugCset, aq ...AdditionalQuery) (int64, error) {
+	query := selectByCset
+	queryParams := []interface{}{cset}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	row := q.db.QueryRowContext(ctx, query, queryParams...)
 	var id int64
 	err := row.Scan(&id)
 	return id, err
@@ -316,8 +516,16 @@ SELECT id FROM debug
 WHERE Csmallint = ? LIMIT 1
 `
 
-func (q *Queries) SelectByCsmallint(ctx context.Context, csmallint int32) (int64, error) {
-	row := q.db.QueryRowContext(ctx, selectByCsmallint, csmallint)
+func (q *Queries) SelectByCsmallint(ctx context.Context, csmallint int32, aq ...AdditionalQuery) (int64, error) {
+	query := selectByCsmallint
+	queryParams := []interface{}{csmallint}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	row := q.db.QueryRowContext(ctx, query, queryParams...)
 	var id int64
 	err := row.Scan(&id)
 	return id, err
@@ -328,8 +536,16 @@ SELECT id FROM debug
 WHERE Ctext = ? LIMIT 1
 `
 
-func (q *Queries) SelectByCtext(ctx context.Context, ctext string) (int64, error) {
-	row := q.db.QueryRowContext(ctx, selectByCtext, ctext)
+func (q *Queries) SelectByCtext(ctx context.Context, ctext string, aq ...AdditionalQuery) (int64, error) {
+	query := selectByCtext
+	queryParams := []interface{}{ctext}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	row := q.db.QueryRowContext(ctx, query, queryParams...)
 	var id int64
 	err := row.Scan(&id)
 	return id, err
@@ -340,8 +556,16 @@ SELECT id FROM debug
 WHERE Ctime = ? LIMIT 1
 `
 
-func (q *Queries) SelectByCtime(ctx context.Context, ctime time.Time) (int64, error) {
-	row := q.db.QueryRowContext(ctx, selectByCtime, ctime)
+func (q *Queries) SelectByCtime(ctx context.Context, ctime time.Time, aq ...AdditionalQuery) (int64, error) {
+	query := selectByCtime
+	queryParams := []interface{}{ctime}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	row := q.db.QueryRowContext(ctx, query, queryParams...)
 	var id int64
 	err := row.Scan(&id)
 	return id, err
@@ -352,8 +576,16 @@ SELECT id FROM debug
 WHERE Ctimestamp = ? LIMIT 1
 `
 
-func (q *Queries) SelectByCtimestamp(ctx context.Context, ctimestamp time.Time) (int64, error) {
-	row := q.db.QueryRowContext(ctx, selectByCtimestamp, ctimestamp)
+func (q *Queries) SelectByCtimestamp(ctx context.Context, ctimestamp time.Time, aq ...AdditionalQuery) (int64, error) {
+	query := selectByCtimestamp
+	queryParams := []interface{}{ctimestamp}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	row := q.db.QueryRowContext(ctx, query, queryParams...)
 	var id int64
 	err := row.Scan(&id)
 	return id, err
@@ -364,8 +596,16 @@ SELECT id FROM debug
 WHERE Ctinyblob = ? LIMIT 1
 `
 
-func (q *Queries) SelectByCtinyblob(ctx context.Context, ctinyblob []byte) (int64, error) {
-	row := q.db.QueryRowContext(ctx, selectByCtinyblob, ctinyblob)
+func (q *Queries) SelectByCtinyblob(ctx context.Context, ctinyblob []byte, aq ...AdditionalQuery) (int64, error) {
+	query := selectByCtinyblob
+	queryParams := []interface{}{ctinyblob}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	row := q.db.QueryRowContext(ctx, query, queryParams...)
 	var id int64
 	err := row.Scan(&id)
 	return id, err
@@ -376,8 +616,16 @@ SELECT id FROM debug
 WHERE Ctinyint = ? LIMIT 1
 `
 
-func (q *Queries) SelectByCtinyint(ctx context.Context, ctinyint int32) (int64, error) {
-	row := q.db.QueryRowContext(ctx, selectByCtinyint, ctinyint)
+func (q *Queries) SelectByCtinyint(ctx context.Context, ctinyint int32, aq ...AdditionalQuery) (int64, error) {
+	query := selectByCtinyint
+	queryParams := []interface{}{ctinyint}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	row := q.db.QueryRowContext(ctx, query, queryParams...)
 	var id int64
 	err := row.Scan(&id)
 	return id, err
@@ -388,8 +636,16 @@ SELECT id FROM debug
 WHERE Ctinytext = ? LIMIT 1
 `
 
-func (q *Queries) SelectByCtinytext(ctx context.Context, ctinytext string) (int64, error) {
-	row := q.db.QueryRowContext(ctx, selectByCtinytext, ctinytext)
+func (q *Queries) SelectByCtinytext(ctx context.Context, ctinytext string, aq ...AdditionalQuery) (int64, error) {
+	query := selectByCtinytext
+	queryParams := []interface{}{ctinytext}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	row := q.db.QueryRowContext(ctx, query, queryParams...)
 	var id int64
 	err := row.Scan(&id)
 	return id, err
@@ -400,8 +656,16 @@ SELECT id FROM debug
 WHERE Cvarbinary = ? LIMIT 1
 `
 
-func (q *Queries) SelectByCvarbinary(ctx context.Context, cvarbinary []byte) (int64, error) {
-	row := q.db.QueryRowContext(ctx, selectByCvarbinary, cvarbinary)
+func (q *Queries) SelectByCvarbinary(ctx context.Context, cvarbinary []byte, aq ...AdditionalQuery) (int64, error) {
+	query := selectByCvarbinary
+	queryParams := []interface{}{cvarbinary}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	row := q.db.QueryRowContext(ctx, query, queryParams...)
 	var id int64
 	err := row.Scan(&id)
 	return id, err
@@ -412,8 +676,16 @@ SELECT id FROM debug
 WHERE Cvarchar = ? LIMIT 1
 `
 
-func (q *Queries) SelectByCvarchar(ctx context.Context, cvarchar string) (int64, error) {
-	row := q.db.QueryRowContext(ctx, selectByCvarchar, cvarchar)
+func (q *Queries) SelectByCvarchar(ctx context.Context, cvarchar string, aq ...AdditionalQuery) (int64, error) {
+	query := selectByCvarchar
+	queryParams := []interface{}{cvarchar}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	row := q.db.QueryRowContext(ctx, query, queryParams...)
 	var id int64
 	err := row.Scan(&id)
 	return id, err
@@ -424,8 +696,16 @@ SELECT id FROM debug
 WHERE Cyear = ? LIMIT 1
 `
 
-func (q *Queries) SelectByCyear(ctx context.Context, cyear int32) (int64, error) {
-	row := q.db.QueryRowContext(ctx, selectByCyear, cyear)
+func (q *Queries) SelectByCyear(ctx context.Context, cyear int32, aq ...AdditionalQuery) (int64, error) {
+	query := selectByCyear
+	queryParams := []interface{}{cyear}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	row := q.db.QueryRowContext(ctx, query, queryParams...)
 	var id int64
 	err := row.Scan(&id)
 	return id, err
@@ -436,8 +716,16 @@ SELECT id FROM debug
 WHERE id = ? LIMIT 1
 `
 
-func (q *Queries) SelectById(ctx context.Context, id int64) (int64, error) {
-	row := q.db.QueryRowContext(ctx, selectById, id)
+func (q *Queries) SelectById(ctx context.Context, id int64, aq ...AdditionalQuery) (int64, error) {
+	query := selectById
+	queryParams := []interface{}{id}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	row := q.db.QueryRowContext(ctx, query, queryParams...)
 	err := row.Scan(&id)
 	return id, err
 }

--- a/internal/endtoend/testdata/virtual_table/sqlite/go/db.go
+++ b/internal/endtoend/testdata/virtual_table/sqlite/go/db.go
@@ -29,3 +29,8 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/virtual_table/sqlite/go/db.go
+++ b/internal/endtoend/testdata/virtual_table/sqlite/go/db.go
@@ -32,5 +32,5 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/virtual_table/sqlite/go/query.sql.go
+++ b/internal/endtoend/testdata/virtual_table/sqlite/go/query.sql.go
@@ -14,7 +14,10 @@ DELETE FROM tbl_ft WHERE b = ?
 `
 
 func (q *Queries) DeleteTblFt(ctx context.Context, b string) error {
-	_, err := q.db.ExecContext(ctx, deleteTblFt, b)
+	query := deleteTblFt
+	queryParams := []interface{}{b}
+
+	_, err := q.db.ExecContext(ctx, query, queryParams...)
 	return err
 }
 
@@ -28,7 +31,10 @@ type InsertTblFtParams struct {
 }
 
 func (q *Queries) InsertTblFt(ctx context.Context, arg InsertTblFtParams) error {
-	_, err := q.db.ExecContext(ctx, insertTblFt, arg.B, arg.C)
+	query := insertTblFt
+	queryParams := []interface{}{arg.B, arg.C}
+
+	_, err := q.db.ExecContext(ctx, query, queryParams...)
 	return err
 }
 
@@ -37,8 +43,16 @@ SELECT b FROM ft
 WHERE b MATCH ?
 `
 
-func (q *Queries) SelectAllColsFt(ctx context.Context, b string) ([]string, error) {
-	rows, err := q.db.QueryContext(ctx, selectAllColsFt, b)
+func (q *Queries) SelectAllColsFt(ctx context.Context, b string, aq ...AdditionalQuery) ([]string, error) {
+	query := selectAllColsFt
+	queryParams := []interface{}{b}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.QueryContext(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}
@@ -65,8 +79,16 @@ SELECT b, c FROM tbl_ft
 WHERE b MATCH ?
 `
 
-func (q *Queries) SelectAllColsTblFt(ctx context.Context, b string) ([]TblFt, error) {
-	rows, err := q.db.QueryContext(ctx, selectAllColsTblFt, b)
+func (q *Queries) SelectAllColsTblFt(ctx context.Context, b string, aq ...AdditionalQuery) ([]TblFt, error) {
+	query := selectAllColsTblFt
+	queryParams := []interface{}{b}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.QueryContext(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}
@@ -99,8 +121,16 @@ type SelectBm25FuncRow struct {
 	Bm25 float64
 }
 
-func (q *Queries) SelectBm25Func(ctx context.Context, b string) ([]SelectBm25FuncRow, error) {
-	rows, err := q.db.QueryContext(ctx, selectBm25Func, b)
+func (q *Queries) SelectBm25Func(ctx context.Context, b string, aq ...AdditionalQuery) ([]SelectBm25FuncRow, error) {
+	query := selectBm25Func
+	queryParams := []interface{}{b}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.QueryContext(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}
@@ -127,8 +157,16 @@ SELECT highlight(tbl_ft, 0, '<b>', '</b>') FROM tbl_ft
 WHERE b MATCH ?
 `
 
-func (q *Queries) SelectHightlighFunc(ctx context.Context, b string) ([]string, error) {
-	rows, err := q.db.QueryContext(ctx, selectHightlighFunc, b)
+func (q *Queries) SelectHightlighFunc(ctx context.Context, b string, aq ...AdditionalQuery) ([]string, error) {
+	query := selectHightlighFunc
+	queryParams := []interface{}{b}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.QueryContext(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}
@@ -155,8 +193,16 @@ SELECT b FROM ft
 WHERE b = ?
 `
 
-func (q *Queries) SelectOneColFt(ctx context.Context, b string) ([]string, error) {
-	rows, err := q.db.QueryContext(ctx, selectOneColFt, b)
+func (q *Queries) SelectOneColFt(ctx context.Context, b string, aq ...AdditionalQuery) ([]string, error) {
+	query := selectOneColFt
+	queryParams := []interface{}{b}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.QueryContext(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}
@@ -183,8 +229,16 @@ SELECT c FROM tbl_ft
 WHERE b = ?
 `
 
-func (q *Queries) SelectOneColTblFt(ctx context.Context, b string) ([]string, error) {
-	rows, err := q.db.QueryContext(ctx, selectOneColTblFt, b)
+func (q *Queries) SelectOneColTblFt(ctx context.Context, b string, aq ...AdditionalQuery) ([]string, error) {
+	query := selectOneColTblFt
+	queryParams := []interface{}{b}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.QueryContext(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}
@@ -210,8 +264,16 @@ const selectSnippetFunc = `-- name: SelectSnippetFunc :many
 SELECT snippet(tbl_ft, 0, '<b>', '</b>', 'aa', ?) FROM tbl_ft
 `
 
-func (q *Queries) SelectSnippetFunc(ctx context.Context, snippet int64) ([]string, error) {
-	rows, err := q.db.QueryContext(ctx, selectSnippetFunc, snippet)
+func (q *Queries) SelectSnippetFunc(ctx context.Context, snippet int64, aq ...AdditionalQuery) ([]string, error) {
+	query := selectSnippetFunc
+	queryParams := []interface{}{snippet}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	rows, err := q.db.QueryContext(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}
@@ -243,6 +305,9 @@ type UpdateTblFtParams struct {
 }
 
 func (q *Queries) UpdateTblFt(ctx context.Context, arg UpdateTblFtParams) error {
-	_, err := q.db.ExecContext(ctx, updateTblFt, arg.C, arg.B)
+	query := updateTblFt
+	queryParams := []interface{}{arg.C, arg.B}
+
+	_, err := q.db.ExecContext(ctx, query, queryParams...)
 	return err
 }

--- a/internal/endtoend/testdata/where_collate/sqlite/go/db.go
+++ b/internal/endtoend/testdata/where_collate/sqlite/go/db.go
@@ -29,3 +29,8 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/where_collate/sqlite/go/db.go
+++ b/internal/endtoend/testdata/where_collate/sqlite/go/db.go
@@ -32,5 +32,5 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }

--- a/internal/endtoend/testdata/where_collate/sqlite/go/query.sql.go
+++ b/internal/endtoend/testdata/where_collate/sqlite/go/query.sql.go
@@ -15,8 +15,16 @@ WHERE name = ? COLLATE NOCASE
 LIMIT 1
 `
 
-func (q *Queries) GetAccountByName(ctx context.Context, name string) (Account, error) {
-	row := q.db.QueryRowContext(ctx, getAccountByName, name)
+func (q *Queries) GetAccountByName(ctx context.Context, name string, aq ...AdditionalQuery) (Account, error) {
+	query := getAccountByName
+	queryParams := []interface{}{name}
+
+	if len(aq) > 0 {
+		query += " " + aq[0].SQL
+		queryParams = append(queryParams, aq[0].Args...)
+	}
+
+	row := q.db.QueryRowContext(ctx, query, queryParams...)
 	var i Account
 	err := row.Scan(&i.ID, &i.Name)
 	return i, err

--- a/internal/endtoend/testdata/yaml_overrides/go/db.go
+++ b/internal/endtoend/testdata/yaml_overrides/go/db.go
@@ -29,3 +29,8 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 		db: tx,
 	}
 }
+
+type AdditionalQuery struct {
+	SQL  string
+	Args []any
+}

--- a/internal/endtoend/testdata/yaml_overrides/go/db.go
+++ b/internal/endtoend/testdata/yaml_overrides/go/db.go
@@ -32,5 +32,5 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 
 type AdditionalQuery struct {
 	SQL  string
-	Args []any
+	Args []interface{}
 }


### PR DESCRIPTION
## What is this?

This PR is implementation for my proposal in #2021 to allow additional query as function parameter in `:one` and `:many` queries. I've explained my reasoning there, but I will rewrite it again here for clarity.

## Why?

One of the most common feature request for CRUD and BI apps is to make an _**advanced data filter**_ where the users can freely define the parameters to specify which data to be shown. However, since `sqlc` act as compiler for SQL queries to Go code, once the compilation finished it can't be modified anymore. Thanks to this, advanced data filter is impossible to done properly with `sqlc`.

To solve this issue, this PR add `AdditionalQuery` as function parameter in the compiled `:one` and `:many` queries. This way we still able to create advanced data filter while retaining the advantage of compiling the SQL queries.

## Example

For example, let's say we have queries like this:

```sql
-- Example queries for sqlc
CREATE TABLE IF NOT EXISTS product (
	id           INT UNSIGNED  NOT NULL AUTO_INCREMENT,
	identifier   VARBINARY(20) DEFAULT NULL,
	category     VARCHAR(80)   NOT NULL,
	name         VARCHAR(80)   NOT NULL,
	qty          DECIMAL(20,4) NOT NULL,
	capital      DECIMAL(20,4) NOT NULL,
	price        DECIMAL(20,4) NOT NULL,
	specs        JSON          DEFAULT NULL,
	PRIMARY KEY (id),
	UNIQUE KEY product_identifier_UNIQUE (identifier)
) CHARACTER SET utf8mb4;

-- name: FetchProducts :many
SELECT id, category, identifier, name, capital, price
FROM product;
```

From this query, `sqlc` will generate following Go code:

```go
const FetchProducts = `-- name: FetchProducts :many
SELECT id, category, identifier, name, capital, price
FROM product;
`

type FetchProductsRow struct { // Omitted }

func (q *Queries) FetchProducts(ctx context.Context, db DBTX) ([]FetchProductsRow, error) {
	rows, err := db.QueryContext(ctx, FetchProducts)
	if err != nil {
		return nil, err
	}
	defer rows.Close()
	items := []FetchProductsRow{}
	// Omitted
	return items, nil
}
```

As you can see, currently our query for FetchProducts is run immediately by db.QueryContext, making it impossible to define custom SQL filter.

To allow custom SQL filter, this PR will add `AdditionalQuery` as function parameter for SELECT queries. Here is the generated Go code with this PR:

 ```go
type AdditionalQuery struct {
	SQL  string
	Args []any
}

const FetchProducts = `-- name: FetchProducts :many
SELECT id, identifier, name, capital, price FROM product
`

type FetchProductsRow struct { // Omitted }

func (q *Queries) FetchProducts(ctx context.Context, db DBTX, aq ...AdditionalQuery) ([]FetchProductsRow, error) {
	query := FetchProducts
	queryParams := []interface{}{}

	if len(aq) > 0 {
		query += " " + aq[0].SQL
		queryParams = append(queryParams, aq[0].Args...)
	}

	rows, err := db.QueryContext(ctx, query, queryParams...)
	if err != nil {
		return nil, err
	}
	defer rows.Close()
	items := []FetchProductsRow{}
	// Omitted
	return items, nil
}
```

With that new parameter, now we can define custom filter like this:

```go
sql := `WHERE (
	category LIKE ?
	AND name LIKE ?
	AND capital < ?)`
args := []interface{}{
	"%Man%",
	"%Shirt%",
	500}
filter := AdditionalQuery{SQL: sql, Args: args}
products, err := FetchProducts(ctx, db, filter)
```

## Difference with the proposal

If you've read my proposal before, you'll notice there is one difference between the proposal and this PR: in proposal I suggest to wrap the SELECT query inside sub-query.

I decided to not implement it because there might be performance issue coming from using sub-query. Not to mention from the user perspective (i.e. other developers who use sqlc), usually they don't like if the compiler modify their SQL query without any information.

## Pros and cons of this PR

The pros are:

- Making data filter is really easy now, since we can simply add whatever SQL queries that we want. Besides for filter, we can also use the additional SQL for other purpose, e.g. data sorting or limit.
- For sqlc users, since the AdditionalQuery parameter is variadic, it means the generated code can be used as it is so there are no need to modify the existing code.

I'm not really sure about the cons. I've used this PR in production and it seems to be fine. However I'm only using it for basic SELECT queries, so there might be some edge cases that I'm not aware of.

## Status of this PR

I've separated this PR into several commits:

- [209c3df](https://github.com/sqlc-dev/sqlc/pull/2636/commits/209c3dfd1a3c80c42c589e43ace3780142302380) is the main change in this PR which modified the template files.
- [c28d048](https://github.com/sqlc-dev/sqlc/pull/2636/commits/c28d048d6e643618932f50f3fe3ae4242307f63b) contains files that generated by `make regen`.
- [e874732](https://github.com/sqlc-dev/sqlc/pull/2636/commits/e87473260a7214ba8aa4786ac18ee48452b8ad9e) fix test `diff_output` and `diff_no_output`.
- [f15bd18](https://github.com/sqlc-dev/sqlc/pull/2636/commits/f15bd18f027711a6668bf379d9f35bb026682b94) fix test for `process_plugin_disabled`.