### PR TITLE
Add support for ignoring DDL statements using `-- sqlc:ignore`.

### DIFF
--- a/internal/cmd/createdb.go
+++ b/internal/cmd/createdb.go
@@ -85,7 +85,7 @@ func CreateDB(ctx context.Context, dir, filename, querySetName string, o *Option
 		if err != nil {
 			return fmt.Errorf("read file: %w", err)
 		}
-		ddl = append(ddl, migrations.RemoveRollbackStatements(string(contents)))
+		ddl = append(ddl, migrations.RemoveIgnoredStatements(string(contents)))
 	}
 
 	client, err := quickdb.NewClientFromConfig(conf.Cloud)

--- a/internal/cmd/vet.go
+++ b/internal/cmd/vet.go
@@ -422,7 +422,7 @@ func (c *checker) fetchDatabaseUri(ctx context.Context, s config.SQL) (string, f
 		if err != nil {
 			return "", cleanup, fmt.Errorf("read file: %w", err)
 		}
-		ddl = append(ddl, migrations.RemoveRollbackStatements(string(contents)))
+		ddl = append(ddl, migrations.RemoveIgnoredStatements(string(contents)))
 	}
 
 	resp, err := c.Client.CreateEphemeralDatabase(ctx, &pb.CreateEphemeralDatabaseRequest{

--- a/internal/compiler/compile.go
+++ b/internal/compiler/compile.go
@@ -37,7 +37,7 @@ func (c *Compiler) parseCatalog(schemas []string) error {
 			merr.Add(filename, "", 0, err)
 			continue
 		}
-		contents := migrations.RemoveRollbackStatements(string(blob))
+		contents := migrations.RemoveIgnoredStatements(string(blob))
 		c.schema = append(c.schema, contents)
 		stmts, err := c.parser.Parse(strings.NewReader(contents))
 		if err != nil {

--- a/internal/migrations/migrations.go
+++ b/internal/migrations/migrations.go
@@ -5,29 +5,44 @@ import (
 	"strings"
 )
 
-// Remove all lines after a rollback comment.
+// Remove all lines that should be ignored by sqlc, such as rollback
+// comments or explicit "sqlc:ignore" lines.
 //
 // goose:       -- +goose Down
 // sql-migrate: -- +migrate Down
 // tern:        ---- create above / drop below ----
 // dbmate:      -- migrate:down
-func RemoveRollbackStatements(contents string) string {
+// generic:     `-- sqlc:ignore` until `-- sqlc:ignore end`
+func RemoveIgnoredStatements(contents string) string {
 	s := bufio.NewScanner(strings.NewReader(contents))
 	var lines []string
+	var ignoring bool
 	for s.Scan() {
-		if strings.HasPrefix(s.Text(), "-- +goose Down") {
+		line := s.Text()
+
+		if strings.HasPrefix(line, "-- +goose Down") {
 			break
 		}
-		if strings.HasPrefix(s.Text(), "-- +migrate Down") {
+		if strings.HasPrefix(line, "-- +migrate Down") {
 			break
 		}
-		if strings.HasPrefix(s.Text(), "---- create above / drop below ----") {
+		if strings.HasPrefix(line, "---- create above / drop below ----") {
 			break
 		}
-		if strings.HasPrefix(s.Text(), "-- migrate:down") {
+		if strings.HasPrefix(line, "-- migrate:down") {
 			break
 		}
-		lines = append(lines, s.Text())
+
+		if strings.HasPrefix(line, "-- sqlc:ignore end") {
+			ignoring = false
+		} else if strings.HasPrefix(line, "-- sqlc:ignore") {
+			ignoring = true
+		} else if ignoring {
+			// make this line empty, so that errors are still reported on the
+			// correct line
+			line = ""
+		}
+		lines = append(lines, line)
 	}
 	return strings.Join(lines, "\n")
 }


### PR DESCRIPTION
**NOTE: This PR is in a draft state, because it still requires (at the very least) documentation updates.**

This PR adds support for commenting out parts of the schema. This is most useful in the case where the schema is defined by migrations, and such migrations contain queries that are not yet supported by sqlc. See for example #3129, #1756.

By wrapping such unsupported queries in `sqlc:ignore` comments, they are ignored and the rest of the schema can be parsed appropriately.

Example usage in a migration file:

```
CREATE TABLE person_email (
  email TEXT NOT NULL
);

-- sqlc:ignore until https://github.com/sqlc-dev/sqlc/issues/3129 is resolved
INSERT INTO person_email (`email`)
  SELECT pe.email
  FROM person AS p
  JOIN JSON_TABLE(p.emails, '$[*]' COLUMNS(email TEXT PATH '$')) AS pe;
-- sqlc:ignore end

ALTER TABLE person_email ADD PRIMARY KEY (`email`);
```

See https://github.com/sqlc-dev/sqlc/issues/3129 for a full use-case.

Since the lines are actually cleared, instead of removed, errors on queries below the `sqlc:ignore end` marker are still shown with the correct line number.