### PR TITLE
Add note specifying unsupported @ operator for mysql

### DIFF
--- a/docs/howto/named_parameters.md
+++ b/docs/howto/named_parameters.md
@@ -46,6 +46,10 @@ type UpdateAuthorNameParams struct {
 If the `sqlc.arg()` syntax is too verbose for your taste, you can use the `@`
 operator as a shortcut.
 
+```{note}
+The `@` operator as a shortcut for `sqlc.arg()` is not supported in MySQL.
+```
+
 ```sql
 -- name: UpsertAuthorName :one
 UPDATE author


### PR DESCRIPTION
The `@` operator shortcut for `sqlc.arg()` is not supported for mysql. This is confusing users and it needs to be specified in the documentation. This confusion is evident in the issue #3181 and the developer has even mention the documentation. Clearly stating that the operator is not supported for mysql will ensure developers do not mark it as a bug.