### PR TITLE
feat(generate): support yml extension

### DIFF
--- a/.github/ISSUE_TEMPLATE/BUG_REPORT.yml
+++ b/.github/ISSUE_TEMPLATE/BUG_REPORT.yml
@@ -51,7 +51,7 @@ body:
     id: config
     attributes:
       label: Configuration
-      description: Please include the sqlc.yaml or sqlc.json file you using in your project. This will be automatically formatted, so no need for backticks.
+      description: Please include the sqlc.(yaml|yml) or sqlc.json file you using in your project. This will be automatically formatted, so no need for backticks.
       render: yaml
   - type: input
     id: playground

--- a/docs/reference/config.md
+++ b/docs/reference/config.md
@@ -61,24 +61,24 @@ The `codegen` mapping supports the following keys:
   - A mapping of plugin-specific options.
 
 ```yaml
-version: "2"
+version: '2'
 plugins:
-  - name: py
-    wasm:
-      url: https://github.com/sqlc-dev/sqlc-gen-python/releases/download/v0.16.0-alpha/sqlc-gen-python.wasm
-      sha256: 428476c7408fd4c032da4ec74e8a7344f4fa75e0f98a5a3302f238283b9b95f2
+- name: py
+  wasm:
+    url: https://github.com/sqlc-dev/sqlc-gen-python/releases/download/v0.16.0-alpha/sqlc-gen-python.wasm
+    sha256: 428476c7408fd4c032da4ec74e8a7344f4fa75e0f98a5a3302f238283b9b95f2
 sql:
-  - schema: "schema.sql"
-    queries: "query.sql"
-    engine: postgresql
-    codegen:
-      - out: src/authors
-        plugin: py
-        options:
-          package: authors
-          emit_sync_querier: true
-          emit_async_querier: true
-          query_parameter_limit: 5
+- schema: "schema.sql"
+  queries: "query.sql"
+  engine: postgresql
+  codegen:
+  - out: src/authors
+    plugin: py
+    options:
+      package: authors
+      emit_sync_querier: true
+      emit_async_querier: true
+      query_parameter_limit: 5
 ```
 
 ### database
@@ -93,19 +93,19 @@ syntax. In the following example, the connection string will have the value of
 the `PG_PASSWORD` environment variable set as its password.
 
 ```yaml
-version: "2"
+version: '2'
 sql:
-  - schema: schema.sql
-    queries: query.sql
-    engine: postgresql
-    database:
-      uri: postgresql://postgres:${PG_PASSWORD}@localhost:5432/authors
-    gen:
-      go:
-        package: authors
-        out: postgresql
+- schema: schema.sql
+  queries: query.sql
+  engine: postgresql
+  database:
+    uri: postgresql://postgres:${PG_PASSWORD}@localhost:5432/authors
+  gen:
+    go:
+      package: authors
+      out: postgresql
 ```
-
+ 
 ### gen
 
 The `gen` mapping supports the following keys:
@@ -255,19 +255,19 @@ Each mapping in the `plugins` collection has the following keys:
     - The URL to fetch the WASM file. Supports the `https://` or `file://` schemes.
   - `sha256`
     - The SHA256 checksum for the downloaded file.
-
+   
 ```yaml
 version: "2"
 plugins:
-  - name: "py"
-    wasm:
-      url: "https://github.com/sqlc-dev/sqlc-gen-python/releases/download/v0.16.0-alpha/sqlc-gen-python.wasm"
-      sha256: "428476c7408fd4c032da4ec74e8a7344f4fa75e0f98a5a3302f238283b9b95f2"
-  - name: "js"
-    env:
-      - PATH
-    process:
-      cmd: "sqlc-gen-json"
+- name: "py"
+  wasm: 
+    url: "https://github.com/sqlc-dev/sqlc-gen-python/releases/download/v0.16.0-alpha/sqlc-gen-python.wasm"
+    sha256: "428476c7408fd4c032da4ec74e8a7344f4fa75e0f98a5a3302f238283b9b95f2"
+- name: "js"
+  env:
+  - PATH
+  process: 
+    cmd: "sqlc-gen-json"
 ```
 
 ### rules
@@ -283,7 +283,7 @@ Each mapping in the `rules` collection has the following keys:
 
 See the [vet](../howto/vet.md) documentation for a list of built-in rules and
 help writing custom rules.
