### PR TITLE
fix(mysql): Fix the generation of between keyword in CTE

### DIFF
--- a/internal/compiler/resolve.go
+++ b/internal/compiler/resolve.go
@@ -312,6 +312,8 @@ func (comp *Compiler) resolveCatalogRefs(qc *QueryCatalog, rvs []*ast.RangeVar, 
 							IsSqlcSlice:  p.IsSqlcSlice(),
 						},
 					})
+
+					break
 				}
 			}
 

--- a/internal/endtoend/testdata/between_args/mysql/query.sql
+++ b/internal/endtoend/testdata/between_args/mysql/query.sql
@@ -17,3 +17,9 @@ WHERE   p.price BETWEEN ? AND ?;
 SELECT  *
 FROM    products
 WHERE   price BETWEEN sqlc.arg(min_price) AND sqlc.arg(max_price);
+
+-- name: GetBetweenPricesTableWithCTE :many
+WITH cte AS (SELECT id FROM products WHERE products.price BETWEEN ? AND ?)
+SELECT * FROM products
+INNER JOIN cte ON products.id = cte.id
+ORDER BY name;


### PR DESCRIPTION
Fixes https://github.com/sqlc-dev/sqlc/issues/2983

The incorrectly generated code in this issue is generated as follows.

```go
const listAuthorsWithCTE = `-- name: ListAuthorsWithCTE :many
WITH page AS (SELECT id FROM authors WHERE authors.created_at BETWEEN ? AND ?)
SELECT authors.id, name, bio, created_at, page.id FROM authors
INNER JOIN page ON page.id = authors.id
ORDER BY name
`

type ListAuthorsWithCTEParams struct {
	FromCreatedAt   time.Time
	ToCreatedAt     time.Time
}
```

```go
rows, err := q.db.QueryContext(ctx, listAuthorsWithCTE, arg.FromCreatedAt, arg.ToCreatedAt)
```


