### PR TITLE
feat: trim output extension

### DIFF
--- a/docs/reference/config.md
+++ b/docs/reference/config.md
@@ -14,7 +14,7 @@ sql:
   queries: "postgresql/query.sql"
   engine: "postgresql"
   gen:
-    go: 
+    go:
       package: "authors"
       out: "postgresql"
   database:
@@ -122,7 +122,7 @@ The `analyzer` mapping supports the following keys:
 
 - `database`:
   -  If false, do not use the configured database for query analysis. Defaults to `true`.
-  
+
 ### gen
 
 The `gen` mapping supports the following keys:
@@ -185,6 +185,8 @@ The `gen` mapping supports the following keys:
   - Customize the name of the copyfrom file. Defaults to `copyfrom.go`.
 - `output_files_suffix`:
   - If specified the suffix will be added to the name of the generated files.
+- `output_trim_extension`:
+  - If true, remove the source file extension from generated file names. Defaults to `false`.
 - `query_parameter_limit`:
   - The number of positional arguments that will be generated for Go functions. To always emit a parameter struct, set this to `0`. Defaults to `1`.
 - `rename`:
@@ -274,18 +276,18 @@ Each mapping in the `plugins` collection has the following keys:
     - The URL to fetch the WASM file. Supports the `https://` or `file://` schemes.
   - `sha256`
     - The SHA256 checksum for the downloaded file.
-   
+
 ```yaml
 version: "2"
 plugins:
 - name: "py"
-  wasm: 
+  wasm:
     url: "https://github.com/sqlc-dev/sqlc-gen-python/releases/download/v0.16.0-alpha/sqlc-gen-python.wasm"
     sha256: "428476c7408fd4c032da4ec74e8a7344f4fa75e0f98a5a3302f238283b9b95f2"
 - name: "js"
   env:
   - PATH
-  process: 
+  process:
     cmd: "sqlc-gen-json"
 ```
 
@@ -302,7 +304,7 @@ Each mapping in the `rules` collection has the following keys:
 
 See the [vet](../howto/vet.md) documentation for a list of built-in rules and
 help writing custom rules.
-   
+
 ```yaml
 version: "2"
 sql:
@@ -336,7 +338,7 @@ rules:
     rule: |
       query.cmd == "exec"
 ```
-  
+
 ### Global overrides
 
 Sometimes, the same configuration must be done across various specifications of
@@ -362,7 +364,7 @@ sql:
   queries: "postgresql/query.sql"
   engine: "postgresql"
   gen:
-    go: 
+    go:
       package: "authors"
       out: "postgresql"
 - schema: "mysql/schema.sql"
@@ -483,6 +485,8 @@ Each mapping in the `packages` collection has the following keys:
   - Customize the name of the copyfrom file. Defaults to `copyfrom.go`.
 - `output_files_suffix`:
   - If specified the suffix will be added to the name of the generated files.
+- `output_trim_extension`:
+  - If true, remove the source file extension from generated file names. Defaults to `false`.
 - `query_parameter_limit`:
   - Positional arguments that will be generated in Go functions (`>= 0`). To always emit a parameter struct, you would need to set it to `0`. Defaults to `1`.
 

--- a/internal/codegen/golang/gen.go
+++ b/internal/codegen/golang/gen.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"fmt"
 	"go/format"
+	"path/filepath"
 	"strings"
 	"text/template"
 
@@ -249,6 +250,10 @@ func generate(req *plugin.GenerateRequest, options *opts.Options, enums []Enum, 
 		if err != nil {
 			fmt.Println(b.String())
 			return fmt.Errorf("source error: %w", err)
+		}
+
+		if options.OutputTrimExtension {
+			name = strings.TrimSuffix(name, filepath.Ext(name))
 		}
 
 		if templateName == "queryFile" && options.OutputFilesSuffix != "" {

--- a/internal/codegen/golang/opts/options.go
+++ b/internal/codegen/golang/opts/options.go
@@ -38,6 +38,7 @@ type Options struct {
 	OutputQuerierFileName       string            `json:"output_querier_file_name,omitempty" yaml:"output_querier_file_name"`
 	OutputCopyfromFileName      string            `json:"output_copyfrom_file_name,omitempty" yaml:"output_copyfrom_file_name"`
 	OutputFilesSuffix           string            `json:"output_files_suffix,omitempty" yaml:"output_files_suffix"`
+	OutputTrimExtension         bool              `json:"output_trim_extension,omitempty" yaml:"output_trim_extension"`
 	InflectionExcludeTableNames []string          `json:"inflection_exclude_table_names,omitempty" yaml:"inflection_exclude_table_names"`
 	QueryParameterLimit         *int32            `json:"query_parameter_limit,omitempty" yaml:"query_parameter_limit"`
 	OmitSqlcVersion             bool              `json:"omit_sqlc_version,omitempty" yaml:"omit_sqlc_version"`

--- a/internal/config/v_two.json
+++ b/internal/config/v_two.json
@@ -251,6 +251,9 @@
                                 "output_files_suffix": {
                                     "type": "string"
                                 },
+                                "output_trim_extension": {
+                                    "type": "boolean"
+                                },
                                 "inflection_exclude_table_names": {
                                     "type": "array",
                                     "items": {


### PR DESCRIPTION
Add an option to trim the extension of the source filename when writing outputs. This allows consumers to eliminate unnecessary .sql within the names of the generated files.