### PR TITLE
fix(postgresql): Remove temporary pool config

### DIFF
--- a/internal/engine/postgresql/analyzer/analyze.go
+++ b/internal/engine/postgresql/analyzer/analyze.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"strings"
 	"sync"
-	"time"
 
 	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgconn"
@@ -213,9 +212,6 @@ func (a *Analyzer) Analyze(ctx context.Context, n ast.Node, query string, migrat
 		if err != nil {
 			return nil, err
 		}
-		conf.MaxConns = 2
-		conf.MinConns = 0
-		conf.MaxConnLifetime = time.Second * 1
 		pool, err := pgxpool.NewWithConfig(ctx, conf)
 		if err != nil {
 			return nil, err


### PR DESCRIPTION
The connection pool config was there before I was closing the pool after analysis. The short connection lifespan was causing connection churn.