### PR TITLE
refactor(astutils): remove redundant nil check in `Walk`

### DIFF
--- a/internal/sql/astutils/walk.go
+++ b/internal/sql/astutils/walk.go
@@ -2158,10 +2158,8 @@ func Walk(f Visitor, node ast.Node) {
 		}
 
 	case *ast.In:
-		if n.List != nil {
-			for _, l := range n.List {
-				Walk(f, l)
-			}
+		for _, l := range n.List {
+			Walk(f, l)
 		}
 		if n.Sel != nil {
 			Walk(f, n.Sel)


### PR DESCRIPTION
From the Go docs:

>  "For a nil slice, the number of iterations is 0." https://go.dev/ref/spec#For_range

Therefore, an additional nil check for before the loop is unnecessary. Example: https://go.dev/play/p/tMQ9JcUOMcI