### PR TITLE
fix: Use derived ArrayDims instead of deprecated attndims

### DIFF
--- a/internal/engine/postgresql/analyzer/analyze.go
+++ b/internal/engine/postgresql/analyzer/analyze.go
@@ -253,8 +253,7 @@ func (a *Analyzer) Analyze(ctx context.Context, n ast.Node, query string, migrat
 			if err != nil {
 				return nil, err
 			}
-			// TODO: Why are these dims different?
-			dt, isArray, _ := parseType(col.DataType)
+			dt, isArray, dims := parseType(col.DataType)
 			notNull := col.NotNull
 			name := field.Name
 			result.Columns = append(result.Columns, &core.Column{
@@ -263,7 +262,7 @@ func (a *Analyzer) Analyze(ctx context.Context, n ast.Node, query string, migrat
 				DataType:     dt,
 				NotNull:      notNull,
 				IsArray:      isArray,
-				ArrayDims:    int32(col.ArrayDims),
+				ArrayDims:    int32(dims),
 				Table: &core.Identifier{
 					Schema: tbl.SchemaName,
 					Name:   tbl.TableName,


### PR DESCRIPTION
Postgres sometimes returns incorrect values for attndims which explains the TODO in the code. Use the type-derived dimensions instead.
This fixes a bug where in rare cases arrays were not correctly detected in one of our applications.

According to https://postgrespro.com/list/thread-id/2304332
> We don't really care.  attndims is a historical leftover and should never
be relied on for any semantically significant purpose.
TBH, my inclination would be to remove the column altogether rather than
"fix" this.