-
+   
 ```yaml
 version: "2"
 sql:
@@ -317,11 +317,11 @@ rules:
     rule: |
       query.cmd == "exec"
 ```
-
+  
 ### global overrides
 
 Sometimes, the same configuration must be done across various specifications of
-code generation. Then a global definition for type overriding and field
+code generation.  Then a global definition for type overriding and field
 renaming can be done using the `overrides` mapping the following manner:
 
 ```yaml
@@ -339,27 +339,27 @@ overrides:
           package: "null"
           type: "Time"
 sql:
-  - schema: "postgresql/schema.sql"
-    queries: "postgresql/query.sql"
-    engine: "postgresql"
-    gen:
-      go:
-        package: "authors"
-        out: "postgresql"
-  - schema: "mysql/schema.sql"
-    queries: "mysql/query.sql"
-    engine: "mysql"
-    gen:
-      go:
-        package: "authors"
-        out: "mysql"
+- schema: "postgresql/schema.sql"
+  queries: "postgresql/query.sql"
+  engine: "postgresql"
+  gen:
+    go: 
+      package: "authors"
+      out: "postgresql"
+- schema: "mysql/schema.sql"
+  queries: "mysql/query.sql"
+  engine: "mysql"
+  gen:
+    go:
+      package: "authors"
+      out: "mysql"
 ```
 
 With the previous configuration, whenever a struct field is generated from a
 table column that is called `id`, it will generated as `Identifier`.
 
 Also, whenever there is a nullable `timestamp with time zone` column in a
-Postgres table, it will be generated as `null.Time`. Note that the mapping for
+Postgres table, it will be generated as `null.Time`.  Note that the mapping for
 global type overrides has a field called `engine` that is absent in the regular
 type overrides. This field is only used when there are multiple definitions
 using multiple engines. Otherwise, the value of the `engine` key

--- a/docs/reference/config.md
+++ b/docs/reference/config.md
@@ -8,24 +8,24 @@ file must be in the directory where the `sqlc` command is run.
 ```yaml
 version: "2"
 sql:
-  - schema: "postgresql/schema.sql"
-    queries: "postgresql/query.sql"
-    engine: "postgresql"
-    gen:
-      go:
-        package: "authors"
-        out: "postgresql"
-    database:
-      uri: "postgresql://postgres:postgres@localhost:5432/postgres"
-    rules:
-      - sqlc/db-prepare
-  - schema: "mysql/schema.sql"
-    queries: "mysql/query.sql"
-    engine: "mysql"
-    gen:
-      go:
-        package: "authors"
-        out: "mysql"
+- schema: "postgresql/schema.sql"
+  queries: "postgresql/query.sql"
+  engine: "postgresql"
+  gen:
+    go: 
+      package: "authors"
+      out: "postgresql"
+  database:
+    uri: "postgresql://postgres:postgres@localhost:5432/postgres"
+  rules:
+    - sqlc/db-prepare
+- schema: "mysql/schema.sql"
+  queries: "mysql/query.sql"
+  engine: "mysql"
+  gen:
+    go:
+      package: "authors"
+      out: "mysql"
 ```
 
 ### sql

--- a/docs/reference/config.md
+++ b/docs/reference/config.md
@@ -8,24 +8,24 @@ file must be in the directory where the `sqlc` command is run.
 ```yaml
 version: "2"
 sql:
-- schema: "postgresql/schema.sql"
-  queries: "postgresql/query.sql"
-  engine: "postgresql"
-  gen:
-    go: 
-      package: "authors"
-      out: "postgresql"
-  database:
-    uri: "postgresql://postgres:postgres@localhost:5432/postgres"
-  rules:
-    - sqlc/db-prepare
-- schema: "mysql/schema.sql"
-  queries: "mysql/query.sql"
-  engine: "mysql"
-  gen:
-    go:
-      package: "authors"
-      out: "mysql"
+  - schema: "postgresql/schema.sql"
+    queries: "postgresql/query.sql"
+    engine: "postgresql"
+    gen:
+      go:
+        package: "authors"
+        out: "postgresql"
+    database:
+      uri: "postgresql://postgres:postgres@localhost:5432/postgres"
+    rules:
+      - sqlc/db-prepare
+  - schema: "mysql/schema.sql"
+    queries: "mysql/query.sql"
+    engine: "mysql"
+    gen:
+      go:
+        package: "authors"
+        out: "mysql"
 ```
 
 ### sql

