### PR TITLE
fix(docker): Use distroless instead of scratch

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ ENV VERSION=$version
 RUN go run scripts/release.go -docker
 
 # STEP 2: Build a tiny image
-FROM scratch
+FROM gcr.io/distroless/base-debian12
 
 COPY --from=builder /workspace/sqlc /workspace/sqlc
 ENTRYPOINT ["/workspace/sqlc"]


### PR DESCRIPTION
By changing our base to distroless/base, we make sure that our image has the correct SSL/TLS root certificates.

Originally reported by [denge6629](https://discord.com/channels/946447283321438248/1192745342597333052/1192745342597333052) in Discord.