### PR TITLE
docs: Missing emit_pointers_for_null_types configuration option in version 2 (#2682)

### DIFF
--- a/docs/reference/config.md
+++ b/docs/reference/config.md
@@ -138,6 +138,8 @@ The `gen` mapping supports the following keys:
   - If true, parameters are passed as pointers to structs. Defaults to `false`.
 - `emit_methods_with_db_argument`:
   - If true, generated methods will accept a DBTX argument instead of storing a DBTX on the `*Queries` struct. Defaults to `false`.
+- `emit_pointers_for_null_types`:
+  - If true and `sql_package` is set to `pgx/v4` or `pgx/v5`, generated types for nullable columns are emitted as pointers (ie. `*string`) instead of `database/sql` null types (ie. `NullString`). Defaults to `false`.
 - `emit_enum_valid_method`:
   - If true, generate a Valid method on enum types,
     indicating whether a string is a valid enum value.


### PR DESCRIPTION
[#2682](https://github.com/sqlc-dev/sqlc/issues/2682)