--- a/docs/reference/config.md
+++ b/docs/reference/config.md
@@ -1,6 +1,6 @@
 # Configuration
 
-The `sqlc` tool is configured via a `sqlc.yaml` or `sqlc.json` file. This
+The `sqlc` tool is configured via a `sqlc.(yaml|yml)` or `sqlc.json` file. This
 file must be in the directory where the `sqlc` command is run.
 
 ## Version 2
@@ -61,24 +61,24 @@ The `codegen` mapping supports the following keys:
   - A mapping of plugin-specific options.
 
 ```yaml
-version: '2'
+version: "2"
 plugins:
-- name: py
-  wasm:
-    url: https://github.com/sqlc-dev/sqlc-gen-python/releases/download/v0.16.0-alpha/sqlc-gen-python.wasm
-    sha256: 428476c7408fd4c032da4ec74e8a7344f4fa75e0f98a5a3302f238283b9b95f2
+  - name: py
+    wasm:
+      url: https://github.com/sqlc-dev/sqlc-gen-python/releases/download/v0.16.0-alpha/sqlc-gen-python.wasm
+      sha256: 428476c7408fd4c032da4ec74e8a7344f4fa75e0f98a5a3302f238283b9b95f2
 sql:
-- schema: "schema.sql"
-  queries: "query.sql"
-  engine: postgresql
-  codegen:
-  - out: src/authors
-    plugin: py
-    options:
-      package: authors
-      emit_sync_querier: true
-      emit_async_querier: true
-      query_parameter_limit: 5
+  - schema: "schema.sql"
+    queries: "query.sql"
+    engine: postgresql
+    codegen:
+      - out: src/authors
+        plugin: py
+        options:
+          package: authors
+          emit_sync_querier: true
+          emit_async_querier: true
+          query_parameter_limit: 5
 ```
 
 ### database
@@ -93,19 +93,19 @@ syntax. In the following example, the connection string will have the value of
 the `PG_PASSWORD` environment variable set as its password.
 
 ```yaml
-version: '2'
+version: "2"
 sql:
-- schema: schema.sql
-  queries: query.sql
-  engine: postgresql
-  database:
-    uri: postgresql://postgres:${PG_PASSWORD}@localhost:5432/authors
-  gen:
-    go:
-      package: authors
-      out: postgresql
+  - schema: schema.sql
+    queries: query.sql
+    engine: postgresql
+    database:
+      uri: postgresql://postgres:${PG_PASSWORD}@localhost:5432/authors
+    gen:
+      go:
+        package: authors
+        out: postgresql
 ```
- 
+
 ### gen
 
 The `gen` mapping supports the following keys:
@@ -255,19 +255,19 @@ Each mapping in the `plugins` collection has the following keys:
     - The URL to fetch the WASM file. Supports the `https://` or `file://` schemes.
   - `sha256`
     - The SHA256 checksum for the downloaded file.
-   
+
 ```yaml
 version: "2"
 plugins:
-- name: "py"
-  wasm: 
-    url: "https://github.com/sqlc-dev/sqlc-gen-python/releases/download/v0.16.0-alpha/sqlc-gen-python.wasm"
-    sha256: "428476c7408fd4c032da4ec74e8a7344f4fa75e0f98a5a3302f238283b9b95f2"
-- name: "js"
-  env:
-  - PATH
-  process: 
-    cmd: "sqlc-gen-json"
+  - name: "py"
+    wasm:
+      url: "https://github.com/sqlc-dev/sqlc-gen-python/releases/download/v0.16.0-alpha/sqlc-gen-python.wasm"
+      sha256: "428476c7408fd4c032da4ec74e8a7344f4fa75e0f98a5a3302f238283b9b95f2"
+  - name: "js"
+    env:
+      - PATH
+    process:
+      cmd: "sqlc-gen-json"
 ```
 
 ### rules
@@ -283,7 +283,7 @@ Each mapping in the `rules` collection has the following keys:
 
 See the [vet](../howto/vet.md) documentation for a list of built-in rules and
 help writing custom rules.
-   
+
 ```yaml
 version: "2"
 sql:
@@ -317,11 +317,11 @@ rules:
     rule: |
       query.cmd == "exec"
 ```
-  
+
 ### global overrides
 
 Sometimes, the same configuration must be done across various specifications of
