### PR TITLE
build(sqlite): Disable modernc for WASM

### DIFF
--- a/internal/cmd/vet.go
+++ b/internal/cmd/vet.go
@@ -20,7 +20,6 @@ import (
 	"github.com/jackc/pgx/v5"
 	"github.com/spf13/cobra"
 	"google.golang.org/protobuf/encoding/protojson"
-	_ "modernc.org/sqlite"
 
 	"github.com/sqlc-dev/sqlc/internal/config"
 	"github.com/sqlc-dev/sqlc/internal/debug"

--- a/internal/cmd/vet_modernc.go
+++ b/internal/cmd/vet_modernc.go
@@ -1,0 +1,7 @@
+//go:build !wasm
+
+package cmd
+
+import (
+	_ "modernc.org/sqlite"
+)

--- a/internal/sqltest/sqlite.go
+++ b/internal/sqltest/sqlite.go
@@ -7,8 +7,6 @@ import (
 	"testing"
 
 	"github.com/sqlc-dev/sqlc/internal/sql/sqlpath"
-
-	_ "modernc.org/sqlite"
 )
 
 func SQLite(t *testing.T, migrations []string) (*sql.DB, func()) {

--- a/internal/sqltest/sqlite_modernc.go
+++ b/internal/sqltest/sqlite_modernc.go
@@ -1,0 +1,7 @@
+//go:build !wasm
+
+package sqltest
+
+import (
+	_ "modernc.org/sqlite"
+)


### PR DESCRIPTION
I've been experimenting with compiling the sqlc CLI to WASI. To get this to work, the `modernc.org/sqlite` package needs to be excluded from the build, as it doesn't support the WASI target.

```
CGO_ENABLED=0 GOOS=wasip1 GOARCH=wasm go build -o sqlc.wasm ./cmd/sqlc
```