### PR TITLE
feat: wildcard in queries config

### DIFF
--- a/internal/sql/sqlpath/read.go
+++ b/internal/sql/sqlpath/read.go
@@ -13,21 +13,27 @@ import (
 // in .sql. Omits hidden files, directories, and migrations.
 func Glob(paths []string) ([]string, error) {
 	var files []string
-	for _, path := range paths {
-		f, err := os.Stat(path)
+	for _, pathForGlob := range paths {
+		globPaths, err := filepath.Glob(pathForGlob)
 		if err != nil {
-			return nil, fmt.Errorf("path %s does not exist", path)
+			return nil, err
 		}
-		if f.IsDir() {
-			listing, err := os.ReadDir(path)
+		for _, path := range globPaths {
+			f, err := os.Stat(path)
 			if err != nil {
-				return nil, err
+				return nil, fmt.Errorf("path %s does not exist", path)
 			}
-			for _, f := range listing {
-				files = append(files, filepath.Join(path, f.Name()))
+			if f.IsDir() {
+				listing, err := os.ReadDir(path)
+				if err != nil {
+					return nil, err
+				}
+				for _, f := range listing {
+					files = append(files, filepath.Join(path, f.Name()))
+				}
+			} else {
+				files = append(files, path)
 			}
-		} else {
-			files = append(files, path)
 		}
 	}
 	var sqlFiles []string


### PR DESCRIPTION
We've got two databases and the same code need to use both of them. So the best way will be:

```
/authenticate
  /authenticate.go
  /query.firstdb.sql
  /query.seconddb.sql
```

And in config we can write:

```
version: "2"
sql:
  - engine: "postgresql"
    queries:
      - "./firstdb/"
      - "./features/*.firstdb.sql"
    schema: "./firstdb/schema.sql"
    gen:
      go:
        package: "firstdb"
        out: "firstdb"
  - engine: "postgresql"
    queries:
      - "./seconddb/schema.sql"
      - "./features/*.seconddb.sql"
    schema: "./seconddb/schema.sql"
    gen:
      go:
        package: "seconddb"
        out: "seconddb"
```

So wildcard in queries helps us to distinguish between sql to first or second DB.