### PR TITLE
build(typescript): Test against sqlc-gen-typescript

### DIFF
--- a/.github/workflows/ci-typescript.yml
+++ b/.github/workflows/ci-typescript.yml
@@ -1,0 +1,23 @@
+name: typescript
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+jobs:
+  build:
+    name: test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v4
+        with:
+          go-version: '1.21.3'
+      - name: install ./...
+        run: go install ./...
+      - uses: actions/checkout@v4
+        with:
+          repository: sqlc-dev/sqlc-gen-typescript
+          path: typescript
+      - run: sqlc diff
+        working-directory: typescript/examples


### PR DESCRIPTION
Now that TypeScript support has landed, let's make sure to run it as part of our build process