### PR TITLE
docs: add clarity and reference to JSON tags

### DIFF
--- a/docs/howto/structs.md
+++ b/docs/howto/structs.md
@@ -31,7 +31,8 @@ CREATE TABLE authors (
 );
 ```
 
-sqlc can generate structs with JSON tags by adding the `emit_json_tags` key to the configuration file as it shows on (configuration reference)[../reference/config.md], by default `false`. The JSON name for a field matches
+sqlc can generate structs with JSON tags by adding the `emit_json_tags` key to the configuration file as it shows on [configuration reference](../reference/config.md).
+The JSON name for a field matches
 the column name in the database.
 
 ```go

--- a/docs/howto/structs.md
+++ b/docs/howto/structs.md
@@ -31,7 +31,7 @@ CREATE TABLE authors (
 );
 ```
 
-sqlc can generate structs with JSON tags. The JSON name for a field matches
+sqlc can generate structs with JSON tags by adding the `emit_json_tags` key to the configuration file as it shows on (configuration reference)[../reference/config.md], by default `false`. The JSON name for a field matches
 the column name in the database.
 
 ```go


### PR DESCRIPTION
* Update docs/howto/structs.md

Added a link to the configuration reference on the JSON tags session.