### PR TITLE
Remove --experimental flag from the persistent FlagSet

### DIFF
--- a/internal/cmd/cmd.go
+++ b/internal/cmd/cmd.go
@@ -36,7 +36,6 @@ func init() {
 func Do(args []string, stdin io.Reader, stdout io.Writer, stderr io.Writer) int {
 	rootCmd := &cobra.Command{Use: "sqlc", SilenceUsage: true}
 	rootCmd.PersistentFlags().StringP("file", "f", "", "specify an alternate config file (default: sqlc.yaml)")
-	rootCmd.PersistentFlags().BoolP("experimental", "x", false, "DEPRECATED: enable experimental features (default: false)")
 	rootCmd.PersistentFlags().Bool("no-remote", false, "disable remote execution (default: false)")
 	rootCmd.PersistentFlags().Bool("remote", false, "enable remote execution (default: false)")
 


### PR DESCRIPTION
The `--experimental` flag was deprecated and later removed from the projects code. However, it seems that the command was not removed from the persistent `FlagSet`. Now this is confusing as it appears on the help list but it is not implemented.