### PR TITLE
fix: Take the maximum array dimensions

### DIFF
--- a/internal/engine/postgresql/analyzer/analyze.go
+++ b/internal/engine/postgresql/analyzer/analyze.go
@@ -262,7 +262,7 @@ func (a *Analyzer) Analyze(ctx context.Context, n ast.Node, query string, migrat
 				DataType:     dt,
 				NotNull:      notNull,
 				IsArray:      isArray,
-				ArrayDims:    int32(dims),
+				ArrayDims:    int32(max(col.ArrayDims, dims)),
 				Table: &core.Identifier{
 					Schema: tbl.SchemaName,
 					Name:   tbl.TableName,


### PR DESCRIPTION
Fixes a bug introduced by https://github.com/sqlc-dev/sqlc/pull/3032

The end-to-end tests on that PR didn't fail as the database-based backed analyzer only runs on PRs created in this repo, which is a bug we'll need to fix soon.

We need to keep reading the value from the column definition for a specific reason

> The current implementation does not enforce the declared number of dimensions either. Arrays of a particular element type are all considered to be of the same type, regardless of size or number of dimensions. So, declaring the array size or number of dimensions in CREATE TABLE is simply documentation; it does not affect run-time behavior.

This means that arrays that should contain arrays of arrays of strings, could just contain an array of strings. We'll need to figure out how to handle this case in a future PR.