### PR TITLE
test(endtoend): Enabled managed-db tests in CI

### DIFF
--- a/internal/endtoend/endtoend_test.go
+++ b/internal/endtoend/endtoend_test.go
@@ -111,9 +111,6 @@ func TestReplay(t *testing.T) {
 				}
 			},
 			Enabled: func() bool {
-				if len(os.Getenv("CI")) > 0 {
-					return false
-				}
 				return len(os.Getenv("SQLC_AUTH_TOKEN")) > 0
 			},
 		},


### PR DESCRIPTION
Now that these tests run a bit faster, let's run them during all CI runs (that have an auth key)