### PR TITLE
fix(docs): correct go install instructions

### DIFF
--- a/docs/overview/install.md
+++ b/docs/overview/install.md
@@ -14,18 +14,12 @@ brew install sqlc
 sudo snap install sqlc
 ```
 
-## go install 
+## go install
 
-### Go >= 1.17:
+Installing recent versions of sqlc requires Go 1.21+.
 
 ```
 go install github.com/sqlc-dev/sqlc/cmd/sqlc@latest
-```
-
-### Go < 1.17:
-
-```
-go get github.com/sqlc-dev/sqlc/cmd/sqlc
 ```
 
 ## Docker


### PR DESCRIPTION
Go 1.21+ is required for recent versions of sqlc. This is because it uses components that require the 1.21 toolchain. Coincidentally 1.21 is also when forward compatibility was introduced.

You can test this
```
$ docker run -it --rm golang:1.19
% go install github.com/sqlc-dev/sqlc/cmd/sqlc@latest
...
pkg/mod/github.com/sqlc-dev/sqlc@latest/internal/bundler/upload.go:7:2: package log/slog is not in GOROOT (/usr/local/go/src/log/slog)
pkg/mod/github.com/sqlc-dev/sqlc@latest/internal/codegen/golang/opts/options.go:6:2: package maps is not in GOROOT (/usr/local/go/src/maps)
```