### PR TITLE
feat: Add `params_struct_overrides`

### DIFF
--- a/internal/codegen/golang/imports.go
+++ b/internal/codegen/golang/imports.go
@@ -320,6 +320,10 @@ func (i *importer) queryImports(filename string) fileImports {
 					return true
 				}
 			}
+			// Check if query params struct is overridden
+			if q.IsParamsStructOverriden {
+				continue
+			}
 			// Check the fields of the argument struct if it's emitted
 			if q.Arg.EmitStruct() {
 				for _, f := range q.Arg.Struct.Fields {

--- a/internal/codegen/golang/opts/options.go
+++ b/internal/codegen/golang/opts/options.go
@@ -43,6 +43,9 @@ type Options struct {
 	OmitSqlcVersion             bool              `json:"omit_sqlc_version,omitempty" yaml:"omit_sqlc_version"`
 	OmitUnusedStructs           bool              `json:"omit_unused_structs,omitempty" yaml:"omit_unused_structs"`
 	BuildTags                   string            `json:"build_tags,omitempty" yaml:"build_tags"`
+
+	// This allows overriding *Params stucts with a Model struct
+	ParamsStructOverrides       []ParamsStructOverride `json:"params_struct_overrides,omitempty" yaml:"params_struct_overrides"`          
 }
 
 type GlobalOptions struct {

--- a/internal/codegen/golang/opts/override.go
+++ b/internal/codegen/golang/opts/override.go
@@ -167,3 +167,8 @@ func (o *Override) parse(req *plugin.GenerateRequest) (err error) {
 	o.ShimOverride = shimOverride(req, o)
 	return nil
 }
+
+type ParamsStructOverride struct {
+	MethodName   string `json:"method_name" yaml:"method_name"`
+	ModelName    string `json:"model_name" yaml:"model_name"`
+}

--- a/internal/codegen/golang/query.go
+++ b/internal/codegen/golang/query.go
@@ -266,6 +266,9 @@ type Query struct {
 	Arg          QueryValue
 	// Used for :copyfrom
 	Table *plugin.Identifier
+	
+	// Used to override query param struct
+	IsParamsStructOverriden bool
 }
 
 func (q Query) hasRetType() bool {

--- a/internal/codegen/golang/result.go
+++ b/internal/codegen/golang/result.go
@@ -264,6 +264,22 @@ func buildQueries(req *plugin.GenerateRequest, options *opts.Options, structs []
 			}
 		}
 
+		if qpl <= 1 {
+			pso := options.ParamsStructOverrides
+			for _, o := range pso {
+				if query.Name == o.MethodName {
+					gq.Arg.Typ = o.ModelName 
+
+					// change arg to first letter of model struct name in lowecase
+					m := string(o.ModelName[0])
+					gq.Arg.Name = strings.ToLower(m)
+
+					// set IsParamsStructOverriden to true to skip query param struct
+					gq.IsParamsStructOverriden = true
+				}
+			}			
+		} 
+
 		if len(query.Columns) == 1 && query.Columns[0].EmbedTable == nil {
 			c := query.Columns[0]
 			name := columnName(c, 0)

--- a/internal/codegen/golang/templates/pgx/queryCode.tmpl
+++ b/internal/codegen/golang/templates/pgx/queryCode.tmpl
@@ -7,6 +7,7 @@ const {{.ConstantName}} = {{$.Q}}-- name: {{.MethodName}} {{.Cmd}}
 {{$.Q}}
 {{end}}
 
+{{if not .IsParamsStructOverriden }}
 {{if ne (hasPrefix .Cmd ":batch") true}}
 {{if .Arg.EmitStruct}}
 type {{.Arg.Type}} struct { {{- range .Arg.Struct.Fields}}
@@ -20,6 +21,7 @@ type {{.Ret.Type}} struct { {{- range .Ret.Struct.Fields}}
   {{.Name}} {{.Type}} {{if .Tag}}{{$.Q}}{{.Tag}}{{$.Q}}{{end}}
   {{- end}}
 }
+{{end}}
 {{end}}
 {{end}}
 


### PR DESCRIPTION
This option  query params structs for selected query methods. It replaces `*Params` structs with a model struct.

This is particulary useful for `insert into` queries. At this moment it only works if `query_paramater_limit` is not set