### PR TITLE
docs: fix sample sql parameters for direct usability

### DIFF
--- a/docs/howto/embedding.md
+++ b/docs/howto/embedding.md
@@ -26,7 +26,7 @@ Here's how we'd usually do that:
 SELECT students.*, test_scores.*
 FROM students
 JOIN test_scores ON test_scores.student_id = students.id
-WHERE students.id = ?;
+WHERE students.id = $1;
 ```
 
 When using Go, sqlc will produce a struct like this:
@@ -50,7 +50,7 @@ flattened list of columns.
 SELECT sqlc.embed(students), sqlc.embed(test_scores)
 FROM students
 JOIN test_scores ON test_scores.student_id = students.id
-WHERE students.id = ?;
+WHERE students.id = $1;
 ```
 
 ```


### PR DESCRIPTION
I encountered a syntax error when attempting to directly copy and paste the SQL code from the sqlc.embed sample. 
I adjusted the param to align with the actual values.

