### PR TITLE
feat: Improve messaging for common cloud config and rpc errors

### DIFF
--- a/internal/cmd/vet.go
+++ b/internal/cmd/vet.go
@@ -156,6 +156,7 @@ func Vet(ctx context.Context, dir, filename string, opts *Options) error {
 		if err := c.checkSQL(ctx, sql); err != nil {
 			if !errors.Is(err, ErrFailedChecks) {
 				fmt.Fprintf(stderr, "%s\n", err)
+				continue
 			}
 			errored = true
 		}
@@ -400,6 +401,7 @@ func (c *checker) fetchDatabaseUri(ctx context.Context, s config.SQL) (string, f
 		uri, err := c.DSN(s.Database.URI)
 		return uri, cleanup, err
 	}
+
 	if s.Engine != config.EnginePostgreSQL {
 		return "", cleanup, fmt.Errorf("managed: only PostgreSQL currently")
 	}
@@ -418,8 +420,8 @@ func (c *checker) fetchDatabaseUri(ctx context.Context, s config.SQL) (string, f
 	if err != nil {
 		return "", cleanup, err
 	}
-	for _, query := range files {
-		contents, err := os.ReadFile(query)
+	for _, schema := range files {
+		contents, err := os.ReadFile(schema)
 		if err != nil {
 			return "", cleanup, fmt.Errorf("read file: %w", err)
 		}

--- a/internal/config/env.go
+++ b/internal/config/env.go
@@ -1,0 +1,17 @@
+package config
+
+import (
+	"fmt"
+	"os"
+	"strings"
+)
+
+func (c *Config) addEnvVars() error {
+	authToken := os.Getenv("SQLC_AUTH_TOKEN")
+	if authToken != "" && !strings.HasPrefix(authToken, "sqlc_") {
+		return fmt.Errorf("$SQLC_AUTH_TOKEN doesn't start with \"sqlc_\"")
+	}
+	c.Cloud.AuthToken = authToken
+
+	return nil
+}

--- a/internal/config/validate.go
+++ b/internal/config/validate.go
@@ -1,12 +1,18 @@
 package config
 
-import "fmt"
-
 func Validate(c *Config) error {
 	for _, sql := range c.SQL {
 		if sql.Database != nil {
 			if sql.Database.URI == "" && !sql.Database.Managed {
-				return fmt.Errorf("invalid config: database must be managed or have a non-empty URI")
+				return ErrInvalidDatabase
+			}
+			if sql.Database.Managed {
+				if c.Cloud.Project == "" {
+					return ErrManagedDatabaseNoProject
+				}
+				if c.Cloud.AuthToken == "" {
+					return ErrManagedDatabaseNoAuthToken
+				}
 			}
 		}
 	}

--- a/internal/ext/process/gen.go
+++ b/internal/ext/process/gen.go
@@ -37,6 +37,9 @@ func (r Runner) Generate(ctx context.Context, req *plugin.CodeGenRequest) (*plug
 		fmt.Sprintf("SQLC_VERSION=%s", req.SqlcVersion),
 	}
 	for _, key := range r.Env {
+		if key == "SQLC_AUTH_TOKEN" {
+			continue
+		}
 		cmd.Env = append(cmd.Env, fmt.Sprintf("%s=%s", key, os.Getenv(key)))
 	}
 

--- a/internal/quickdb/rpc.go
+++ b/internal/quickdb/rpc.go
@@ -2,7 +2,6 @@ package quickdb
 
 import (
 	"crypto/tls"
-	"os"
 
 	"github.com/riza-io/grpc-go/credentials/basic"
 	"google.golang.org/grpc"
@@ -10,14 +9,14 @@ import (
 
 	"github.com/sqlc-dev/sqlc/internal/config"
 	pb "github.com/sqlc-dev/sqlc/internal/quickdb/v1"
+	"github.com/sqlc-dev/sqlc/internal/rpc"
 )
 
 const defaultHostname = "grpc.sqlc.dev"
 
 func NewClientFromConfig(cloudConfig config.Cloud) (pb.QuickClient, error) {
 	projectID := cloudConfig.Project
-	authToken := os.Getenv("SQLC_AUTH_TOKEN")
-	return NewClient(projectID, authToken, WithHost(cloudConfig.Hostname))
+	return NewClient(projectID, cloudConfig.AuthToken, WithHost(cloudConfig.Hostname))
 }
 
 type options struct {
@@ -41,6 +40,7 @@ func NewClient(project, token string, opts ...Option) (pb.QuickClient, error) {
 	dialOpts := []grpc.DialOption{
 		grpc.WithTransportCredentials(credentials.NewTLS(&tls.Config{})),
 		grpc.WithPerRPCCredentials(basic.NewPerRPCCredentials(project, token)),
+		grpc.WithUnaryInterceptor(rpc.UnaryInterceptor),
 	}
 
 	hostname := o.hostname

--- a/internal/remote/rpc.go
+++ b/internal/remote/rpc.go
@@ -2,23 +2,23 @@ package remote
 
 import (
 	"crypto/tls"
-	"os"
 
 	"github.com/riza-io/grpc-go/credentials/basic"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
 
 	"github.com/sqlc-dev/sqlc/internal/config"
+	"github.com/sqlc-dev/sqlc/internal/rpc"
 )
 
 const defaultHostname = "remote.sqlc.dev"
 
 func NewClient(cloudConfig config.Cloud) (GenClient, error) {
 	authID := cloudConfig.Organization + "/" + cloudConfig.Project
-	authToken := os.Getenv("SQLC_AUTH_TOKEN")
 	opts := []grpc.DialOption{
 		grpc.WithTransportCredentials(credentials.NewTLS(&tls.Config{})),
-		grpc.WithPerRPCCredentials(basic.NewPerRPCCredentials(authID, authToken)),
+		grpc.WithPerRPCCredentials(basic.NewPerRPCCredentials(authID, cloudConfig.AuthToken)),
+		grpc.WithUnaryInterceptor(rpc.UnaryInterceptor),
 	}
 
 	hostname := cloudConfig.Hostname

--- a/internal/rpc/interceptor.go
+++ b/internal/rpc/interceptor.go
@@ -1,0 +1,27 @@
+package rpc
+
+import (
+	"context"
+
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+const errMessageUnauthenticated = `rpc authentication failed
+
+You may be using a sqlc auth token that was created for a different project,
+or your auth token may have expired.`
+
+func UnaryInterceptor(ctx context.Context, method string, req, reply interface{}, cc *grpc.ClientConn, invoker grpc.UnaryInvoker, opts ...grpc.CallOption) error {
+	err := invoker(ctx, method, req, reply, cc, opts...)
+
+	switch status.Convert(err).Code() {
+	case codes.OK:
+		return nil
+	case codes.Unauthenticated:
+		return status.New(codes.Unauthenticated, errMessageUnauthenticated).Err()
+	default:
+		return err
+	}
+}


### PR DESCRIPTION
This turned out to have more changes than I expected. A high-level list follows. There are definitely some style choices I made here that I'm not at all attached to, so feel free to recommend changes.

1. Add a UnaryClientInterceptor for all gRPC client connections to catch and rewrite unauthenticated error messages

2. Put the sqlc auth token in the config struct, and add simple validation

3. Add more explanatory error messages in cases where users try to use cloud features without the proper configuration

4. Prevent sending the SQLC_AUTH_TOKEN env var to plugins

Resolves https://github.com/sqlc-dev/sqlc/issues/2881