### PR TITLE
build(buf): Change root of Buf module

### DIFF
--- a/buf.yaml
+++ b/buf.yaml
@@ -1,8 +1,0 @@
-version: v1
-name: buf.build/sqlc/sqlc
-breaking:
-  use:
-    - FILE
-lint:
-  use:
-    - DEFAULT

--- a/protos/buf.yaml
+++ b/protos/buf.yaml
@@ -1,5 +1,5 @@
 version: v1
-name: github.com/sqlc-dev/sqlc
+name: buf.build/sqlc/sqlc
 breaking:
 lint:
   use:


### PR DESCRIPTION
This removes the "protos" name from the import path.