### PR TITLE
feat(plugin): Calculate SHA256 if it does not exist

### DIFF
--- a/internal/ext/wasm/wasm.go
+++ b/internal/ext/wasm/wasm.go
@@ -10,6 +10,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"log/slog"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -56,6 +57,7 @@ func (r *Runner) getChecksum(ctx context.Context) (string, error) {
 	if err != nil {
 		return "", err
 	}
+	slog.Warn("fetching WASM binary to calculate sha256. Set this value in sqlc.yaml to prevent unneeded work", "sha256", sum)
 	return sum, nil
 }
 


### PR DESCRIPTION
When developing or using a plugin locally, having to update the configuration file every time to pull in a SHA256 can be very annoying. When fetching a plugin for the first time via HTTP, you may not know the SHA256 of the file you're fetching.

I've changed the plugin fetching behavior to calculate the SHA256 if it's not present. This results in extra network requests or filesystem reads, so it's still advised to set the SHA256, especially if it's not changing.

Before release, we'll add some logging to make it clear the extra requests are happening.

```
2023/11/02 10:10:49 WARN fetching WASM binary to calculate sha256. Set this value in sqlc.yaml to prevent unneeded work sha256=c8c759e80b7d66c728cf9d37674f8f5c9cc33774afa789dbceee0e3446773458
```