### PR TITLE
Improve nullability evaluation

### DIFF
--- a/internal/codegen/golang/result.go
+++ b/internal/codegen/golang/result.go
@@ -379,7 +379,11 @@ func columnsToStruct(req *plugin.CodeGenRequest, options *opts, name string, col
 		if c.embed == nil {
 			f.Type = goType(req, options, c.Column)
 		} else {
-			f.Type = c.embed.modelType
+			if c.NotNull {
+				f.Type = c.embed.modelType
+			} else {
+				return nil, fmt.Errorf("embedded macro for %q is nullable, this is currently unsupported", c.embed.modelName)
+			}
 			f.EmbedFields = c.embed.fields
 		}
 


### PR DESCRIPTION
This now supports evaluating nullability if subqueries, function-defined tables or sqlc.embed macros are involved.
If nullable embeds are generated, this now errors out instead of emitting code which breaks at runtime.

Generating correct type definitions for that case would be easy, but scanning data into embed pointers is hard as it would require "peeking" at row nullability to decide if the type should be allocated and scanned into. Otherwise the null columns need to be directed into some kind of sink. Because this is nontrivial to do this is not part of this PR.