### PR TITLE
chore(endtoend): Skip tests if secrets are missing

### DIFF
--- a/internal/endtoend/ddl_test.go
+++ b/internal/endtoend/ddl_test.go
@@ -23,13 +23,8 @@ func TestValidSchema(t *testing.T) {
 
 	projectID := os.Getenv("CI_SQLC_PROJECT_ID")
 	authToken := os.Getenv("CI_SQLC_AUTH_TOKEN")
-
 	if projectID == "" || authToken == "" {
-		if os.Getenv("CI") == "" {
-			t.Skip("skiping ddl tests outside of CI")
-		} else {
-			t.Fatal("missing project id and auth token")
-		}
+		t.Skip("missing project id or auth token")
 	}
 
 	client, err := quickdb.NewClient(projectID, authToken)

--- a/internal/endtoend/vet_test.go
+++ b/internal/endtoend/vet_test.go
@@ -31,6 +31,11 @@ func TestExamplesVet(t *testing.T) {
 	t.Parallel()
 	ctx := context.Background()
 
+	authToken := os.Getenv("SQLC_AUTH_TOKEN")
+	if authToken == "" {
+		t.Skip("missing auth token")
+	}
+
 	examples, err := filepath.Abs(filepath.Join("..", "..", "examples"))
 	if err != nil {
 		t.Fatal(err)


### PR DESCRIPTION
GitHub does not populate secrets on pull requests sent from a forked repository. Skip tests that require these secrets when they aren't present.