-code generation.  Then a global definition for type overriding and field
+code generation. Then a global definition for type overriding and field
 renaming can be done using the `overrides` mapping the following manner:
 
 ```yaml
@@ -339,27 +339,27 @@ overrides:
           package: "null"
           type: "Time"
 sql:
-- schema: "postgresql/schema.sql"
-  queries: "postgresql/query.sql"
-  engine: "postgresql"
-  gen:
-    go: 
-      package: "authors"
-      out: "postgresql"
-- schema: "mysql/schema.sql"
-  queries: "mysql/query.sql"
-  engine: "mysql"
-  gen:
-    go:
-      package: "authors"
-      out: "mysql"
+  - schema: "postgresql/schema.sql"
+    queries: "postgresql/query.sql"
+    engine: "postgresql"
+    gen:
+      go:
+        package: "authors"
+        out: "postgresql"
+  - schema: "mysql/schema.sql"
+    queries: "mysql/query.sql"
+    engine: "mysql"
+    gen:
+      go:
+        package: "authors"
+        out: "mysql"
 ```
 
 With the previous configuration, whenever a struct field is generated from a
 table column that is called `id`, it will generated as `Identifier`.
 
 Also, whenever there is a nullable `timestamp with time zone` column in a
-Postgres table, it will be generated as `null.Time`.  Note that the mapping for
+Postgres table, it will be generated as `null.Time`. Note that the mapping for
 global type overrides has a field called `engine` that is absent in the regular
 type overrides. This field is only used when there are multiple definitions
 using multiple engines. Otherwise, the value of the `engine` key

--- a/docs/tutorials/getting-started-mysql.md
+++ b/docs/tutorials/getting-started-mysql.md
@@ -11,7 +11,7 @@ Initialize a new Go module named `tutorial.sql.dev/app`
 go mod init tutorial.sqlc.dev/app
 ```
 
-sqlc looks for either a `sqlc.yaml` or `sqlc.json` file in the current
+sqlc looks for either a `sqlc.(yaml|yml)` or `sqlc.json` file in the current
 directory. In our new directory, create a file named `sqlc.yaml` with the
 following contents:
 

--- a/docs/tutorials/getting-started-postgresql.md
+++ b/docs/tutorials/getting-started-postgresql.md
@@ -1,4 +1,4 @@
-# Getting started with PostgreSQL 
+# Getting started with PostgreSQL
 
 This tutorial assumes that the latest version of sqlc is
 [installed](../overview/install.md) and ready to use.
@@ -11,7 +11,7 @@ Initialize a new Go module named `tutorial.sqlc.dev/app`
 go mod init tutorial.sqlc.dev/app
 ```
 
-sqlc looks for either a `sqlc.yaml` or `sqlc.json` file in the current
+sqlc looks for either a `sqlc.(yaml|yml)` or `sqlc.json` file in the current
 directory. In our new directory, create a file named `sqlc.yaml` with the
 following contents:
 

