### PR TITLE
fix(mysql): Handle NULLs returned by locking funcs

### DIFF
--- a/internal/engine/dolphin/stdlib.go
+++ b/internal/engine/dolphin/stdlib.go
@@ -1033,6 +1033,7 @@ func defaultSchema(name string) *catalog.Schema {
 				},
 			},
 			ReturnType: &ast.TypeName{Name: "bool"},
+			ReturnTypeNullable: true,
 		},
 		{
 			Name: "GREATEST",
@@ -1259,6 +1260,7 @@ func defaultSchema(name string) *catalog.Schema {
 				},
 			},
 			ReturnType: &ast.TypeName{Name: "bool"},
+			ReturnTypeNullable: true,
 		},
 		{
 			Name: "IS_IPV4",
@@ -1304,6 +1306,7 @@ func defaultSchema(name string) *catalog.Schema {
 				},
 			},
 			ReturnType: &ast.TypeName{Name: "bool"},
+			ReturnTypeNullable: true,
 		},
 		{
 			Name: "IS_UUID",
@@ -2729,6 +2732,7 @@ func defaultSchema(name string) *catalog.Schema {
 				},
 			},
 			ReturnType: &ast.TypeName{Name: "bool"},
+			ReturnTypeNullable: true,
 		},
 		{
 			Name: "REPEAT",


### PR DESCRIPTION
According to https://dev.mysql.com/doc/refman/8.0/en/locking-functions.html,
certain locking functions can return NULL, e.g. RELEASE_LOCK(str) returns it
if the named lock did not exist.
