### PR TITLE
docs: Avoid test failure

### DIFF
--- a/docs/guides/development.md
+++ b/docs/guides/development.md
@@ -8,6 +8,12 @@ For local development, install `sqlc` under an alias. We suggest `sqlc-dev`.
 go build -o ~/go/bin/sqlc-dev ./cmd/sqlc
 ```
 
+Install `sqlc-gen-json` to avoid test failure.
+
+```
+go build -o ~/go/bin/sqlc-gen-json ./cmd/sqlc-gen-json
+```
+
 ## Running Tests
 
 ```


### PR DESCRIPTION
### Summary
Add `sqlc-gen-json` installation step to avoid the following error when tests running.

```
--- FAIL: TestReplay (0.13s)
    --- FAIL: TestReplay/base/process_plugin_sqlc_gen_json (0.01s)
        endtoend_test.go:231: sqlc generate failed: # package jsonb
            error generating code: process: sqlc-gen-json not found
FAIL
FAIL	github.com/sqlc-dev/sqlc/internal/endtoend	2.156s
```

### How to reproduce the error
1. Clone the repo (I tried the latest commit: 8d7ec15953725dde6c0dc4d55bc20c0304fd1b01)
2. Run tests by `go test ./...` command
3. The error occurs