### PR TITLE
Fix Type Inference for Array Comparisons in SQL Queries

### DIFF
--- a/internal/codegen/golang/result.go
+++ b/internal/codegen/golang/result.go
@@ -238,6 +238,7 @@ func buildQueries(req *plugin.GenerateRequest, options *opts.Options, structs []
 				Typ:       goType(req, options, p.Column),
 				SQLDriver: sqlpkg,
 				Column:    p.Column,
+				QueryText: gq.SQL,
 			}
 		} else if len(query.Params) >= 1 {
 			var cols []goColumn
@@ -257,6 +258,7 @@ func buildQueries(req *plugin.GenerateRequest, options *opts.Options, structs []
 				Struct:      s,
 				SQLDriver:   sqlpkg,
 				EmitPointer: options.EmitParamsStructPointers,
+				QueryText:   gq.SQL,
 			}
 
 			// if query params is 2, and query params limit is 4 AND this is a copyfrom, we still want to emit the query's model


### PR DESCRIPTION
**Description**
In array comparisons made using ANY/SOME/ALL operators, the auto-generated Go code has incorrect type declarations.

**Related Issue**

#3083 

**Changes**

- The **_QueryValue_** struct accepts an extra field. This _QueryText_ field is of string type and contains the SQL query running in context.
- _isUsedWithArrayComparison()_, a method belonging to the _QueryValue_ struct, has been implemented. In the running SQL query, it checks whether any of the ANY/SOME/ALL operators are used for the current field and returns bool. In this way, we do not encapsulate it with pr.Array() and we can convert the slice type argument into single data.

If desired, I am more than willing to add comprehensive tests to cover the modified functionality. Please let me know if this is something you'd like to include, and I'll be happy to work on it.