### PR TITLE
patch: use docker compose v2 and update MYSQL_DATABASE env var

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,7 +33,7 @@ sqlc-gen-json:
 	go build -o ~/bin/sqlc-gen-json ./cmd/sqlc-gen-json
 
 start:
-	docker-compose up -d
+	docker compose up -d
 
 fmt:
 	go fmt ./...

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,7 +6,7 @@ services:
       - "3306:3306"
     restart: always
     environment:
-      MYSQL_DATABASE: mysql
+      MYSQL_DATABASE: dinotest
       MYSQL_ROOT_PASSWORD: mysecretpassword
       MYSQL_ROOT_HOST: '%'
 
@@ -16,7 +16,7 @@ services:
       - "3305:3306"
     restart: always
     environment:
-      MYSQL_DATABASE: mysql
+      MYSQL_DATABASE: dinotest
       MYSQL_ROOT_PASSWORD: mysecretpassword
       MYSQL_ROOT_HOST: '%'
     profiles:

--- a/docs/guides/development.md
+++ b/docs/guides/development.md
@@ -24,7 +24,7 @@ These tests require locally-running database instances. Run these databases
 using [Docker Compose](https://docs.docker.com/compose/).
 
 ```
-docker-compose up -d
+docker compose up -d
 ```
 
 The tests use the following environment variables to connect to the
@@ -51,7 +51,7 @@ MYSQL_HOST      127.0.0.1
 MYSQL_PORT      3306
 MYSQL_USER      root
 MYSQL_ROOT_PASSWORD  mysecretpassword
-MYSQL_DATABASE  dinotest
+MYSQL_DATABASE  mysql
 ```
 
 ## Regenerate expected test output

--- a/docs/guides/development.md
+++ b/docs/guides/development.md
@@ -51,7 +51,7 @@ MYSQL_HOST      127.0.0.1
 MYSQL_PORT      3306
 MYSQL_USER      root
 MYSQL_ROOT_PASSWORD  mysecretpassword
-MYSQL_DATABASE  mysql
+MYSQL_DATABASE  dinotest
 ```
 
 ## Regenerate expected test output

--- a/go.sum
+++ b/go.sum
@@ -100,7 +100,6 @@ github.com/jackc/pgx/v5 v5.4.3/go.mod h1:Ig06C2Vu0t5qXC60W8sqIthScaEnFvojjj9dSlj
 github.com/jackc/puddle v0.0.0-20190413234325-e4ced69a3a2b/go.mod h1:m4B5Dj62Y0fbyuIc15OsIqK0+JU8nkqQjsgx7dvjSWk=
 github.com/jackc/puddle v0.0.0-20190608224051-11cab39313c9/go.mod h1:m4B5Dj62Y0fbyuIc15OsIqK0+JU8nkqQjsgx7dvjSWk=
 github.com/jackc/puddle v1.1.3/go.mod h1:m4B5Dj62Y0fbyuIc15OsIqK0+JU8nkqQjsgx7dvjSWk=
-github.com/jackc/puddle v1.3.0 h1:eHK/5clGOatcjX3oWGBO/MpxpbHzSwud5EWTSCI+MX0=
 github.com/jackc/puddle v1.3.0/go.mod h1:m4B5Dj62Y0fbyuIc15OsIqK0+JU8nkqQjsgx7dvjSWk=
 github.com/jackc/puddle/v2 v2.2.1 h1:RhxXJtFG022u4ibrCSMSiu5aOq1i77R3OHKNJj77OAk=
 github.com/jackc/puddle/v2 v2.2.1/go.mod h1:vriiEXHvEE654aYKXXjOvZM39qJ0q+azkZFrfEOc3H4=
@@ -140,8 +139,6 @@ github.com/pingcap/failpoint v0.0.0-20220801062533-2eaa32854a6c h1:CgbKAHto5CQgW
 github.com/pingcap/failpoint v0.0.0-20220801062533-2eaa32854a6c/go.mod h1:4qGtCB0QK0wBzKtFEGDhxXnSnbQApw1gc9siScUl8ew=
 github.com/pingcap/log v1.1.0 h1:ELiPxACz7vdo1qAvvaWJg1NrYFoY6gqAh/+Uo6aXdD8=
 github.com/pingcap/log v1.1.0/go.mod h1:DWQW5jICDR7UJh4HtxXSM20Churx4CQL0fwL/SoOSA4=
-github.com/pingcap/tidb/parser v0.0.0-20230815160630-b69fa21942d1 h1:FvX5fDJ32eblK9f6KJIOVujjtu3FDEfcRGHsEDfJ4kI=
-github.com/pingcap/tidb/parser v0.0.0-20230815160630-b69fa21942d1/go.mod h1:pWA6mNa/o7UTDKrg+4H75NdpRgpWRTox/cqQjaQ4ZBU=
 github.com/pingcap/tidb/parser v0.0.0-20231010133155-38cb4f3312be h1:4HUBkIZs+4j+tbXGm5/B0yjB66OTz218HDKA6VrhO7U=
 github.com/pingcap/tidb/parser v0.0.0-20231010133155-38cb4f3312be/go.mod h1:cwq4bKUlftpWuznB+rqNwbN0xy6/i5SL/nYvEKeJn4s=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=


### PR DESCRIPTION
small changes to development.md file and makefile
- updates to use [docker compose v2](https://docs.docker.com/compose/)
- fixes environment variable for MYSQL_DATABASE was causing failing tests when running `make test-examples`

I'm new to this repo and to contributing, please let me know if i had missed anything.