### PR TITLE
Improve table catalog lookups

### DIFF
--- a/internal/compiler/analyze.go
+++ b/internal/compiler/analyze.go
@@ -140,7 +140,7 @@ func (c *Compiler) _analyzeQuery(raw *ast.RawStmt, query string, failfast bool) 
 	if err := check(validate.In(c.catalog, raw)); err != nil {
 		return nil, err
 	}
-	rvs := rangeVars(raw.Stmt)
+	rvs, rss, rfs := rawRangeTblRefs(raw.Stmt)
 	refs, errs := findParameters(raw.Stmt)
 	if len(errs) > 0 {
 		if failfast {
@@ -160,7 +160,7 @@ func (c *Compiler) _analyzeQuery(raw *ast.RawStmt, query string, failfast bool) 
 		return nil, err
 	}
 
-	params, err := c.resolveCatalogRefs(qc, rvs, refs, namedParams, embeds)
+	params, err := c.resolveCatalogRefs(qc, rvs, rss, rfs, refs, namedParams, embeds)
 	if err := check(err); err != nil {
 		return nil, err
 	}

--- a/internal/compiler/parse.go
+++ b/internal/compiler/parse.go
@@ -108,16 +108,22 @@ func (c *Compiler) parseQuery(stmt ast.Node, src string, o opts.Parser) (*Query,
 	}, nil
 }
 
-func rangeVars(root ast.Node) []*ast.RangeVar {
+func rawRangeTblRefs(root ast.Node) ([]*ast.RangeVar, []*ast.RangeSubselect, []*ast.RangeFunction) {
 	var vars []*ast.RangeVar
-	find := astutils.VisitorFunc(func(node ast.Node) {
+	var subs []*ast.RangeSubselect
+	var funs []*ast.RangeFunction
+	find := astutils.SingleQueryVisitorFunc(func(node ast.Node) {
 		switch n := node.(type) {
 		case *ast.RangeVar:
 			vars = append(vars, n)
+		case *ast.RangeSubselect:
+			subs = append(subs, n)
+		case *ast.RangeFunction:
+			funs = append(funs, n)
 		}
 	})
 	astutils.Walk(find, root)
-	return vars
+	return vars, subs, funs
 }
 
 func uniqueParamRefs(in []paramRef, dollar bool) []paramRef {

--- a/internal/sql/astutils/walk.go
+++ b/internal/sql/astutils/walk.go
@@ -17,6 +17,19 @@ func (vf VisitorFunc) Visit(node ast.Node) Visitor {
 	return vf
 }
 
+type SingleQueryVisitorFunc func(ast.Node)
+
+func (vf SingleQueryVisitorFunc) Visit(node ast.Node) Visitor {
+	switch node.(type) {
+	case *ast.RangeSubselect, *ast.RangeTblEntry:
+		vf(node)
+		return nil
+	default:
+		vf(node)
+		return vf
+	}
+}
+
 func Walk(f Visitor, node ast.Node) {
 	if f = f.Visit(node); f == nil {
 		return


### PR DESCRIPTION
This prevents rangeVars (now rawRangeTblRefs) from descending into subqueries, which caused it to look at table references not in this query's scope.

It also renames this function and makes it extract all relevant table definition AST nodes instead of just RangeVars. It then passes these to resolveCatalogRefs.

resolveCatalgoRefs now also rejects attempts to use sqlc.embed with ad-hoc-defined tables (function outputs and subqueries) as their outputs do not have corresponding model types. Previously this generated broken code.