### PR TITLE
enable go_struct_tag on column types

### DIFF
--- a/internal/codegen/golang/go_type.go
+++ b/internal/codegen/golang/go_type.go
@@ -14,7 +14,7 @@ func addExtraGoStructTags(tags map[string]string, req *plugin.GenerateRequest, o
 		if oride.GoType.StructTags == nil {
 			continue
 		}
-		dbTypeMatches := col.Type.Name == oride.DbType
+		dbTypeMatches := col.Type.Name == oride.DbType && col.NotNull == oride.Nullable
 		if !dbTypeMatches && !override.Matches(col.Table, req.Catalog.DefaultSchema) {
 			// Different table.
 			continue

--- a/internal/codegen/golang/go_type.go
+++ b/internal/codegen/golang/go_type.go
@@ -14,7 +14,8 @@ func addExtraGoStructTags(tags map[string]string, req *plugin.GenerateRequest, o
 		if oride.GoType.StructTags == nil {
 			continue
 		}
-		if !override.Matches(col.Table, req.Catalog.DefaultSchema) {
+		dbTypeMatches := col.Type.Name == oride.DbType
+		if !dbTypeMatches && !override.Matches(col.Table, req.Catalog.DefaultSchema) {
 			// Different table.
 			continue
 		}
@@ -22,7 +23,7 @@ func addExtraGoStructTags(tags map[string]string, req *plugin.GenerateRequest, o
 		if col.OriginalName != "" {
 			cname = col.OriginalName
 		}
-		if !sdk.MatchString(oride.ColumnName, cname) {
+		if !dbTypeMatches && !sdk.MatchString(oride.ColumnName, cname) {
 			// Different column.
 			continue
 		}

--- a/internal/codegen/golang/go_type.go
+++ b/internal/codegen/golang/go_type.go
@@ -14,7 +14,7 @@ func addExtraGoStructTags(tags map[string]string, req *plugin.GenerateRequest, o
 		if oride.GoType.StructTags == nil {
 			continue
 		}
-		dbTypeMatches := col.Type.Name == oride.DbType && col.NotNull == oride.Nullable
+		dbTypeMatches := col.Type.Name == oride.DbType && !col.NotNull == oride.Nullable
 		if !dbTypeMatches && !override.Matches(col.Table, req.Catalog.DefaultSchema) {
 			// Different table.
 			continue


### PR DESCRIPTION
Hi,

So, first, this is my first contribution on open source, which means the quality of the pull request isn't the greatest, but I hope at least it leads to the right solution.

I noticed that when specifying the go_struct_tags on overrides, it would only work with column and not db_type.

I found something which to me seems like a workaround, but it now works on my end.

I ran the tests and it seems to all be passing just fine (5 failing tests before the change and after, so no difference there).

I'm looking forward to some feedback and see if this can be merged into the project.

Thanks to everyone!