### PR TITLE
feat(compiler): Parse query parameter metadata from comments

### DIFF
--- a/internal/cmd/shim.go
+++ b/internal/cmd/shim.go
@@ -181,13 +181,13 @@ func pluginQueries(r *compiler.Result) []*plugin.Query {
 			}
 		}
 		out = append(out, &plugin.Query{
-			Name:            q.Name,
-			Cmd:             q.Cmd,
+			Name:            q.Metadata.Name,
+			Cmd:             q.Metadata.Cmd,
 			Text:            q.SQL,
-			Comments:        q.Comments,
+			Comments:        q.Metadata.Comments,
 			Columns:         columns,
 			Params:          params,
-			Filename:        q.Filename,
+			Filename:        q.Metadata.Filename,
 			InsertIntoTable: iit,
 		})
 	}

--- a/internal/cmd/vet.go
+++ b/internal/cmd/vet.go
@@ -545,7 +545,7 @@ func (c *checker) checkSQL(ctx context.Context, s config.SQL) error {
 	req := codeGenRequest(result, combo)
 	cfg := vetConfig(req)
 	for i, query := range req.Queries {
-		if result.Queries[i].Flags[QueryFlagSqlcVetDisable] {
+		if result.Queries[i].Metadata.Flags[QueryFlagSqlcVetDisable] {
 			if debug.Active {
 				log.Printf("Skipping vet rules for query: %s\n", query.Name)
 			}

--- a/internal/compiler/compile.go
+++ b/internal/compiler/compile.go
@@ -90,14 +90,15 @@ func (c *Compiler) parseQueries(o opts.Parser) (*Result, error) {
 				merr.Add(filename, src, loc, err)
 				continue
 			}
-			if query.Name != "" {
-				if _, exists := set[query.Name]; exists {
-					merr.Add(filename, src, stmt.Raw.Pos(), fmt.Errorf("duplicate query name: %s", query.Name))
+			queryName := query.Metadata.Name
+			if queryName != "" {
+				if _, exists := set[queryName]; exists {
+					merr.Add(filename, src, stmt.Raw.Pos(), fmt.Errorf("duplicate query name: %s", queryName))
 					continue
 				}
-				set[query.Name] = struct{}{}
+				set[queryName] = struct{}{}
 			}
-			query.Filename = filepath.Base(filename)
+			query.Metadata.Filename = filepath.Base(filename)
 			if query != nil {
 				q = append(q, query)
 			}

--- a/internal/compiler/compile.go
+++ b/internal/compiler/compile.go
@@ -8,10 +8,10 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/sqlc-dev/sqlc/internal/metadata"
 	"github.com/sqlc-dev/sqlc/internal/migrations"
 	"github.com/sqlc-dev/sqlc/internal/multierr"
 	"github.com/sqlc-dev/sqlc/internal/opts"
+	"github.com/sqlc-dev/sqlc/internal/source"
 	"github.com/sqlc-dev/sqlc/internal/sql/ast"
 	"github.com/sqlc-dev/sqlc/internal/sql/sqlerr"
 	"github.com/sqlc-dev/sqlc/internal/sql/sqlpath"
@@ -20,7 +20,7 @@ import (
 // TODO: Rename this interface Engine
 type Parser interface {
 	Parse(io.Reader) ([]ast.Statement, error)
-	CommentSyntax() metadata.CommentSyntax
+	CommentSyntax() source.CommentSyntax
 	IsReservedKeyword(string) bool
 }
 

--- a/internal/compiler/parse.go
+++ b/internal/compiler/parse.go
@@ -43,11 +43,18 @@ func (c *Compiler) parseQuery(stmt ast.Node, src string, o opts.Parser) (*Query,
 		return nil, errors.New("missing semicolon at end of file")
 	}
 
-	md := metadata.Metadata{}
-
-	md.Name, md.Cmd, err = metadata.ParseQueryNameAndType(rawSQL, metadata.CommentSyntax(c.parser.CommentSyntax()))
+	name, cmd, err := metadata.ParseQueryNameAndType(rawSQL, metadata.CommentSyntax(c.parser.CommentSyntax()))
 	if err != nil {
 		return nil, err
+	}
+
+	if err := validate.Cmd(raw.Stmt, name, cmd); err != nil {
+		return nil, err
+	}
+
+	md := metadata.Metadata{
+		Name: name,
+		Cmd:  cmd,
 	}
 
 	// TODO eventually can use this for name and type/cmd parsing too
@@ -58,10 +65,6 @@ func (c *Compiler) parseQuery(stmt ast.Node, src string, o opts.Parser) (*Query,
 
 	md.Params, md.Flags, err = metadata.ParseParamsAndFlags(cleanedComments)
 	if err != nil {
-		return nil, err
-	}
-
-	if err := validate.Cmd(raw.Stmt, md.Name, md.Cmd); err != nil {
 		return nil, err
 	}
 

--- a/internal/compiler/parse.go
+++ b/internal/compiler/parse.go
@@ -43,13 +43,15 @@ func (c *Compiler) parseQuery(stmt ast.Node, src string, o opts.Parser) (*Query,
 		return nil, errors.New("missing semicolon at end of file")
 	}
 
-	cleanedComments, err := source.CleanedComments(rawSQL, c.parser.CommentSyntax())
+	md := metadata.Metadata{}
+
+	md.Name, md.Cmd, err = metadata.ParseQueryNameAndType(rawSQL, metadata.CommentSyntax(c.parser.CommentSyntax()))
 	if err != nil {
 		return nil, err
 	}
 
-	md := metadata.Metadata{}
-	md.Name, md.Cmd, err = metadata.ParseQueryNameAndType(rawSQL, metadata.CommentSyntax(c.parser.CommentSyntax()))
+	// TODO eventually can use this for name and type/cmd parsing too
+	cleanedComments, err := source.CleanedComments(rawSQL, c.parser.CommentSyntax())
 	if err != nil {
 		return nil, err
 	}

--- a/internal/compiler/parse.go
+++ b/internal/compiler/parse.go
@@ -86,7 +86,7 @@ func (c *Compiler) parseQuery(stmt ast.Node, src string, o opts.Parser) (*Query,
 		}
 	}
 
-	trimmed, _, err := source.StripComments(expanded)
+	trimmed, err := source.StripComments(expanded)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/compiler/query.go
+++ b/internal/compiler/query.go
@@ -1,6 +1,7 @@
 package compiler
 
 import (
+	"github.com/sqlc-dev/sqlc/internal/metadata"
 	"github.com/sqlc-dev/sqlc/internal/sql/ast"
 )
 
@@ -41,15 +42,9 @@ type Column struct {
 
 type Query struct {
 	SQL      string
-	Name     string
-	Cmd      string // TODO: Pick a better name. One of: one, many, exec, execrows, copyFrom
-	Flags    map[string]bool
+	Metadata metadata.Metadata
 	Columns  []*Column
 	Params   []Parameter
-	Comments []string
-
-	// XXX: Hack
-	Filename string
 
 	// Needed for CopyFrom
 	InsertIntoTable *ast.TableName

--- a/internal/endtoend/testdata/comment_syntax/mysql/go/query.sql.go
+++ b/internal/endtoend/testdata/comment_syntax/mysql/go/query.sql.go
@@ -22,7 +22,6 @@ func (q *Queries) DoubleDash(ctx context.Context) (sql.NullString, error) {
 }
 
 const hash = `-- name: Hash :one
-# name: Hash :one
 SELECT bar FROM foo LIMIT 1
 `
 

--- a/internal/endtoend/testdata/invalid_queries_foo/pgx/v4/stderr.txt
+++ b/internal/endtoend/testdata/invalid_queries_foo/pgx/v4/stderr.txt
@@ -1,5 +1,5 @@
 # package querytest
-query.sql:1:1: invalid query comment: -- name: ListFoos
+query.sql:1:1: missing query type [':one', ':many', ':exec', ':execrows', ':execlastid', ':execresult', ':copyfrom', 'batchexec', 'batchmany', 'batchone']: -- name: ListFoos
 query.sql:5:1: invalid query comment: -- name: ListFoos :one :many
 query.sql:8:1: invalid query type: :two
 query.sql:11:1: query "DeleteFoo" specifies parameter ":one" without containing a RETURNING clause

--- a/internal/endtoend/testdata/invalid_queries_foo/pgx/v5/stderr.txt
+++ b/internal/endtoend/testdata/invalid_queries_foo/pgx/v5/stderr.txt
@@ -1,5 +1,5 @@
 # package querytest
-query.sql:1:1: invalid query comment: -- name: ListFoos
+query.sql:1:1: missing query type [':one', ':many', ':exec', ':execrows', ':execlastid', ':execresult', ':copyfrom', 'batchexec', 'batchmany', 'batchone']: -- name: ListFoos
 query.sql:5:1: invalid query comment: -- name: ListFoos :one :many
 query.sql:8:1: invalid query type: :two
 query.sql:11:1: query "DeleteFoo" specifies parameter ":one" without containing a RETURNING clause

--- a/internal/endtoend/testdata/invalid_queries_foo/stdlib/stderr.txt
+++ b/internal/endtoend/testdata/invalid_queries_foo/stdlib/stderr.txt
@@ -1,5 +1,5 @@
 # package querytest
-query.sql:1:1: invalid query comment: -- name: ListFoos
+query.sql:1:1: missing query type [':one', ':many', ':exec', ':execrows', ':execlastid', ':execresult', ':copyfrom', 'batchexec', 'batchmany', 'batchone']: -- name: ListFoos
 query.sql:5:1: invalid query comment: -- name: ListFoos :one :many
 query.sql:8:1: invalid query type: :two
 query.sql:11:1: query "DeleteFoo" specifies parameter ":one" without containing a RETURNING clause

--- a/internal/engine/dolphin/parse.go
+++ b/internal/engine/dolphin/parse.go
@@ -10,7 +10,7 @@ import (
 	"github.com/pingcap/tidb/parser"
 	_ "github.com/pingcap/tidb/parser/test_driver"
 
-	"github.com/sqlc-dev/sqlc/internal/metadata"
+	"github.com/sqlc-dev/sqlc/internal/source"
 	"github.com/sqlc-dev/sqlc/internal/sql/ast"
 	"github.com/sqlc-dev/sqlc/internal/sql/sqlerr"
 )
@@ -86,8 +86,8 @@ func (p *Parser) Parse(r io.Reader) ([]ast.Statement, error) {
 }
 
 // https://dev.mysql.com/doc/refman/8.0/en/comments.html
-func (p *Parser) CommentSyntax() metadata.CommentSyntax {
-	return metadata.CommentSyntax{
+func (p *Parser) CommentSyntax() source.CommentSyntax {
+	return source.CommentSyntax{
 		Dash:      true,
 		SlashStar: true,
 		Hash:      true,

--- a/internal/engine/postgresql/parse.go
+++ b/internal/engine/postgresql/parse.go
@@ -12,7 +12,7 @@ import (
 	nodes "github.com/pganalyze/pg_query_go/v4"
 	"github.com/pganalyze/pg_query_go/v4/parser"
 
-	"github.com/sqlc-dev/sqlc/internal/metadata"
+	"github.com/sqlc-dev/sqlc/internal/source"
 	"github.com/sqlc-dev/sqlc/internal/sql/ast"
 	"github.com/sqlc-dev/sqlc/internal/sql/sqlerr"
 )
@@ -199,8 +199,8 @@ func normalizeErr(err error) error {
 }
 
 // https://www.postgresql.org/docs/current/sql-syntax-lexical.html#SQL-SYNTAX-COMMENTS
-func (p *Parser) CommentSyntax() metadata.CommentSyntax {
-	return metadata.CommentSyntax{
+func (p *Parser) CommentSyntax() source.CommentSyntax {
+	return source.CommentSyntax{
 		Dash:      true,
 		SlashStar: true,
 	}

--- a/internal/engine/sqlite/parse.go
+++ b/internal/engine/sqlite/parse.go
@@ -8,7 +8,7 @@ import (
 	"github.com/antlr/antlr4/runtime/Go/antlr/v4"
 
 	"github.com/sqlc-dev/sqlc/internal/engine/sqlite/parser"
-	"github.com/sqlc-dev/sqlc/internal/metadata"
+	"github.com/sqlc-dev/sqlc/internal/source"
 	"github.com/sqlc-dev/sqlc/internal/sql/ast"
 )
 
@@ -86,8 +86,8 @@ func (p *Parser) Parse(r io.Reader) ([]ast.Statement, error) {
 	return stmts, nil
 }
 
-func (p *Parser) CommentSyntax() metadata.CommentSyntax {
-	return metadata.CommentSyntax{
+func (p *Parser) CommentSyntax() source.CommentSyntax {
+	return source.CommentSyntax{
 		Dash:      true,
 		Hash:      false,
 		SlashStar: true,

--- a/internal/metadata/meta.go
+++ b/internal/metadata/meta.go
@@ -9,6 +9,8 @@ import (
 	"github.com/sqlc-dev/sqlc/internal/source"
 )
 
+type CommentSyntax source.CommentSyntax
+
 type Metadata struct {
 	Name     string
 	Cmd      string
@@ -18,8 +20,6 @@ type Metadata struct {
 
 	Filename string
 }
-
-type CommentSyntax source.CommentSyntax
 
 const (
 	CmdExec       = ":exec"

--- a/internal/metadata/meta.go
+++ b/internal/metadata/meta.go
@@ -58,7 +58,7 @@ func validateQueryName(name string) error {
 func ParseQueryMetadata(rawSql string, commentStyle CommentSyntax) (Metadata, error) {
 	md := Metadata{}
 	s := bufio.NewScanner(strings.NewReader(strings.TrimSpace(rawSql)))
-	var lines, comments []string
+	var comments []string
 	for s.Scan() {
 		line := s.Text()
 		var prefix string
@@ -81,7 +81,6 @@ func ParseQueryMetadata(rawSql string, commentStyle CommentSyntax) (Metadata, er
 			prefix = "#"
 		}
 		if prefix == "" {
-			lines = append(lines, line)
 			continue
 		}
 

--- a/internal/metadata/meta.go
+++ b/internal/metadata/meta.go
@@ -141,8 +141,9 @@ func parseParamsAndFlags(comments []string) (map[string]string, map[string]bool)
 			parts := strings.SplitN(cleanLine, " ", 2)
 			name := parts[0]
 			switch name {
-			case "param":
-				params[name] = parts[1]
+			case "@param":
+				paramParts := strings.SplitN(parts[1], " ", 2)
+				params[paramParts[0]] = paramParts[1]
 			default:
 				flags[name] = true
 			}

--- a/internal/metadata/meta.go
+++ b/internal/metadata/meta.go
@@ -141,7 +141,6 @@ func parseParamsAndFlags(comments []string) (map[string]string, map[string]bool,
 		s := bufio.NewScanner(strings.NewReader(line))
 		s.Split(bufio.ScanWords)
 
-		s.Scan() // The first token is always the comment indicator, e.g. "--"
 		s.Scan()
 		token := s.Text()
 

--- a/internal/metadata/meta_test.go
+++ b/internal/metadata/meta_test.go
@@ -79,7 +79,7 @@ func TestParseQueryParams(t *testing.T) {
 	} {
 		params, _, err := ParseParamsAndFlags(comments)
 		if err != nil {
-			t.Error("expected comments to parse:", err)
+			t.Errorf("expected comments to parse, got err: %s", err)
 		}
 
 		pt, ok := params["foo_id"]
@@ -125,7 +125,7 @@ func TestParseQueryFlags(t *testing.T) {
 	} {
 		_, flags, err := ParseParamsAndFlags(comments)
 		if err != nil {
-			t.Error("expected comments to parse:", err)
+			t.Errorf("expected comments to parse, got err: %s", err)
 		}
 
 		if !flags["@flag-foo"] {

--- a/internal/metadata/meta_test.go
+++ b/internal/metadata/meta_test.go
@@ -17,7 +17,7 @@ func TestParseQueryNameAndType(t *testing.T) {
 		"-- name:CreateFoo",
 		`--name:CreateFoo :two`,
 	} {
-		if _, err := ParseQueryMetadata(query, CommentSyntax{Dash: true}); err == nil {
+		if _, _, err := ParseQueryNameAndType(query, CommentSyntax{Dash: true}); err == nil {
 			t.Errorf("expected invalid metadata: %q", query)
 		}
 	}
@@ -27,7 +27,7 @@ func TestParseQueryNameAndType(t *testing.T) {
 		`-- name comment`,
 		`--name comment`,
 	} {
-		if _, err := ParseQueryMetadata(query, CommentSyntax{Dash: true}); err != nil {
+		if _, _, err := ParseQueryNameAndType(query, CommentSyntax{Dash: true}); err != nil {
 			t.Errorf("expected valid comment: %q", query)
 		}
 	}
@@ -37,15 +37,15 @@ func TestParseQueryNameAndType(t *testing.T) {
 		`# name: CreateFoo :one`:     {Hash: true},
 		`/* name: CreateFoo :one */`: {SlashStar: true},
 	} {
-		queryMetadata, err := ParseQueryMetadata(query, cs)
+		queryName, queryCmd, err := ParseQueryNameAndType(query, cs)
 		if err != nil {
 			t.Errorf("expected valid metadata: %q", query)
 		}
-		if queryMetadata.Name != "CreateFoo" {
-			t.Errorf("incorrect queryName parsed: (%q) %q", queryMetadata.Name, query)
+		if queryName != "CreateFoo" {
+			t.Errorf("incorrect queryName parsed: (%q) %q", queryName, query)
 		}
-		if queryMetadata.Cmd != CmdOne {
-			t.Errorf("incorrect queryType parsed: (%q) %q", queryMetadata.Cmd, query)
+		if queryCmd != CmdOne {
+			t.Errorf("incorrect queryCmd parsed: (%q) %q", queryCmd, query)
 		}
 	}
 
@@ -77,7 +77,7 @@ func TestParseQueryParams(t *testing.T) {
 			" @param @invalid UUID ",
 		},
 	} {
-		params, _, err := parseParamsAndFlags(comments)
+		params, _, err := ParseParamsAndFlags(comments)
 		if err != nil {
 			t.Error("expected comments to parse:", err)
 		}
@@ -123,7 +123,7 @@ func TestParseQueryFlags(t *testing.T) {
 			" @param @flag-bar UUID",
 		},
 	} {
-		_, flags, err := parseParamsAndFlags(comments)
+		_, flags, err := ParseParamsAndFlags(comments)
 		if err != nil {
 			t.Error("expected comments to parse:", err)
 		}

--- a/internal/metadata/meta_test.go
+++ b/internal/metadata/meta_test.go
@@ -57,31 +57,27 @@ func TestParseQueryNameAndType(t *testing.T) {
 func TestParseQueryParams(t *testing.T) {
 	for _, comments := range [][]string{
 		{
-			"-- name: CreateFoo :one",
-			"-- @param foo_id UUID",
+			" name: CreateFoo :one",
+			" @param foo_id UUID",
 		},
 		{
-			"/* name: CreateFoo :one */",
-			"/* @param foo_id UUID */",
+			" name: CreateFoo :one ",
+			" @param foo_id UUID ",
 		},
 		{
-			"# name: CreateFoo :one",
-			"# @param foo_id UUID",
+			" name: CreateFoo :one",
+			" @param foo_id UUID",
+			" invalid",
 		},
 		{
-			"-- name: CreateFoo :one",
-			"-- @param foo_id UUID",
-			"-- invalid",
+			" name: CreateFoo :one",
+			" @invalid",
+			" @param foo_id UUID",
 		},
 		{
-			"-- name: CreateFoo :one",
-			"-- @invalid",
-			"-- @param foo_id UUID",
-		},
-		{
-			"-- name: GetFoos :many",
-			"-- @param foo_id UUID",
-			"-- @param @invalid UUID",
+			" name: GetFoos :many ",
+			" @param foo_id UUID ",
+			" @param @invalid UUID ",
 		},
 	} {
 		params, _, err := parseParamsAndFlags(comments)
@@ -108,25 +104,26 @@ func TestParseQueryParams(t *testing.T) {
 func TestParseQueryFlags(t *testing.T) {
 	for _, comments := range [][]string{
 		{
-			"-- name: CreateFoo :one",
-			"-- @flag-foo",
+			" name: CreateFoo :one",
+			" @flag-foo",
 		},
 		{
-			"/* name: CreateFoo :one */",
-			"/* @flag-foo */",
+			" name: CreateFoo :one ",
+			" @flag-foo ",
 		},
 		{
-			"# name: CreateFoo :one",
-			"# @flag-foo",
+			" name: CreateFoo :one",
+			" @flag-foo @flag-bar",
 		},
 		{
-			"-- name: CreateFoo :one",
-			"-- @flag-foo @flag-bar",
+			" name: GetFoos :many",
+			" @param @flag-bar UUID",
+			" @flag-foo",
 		},
 		{
-			"-- name: GetFoos :many",
-			"-- @param @flag-bar UUID",
-			"-- @flag-foo",
+			" name: GetFoos :many",
+			" @flag-foo",
+			" @param @flag-bar UUID",
 		},
 	} {
 		_, flags, err := parseParamsAndFlags(comments)

--- a/internal/metadata/meta_test.go
+++ b/internal/metadata/meta_test.go
@@ -16,9 +16,6 @@ func TestParseQueryNameAndType(t *testing.T) {
 		`--name: CreateFoo :two`,
 		"-- name:CreateFoo",
 		`--name:CreateFoo :two`,
-		`--  name: CreateFoo :two`,
-		`-- name:  CreateFoo :two`,
-		`-- name: CreateFoo  :two`,
 	} {
 		if _, err := ParseQueryMetadata(query, CommentSyntax{Dash: true}); err == nil {
 			t.Errorf("expected invalid metadata: %q", query)

--- a/internal/metadata/meta_test.go
+++ b/internal/metadata/meta_test.go
@@ -45,10 +45,10 @@ func TestParseQueryNameAndType(t *testing.T) {
 			t.Errorf("expected valid metadata: %q", query)
 		}
 		if queryMetadata.Name != "CreateFoo" {
-			t.Errorf("incorrect queryName parsed: %q", query)
+			t.Errorf("incorrect queryName parsed: (%q) %q", queryMetadata.Name, query)
 		}
 		if queryMetadata.Cmd != CmdOne {
-			t.Errorf("incorrect queryType parsed: %q", query)
+			t.Errorf("incorrect queryType parsed: (%q) %q", queryMetadata.Cmd, query)
 		}
 	}
 

--- a/internal/metadata/meta_test.go
+++ b/internal/metadata/meta_test.go
@@ -61,6 +61,14 @@ func TestParseQueryParams(t *testing.T) {
 			"-- @param foo_id UUID",
 		},
 		{
+			"/* name: CreateFoo :one */",
+			"/* @param foo_id UUID */",
+		},
+		{
+			"# name: CreateFoo :one",
+			"# @param foo_id UUID",
+		},
+		{
 			"-- name: CreateFoo :one",
 			"-- @param foo_id UUID",
 			"-- invalid",
@@ -76,11 +84,18 @@ func TestParseQueryParams(t *testing.T) {
 			"-- @param @invalid UUID",
 		},
 	} {
-		params, _ := parseParamsAndFlags(comments)
+		params, _, err := parseParamsAndFlags(comments)
+		if err != nil {
+			t.Error("expected comments to parse:", err)
+		}
 
-		_, ok := params["foo_id"]
+		pt, ok := params["foo_id"]
 		if !ok {
 			t.Errorf("expected param not found")
+		}
+
+		if pt != "UUID" {
+			t.Error("unexpected param metadata:", pt)
 		}
 
 		_, ok = params["invalid"]
@@ -97,6 +112,14 @@ func TestParseQueryFlags(t *testing.T) {
 			"-- @flag-foo",
 		},
 		{
+			"/* name: CreateFoo :one */",
+			"/* @flag-foo */",
+		},
+		{
+			"# name: CreateFoo :one",
+			"# @flag-foo",
+		},
+		{
 			"-- name: CreateFoo :one",
 			"-- @flag-foo @flag-bar",
 		},
@@ -106,7 +129,10 @@ func TestParseQueryFlags(t *testing.T) {
 			"-- @flag-foo",
 		},
 	} {
-		_, flags := parseParamsAndFlags(comments)
+		_, flags, err := parseParamsAndFlags(comments)
+		if err != nil {
+			t.Error("expected comments to parse:", err)
+		}
 
 		if !flags["@flag-foo"] {
 			t.Errorf("expected flag not found")

--- a/internal/metadata/meta_test.go
+++ b/internal/metadata/meta_test.go
@@ -63,7 +63,7 @@ func TestParseQueryParams(t *testing.T) {
 		},
 		{
 			" name: CreateFoo :one",
-			" @param foo_id UUID",
+			"@param foo_id UUID",
 			" invalid",
 		},
 		{
@@ -106,7 +106,7 @@ func TestParseQueryFlags(t *testing.T) {
 		},
 		{
 			" name: CreateFoo :one ",
-			" @flag-foo ",
+			"@flag-foo ",
 		},
 		{
 			" name: CreateFoo :one",

--- a/internal/metadata/meta_test.go
+++ b/internal/metadata/meta_test.go
@@ -54,6 +54,42 @@ func TestParseQueryNameAndType(t *testing.T) {
 
 }
 
+func TestParseQueryParams(t *testing.T) {
+	for _, comments := range [][]string{
+		{
+			"-- name: CreateFoo :one",
+			"-- @param foo_id UUID",
+		},
+		{
+			"-- name: CreateFoo :one",
+			"-- @param foo_id UUID",
+			"-- invalid",
+		},
+		{
+			"-- name: CreateFoo :one",
+			"-- @invalid",
+			"-- @param foo_id UUID",
+		},
+		{
+			"-- name: GetFoos :many",
+			"-- @param foo_id UUID",
+			"-- @param @invalid UUID",
+		},
+	} {
+		params, _ := parseParamsAndFlags(comments)
+
+		_, ok := params["foo_id"]
+		if !ok {
+			t.Errorf("expected param not found")
+		}
+
+		_, ok = params["invalid"]
+		if ok {
+			t.Errorf("unexpected param found")
+		}
+	}
+}
+
 func TestParseQueryFlags(t *testing.T) {
 	for _, comments := range [][]string{
 		{

--- a/internal/source/code.go
+++ b/internal/source/code.go
@@ -90,29 +90,21 @@ func Mutate(raw string, a []Edit) (string, error) {
 	return s, nil
 }
 
-// TODO remove and roll into query parsing
-func StripComments(sql string) (string, []string, error) {
+func StripComments(sql string) (string, error) {
 	s := bufio.NewScanner(strings.NewReader(strings.TrimSpace(sql)))
-	var lines, comments []string
+	var lines []string
 	for s.Scan() {
 		t := s.Text()
-		if strings.HasPrefix(t, "-- name:") {
-			continue
-		}
-		if strings.HasPrefix(t, "/* name:") && strings.HasSuffix(t, "*/") {
-			continue
-		}
 		if strings.HasPrefix(t, "--") {
-			comments = append(comments, strings.TrimPrefix(t, "--"))
 			continue
 		}
 		if strings.HasPrefix(t, "/*") && strings.HasSuffix(t, "*/") {
-			t = strings.TrimPrefix(t, "/*")
-			t = strings.TrimSuffix(t, "*/")
-			comments = append(comments, t)
+			continue
+		}
+		if strings.HasPrefix(t, "#") {
 			continue
 		}
 		lines = append(lines, t)
 	}
-	return strings.Join(lines, "\n"), comments, s.Err()
+	return strings.Join(lines, "\n"), s.Err()
 }

--- a/internal/source/code.go
+++ b/internal/source/code.go
@@ -90,6 +90,7 @@ func Mutate(raw string, a []Edit) (string, error) {
 	return s, nil
 }
 
+// TODO remove and roll into query parsing
 func StripComments(sql string) (string, []string, error) {
 	s := bufio.NewScanner(strings.NewReader(strings.TrimSpace(sql)))
 	var lines, comments []string


### PR DESCRIPTION
Groundwork for https://github.com/sqlc-dev/sqlc/issues/2800 (explicit type annotations in query comments metadata).

There are lots of tests that failed while I was refactoring this, so I have a fairly high degree of confidence that this refactor doesn't break anything. The changed endtoend test output is due to parsing bugs I fixed.

I chose to add a new `Metadata` struct type to house the growing set of stuff we associate with a query, but I don't have to so let me know if an alternative approach is preferred.