### PR TITLE
build(windows): Downgrade to mingw 11.2.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,10 +6,11 @@ on:
   pull_request:
 jobs:
   windows-build:
-    # if: ${{ github.ref == 'refs/heads/main' }}
+    if: ${{ github.ref == 'refs/heads/main' }}
     runs-on: windows-latest
     steps:
     - uses: actions/checkout@v4
+    # wasmtime can't be built with 12.2
     - run: choco install mingw --version 11.2.0.07112021 --allow-downgrade
     - uses: actions/setup-go@v4
       with:
@@ -27,7 +28,6 @@ jobs:
     - run: go build ./...
 
   build:
-    if: false
     name: test
     runs-on: ubuntu-latest
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: windows-latest
     steps:
     - uses: actions/checkout@v4
-    - run: choco install mingw --version 11.2.0.07112021
+    - run: choco install mingw --version 11.2.0.07112021 --allow-downgrade
     - uses: actions/setup-go@v4
       with:
         go-version: '1.21.1'
@@ -27,6 +27,7 @@ jobs:
     - run: go build ./...
 
   build:
+    if: false
     name: test
     runs-on: ubuntu-latest
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,10 +6,11 @@ on:
   pull_request:
 jobs:
   windows-build:
-    if: ${{ github.ref == 'refs/heads/main' }}
+    # if: ${{ github.ref == 'refs/heads/main' }}
     runs-on: windows-latest
     steps:
     - uses: actions/checkout@v4
+    - run: choco install mingw --version 11.2.0.07112021
     - uses: actions/setup-go@v4
       with:
         go-version: '1.21.1'


### PR DESCRIPTION
This change significantly slows down the Windows build, but it's the only way I've found to fix the failures we're seeing.