### PR TITLE
fix(codegen/golang): Use `int16` for MySQL `SMALLINT` and `YEAR`

### DIFF
--- a/internal/codegen/golang/mysql_type.go
+++ b/internal/codegen/golang/mysql_type.go
@@ -38,7 +38,16 @@ func mysqlType(req *plugin.GenerateRequest, options *opts.Options, col *plugin.C
 			return "sql.NullInt32"
 		}
 
-	case "int", "integer", "smallint", "mediumint", "year":
+	case "smallint", "year":
+		if notNull {
+			if unsigned {
+				return "uint16"
+			}
+			return "int16"
+		}
+		return "sql.NullInt16"
+
+	case "int", "integer", "mediumint":
 		if notNull {
 			if unsigned {
 				return "uint32"

--- a/internal/endtoend/testdata/datatype/mysql/go/models.go
+++ b/internal/endtoend/testdata/datatype/mysql/go/models.go
@@ -55,7 +55,7 @@ type DtNumeric struct {
 	A sql.NullInt32
 	B sql.NullInt32
 	C sql.NullInt32
-	D sql.NullInt32
+	D sql.NullInt16
 	E sql.NullInt32
 	F sql.NullInt64
 	G interface{}
@@ -70,7 +70,7 @@ type DtNumericNotNull struct {
 	A int32
 	B int32
 	C int32
-	D int32
+	D int16
 	E int32
 	F int64
 	G interface{}
@@ -85,7 +85,7 @@ type DtNumericUnsigned struct {
 	A sql.NullInt32
 	B sql.NullInt32
 	C sql.NullInt32
-	D sql.NullInt32
+	D sql.NullInt16
 	E sql.NullInt32
 	F sql.NullInt64
 }

--- a/internal/endtoend/testdata/vet_explain/mysql/db/models.go
+++ b/internal/endtoend/testdata/vet_explain/mysql/db/models.go
@@ -99,7 +99,7 @@ func (ns NullDebugCset) Value() (driver.Value, error) {
 
 type Debug struct {
 	ID               int64
-	Csmallint        int32
+	Csmallint        int16
 	Cint             int32
 	Cinteger         int32
 	Cdecimal         string
@@ -118,7 +118,7 @@ type Debug struct {
 	Cdatetime        time.Time
 	Ctimestamp       time.Time
 	Ctime            time.Time
-	Cyear            int32
+	Cyear            int16
 	Cchar            string
 	Cvarchar         string
 	Cbinary          []byte

--- a/internal/endtoend/testdata/vet_explain/mysql/db/query.sql.go
+++ b/internal/endtoend/testdata/vet_explain/mysql/db/query.sql.go
@@ -316,7 +316,7 @@ SELECT id FROM debug
 WHERE Csmallint = ? LIMIT 1
 `
 
-func (q *Queries) SelectByCsmallint(ctx context.Context, csmallint int32) (int64, error) {
+func (q *Queries) SelectByCsmallint(ctx context.Context, csmallint int16) (int64, error) {
 	row := q.db.QueryRowContext(ctx, selectByCsmallint, csmallint)
 	var id int64
 	err := row.Scan(&id)
@@ -424,7 +424,7 @@ SELECT id FROM debug
 WHERE Cyear = ? LIMIT 1
 `
 
-func (q *Queries) SelectByCyear(ctx context.Context, cyear int32) (int64, error) {
+func (q *Queries) SelectByCyear(ctx context.Context, cyear int16) (int64, error) {
 	row := q.db.QueryRowContext(ctx, selectByCyear, cyear)
 	var id int64
 	err := row.Scan(&id)


### PR DESCRIPTION
Resolves https://github.com/sqlc-dev/sqlc/issues/3088