--- a/docs/tutorials/getting-started-sqlite.md
+++ b/docs/tutorials/getting-started-sqlite.md
@@ -11,7 +11,7 @@ Initialize a new Go module named `tutorial.sql.dev/app`
 go mod init tutorial.sqlc.dev/app
 ```
 
-sqlc looks for either a `sqlc.yaml` or `sqlc.json` file in the current
+sqlc looks for either a `sqlc.(yaml|yml)` or `sqlc.json` file in the current
 directory. In our new directory, create a file named `sqlc.yaml` with the
 following contents:
 

--- a/internal/cmd/generate.go
+++ b/internal/cmd/generate.go
@@ -97,7 +97,7 @@ func readConfig(stderr io.Writer, dir, filename string) (string, *config.Config,
 			return "", nil, errors.New("config file missing")
 		}
 
-		if !yamlMissing && !ymlMissing && !jsonMissing {
+		if (!yamlMissing || !ymlMissing) && !jsonMissing {
 			fmt.Fprintln(stderr, "error: both sqlc.json and sqlc.(yaml|yml) files present")
 			return "", nil, errors.New("sqlc.json and sqlc.(yaml|yml) present")
 		}

--- a/internal/cmd/generate.go
+++ b/internal/cmd/generate.go
@@ -76,8 +76,9 @@ func readConfig(stderr io.Writer, dir, filename string) (string, *config.Config,
 	if filename != "" {
 		configPath = filepath.Join(dir, filename)
 	} else {
-		var yamlMissing, jsonMissing bool
+		var yamlMissing, jsonMissing, ymlMissing bool
 		yamlPath := filepath.Join(dir, "sqlc.yaml")
+		ymlPath := filepath.Join(dir, "sqlc.yml")
 		jsonPath := filepath.Join(dir, "sqlc.json")
 
 		if _, err := os.Stat(yamlPath); os.IsNotExist(err) {
@@ -87,18 +88,27 @@ func readConfig(stderr io.Writer, dir, filename string) (string, *config.Config,
 			jsonMissing = true
 		}
 
-		if yamlMissing && jsonMissing {
-			fmt.Fprintln(stderr, "error parsing configuration files. sqlc.yaml or sqlc.json: file does not exist")
+		if _, err := os.Stat(ymlPath); os.IsNotExist(err) {
+			ymlMissing = true
+		}
+
+		if yamlMissing && ymlMissing && jsonMissing {
+			fmt.Fprintln(stderr, "error parsing configuration files. sqlc.(yaml|yml) or sqlc.json: file does not exist")
 			return "", nil, errors.New("config file missing")
 		}
 
-		if !yamlMissing && !jsonMissing {
-			fmt.Fprintln(stderr, "error: both sqlc.json and sqlc.yaml files present")
-			return "", nil, errors.New("sqlc.json and sqlc.yaml present")
+		if !yamlMissing && !ymlMissing && !jsonMissing {
+			fmt.Fprintln(stderr, "error: both sqlc.json and sqlc.(yaml|yml) files present")
+			return "", nil, errors.New("sqlc.json and sqlc.(yaml|yml) present")
 		}
 
-		configPath = yamlPath
-		if yamlMissing {
+		if jsonMissing {
+			if yamlMissing {
+				configPath = ymlPath
+			} else {
+				configPath = yamlPath
+			}
+		} else {
 			configPath = jsonPath
 		}
 	}

--- a/internal/endtoend/ddl_test.go
+++ b/internal/endtoend/ddl_test.go
@@ -39,7 +39,7 @@ func TestValidSchema(t *testing.T) {
 		if err != nil {
 			return err
 		}
-		if filepath.Base(path) == "sqlc.json" || filepath.Base(path) == "sqlc.yaml" {
+		if filepath.Base(path) == "sqlc.json" || filepath.Base(path) == "sqlc.yaml" || filepath.Base(path) == "sqlc.yml" {
 			stderr := filepath.Join(filepath.Dir(path), "stderr.txt")
 			if _, err := os.Stat(stderr); !os.IsNotExist(err) {
 				return nil

--- a/internal/endtoend/endtoend_test.go
+++ b/internal/endtoend/endtoend_test.go
@@ -86,7 +86,7 @@ func TestReplay(t *testing.T) {
 		if err != nil {
 			return err
 		}
-		if info.Name() == "sqlc.json" || info.Name() == "sqlc.yaml" {
+		if info.Name() == "sqlc.json" || info.Name() == "sqlc.yaml" || info.Name() == "sqlc.yml" {
 			dirs = append(dirs, filepath.Dir(path))
 			return filepath.SkipDir
 		}
@@ -251,7 +251,7 @@ func BenchmarkReplay(b *testing.B) {
 		if err != nil {
 			return err
 		}
-		if info.Name() == "sqlc.json" || info.Name() == "sqlc.yaml" {
+		if info.Name() == "sqlc.json" || info.Name() == "sqlc.yaml" || info.Name() == "sqlc.yml" {
 			dirs = append(dirs, filepath.Dir(path))
 			return filepath.SkipDir
 		}

--- a/scripts/regenerate/main.go
+++ b/scripts/regenerate/main.go
@@ -39,7 +39,7 @@ func regenerate(dir string) error {
 		if info.IsDir() {
 			return nil
 		}
-		if strings.HasSuffix(path, "sqlc.json") || strings.HasSuffix(path, "sqlc.yaml") {
+		if strings.HasSuffix(path, "sqlc.json") || strings.HasSuffix(path, "sqlc.yaml") || strings.HasSuffix(path, "sqlc.yml") {
 			cwd := filepath.Dir(path)
 			command, err := parseExecCommand(cwd)
 			if err != nil {


### PR DESCRIPTION
Update `generate.go` to support the `.yml` extension, and also update the documentation files to explicitly indicate the option of using this extension. This is purely a quality of life update.