### PR TITLE
Added support to add open-tracing on go mysql

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,31 @@ Check out [an interactive example](https://play.sqlc.dev/) to see it in action, 
 - [Downloads](https://downloads.sqlc.dev/)
 - [Community](https://discord.gg/EcXzGe5SEs)
 
+### Delta on top of main sqlc
+Added support for `enable_open_tracing` which adds open tracing to the generated code. 
+```go
+span, ctx := opentracing.StartSpanFromContext(ctx, "MethodName")
+defer span.Finish()
+```
+
+```yaml
+version: "2"
+sql:
+  - engine: "mysql"
+    queries: "query.sql"
+    schema: "schema.sql"
+    gen:
+      go:
+        emit_prepared_queries: true
+        emit_interface: true
+        enable_open_tracing: true
+        emit_exact_table_names: false
+        emit_empty_slices: true
+        emit_json_tags: true
+        package: "authors"
+        out: "./authors"
+```
+
 ## Supported languages
 
 - [sqlc-gen-go](https://github.com/sqlc-dev/sqlc-gen-go)

--- a/internal/codegen/golang/gen.go
+++ b/internal/codegen/golang/gen.go
@@ -41,6 +41,7 @@ type tmplCtx struct {
 	UsesBatch                 bool
 	OmitSqlcVersion           bool
 	BuildTags                 string
+	EnableOpenTracing         bool
 }
 
 func (t *tmplCtx) OutputQuery(sourceName string) bool {

--- a/internal/codegen/golang/imports.go
+++ b/internal/codegen/golang/imports.go
@@ -299,6 +299,7 @@ func sortedImports(std map[string]struct{}, pkg map[ImportSpec]struct{}) fileImp
 func (i *importer) queryImports(filename string) fileImports {
 	var gq []Query
 	anyNonCopyFrom := false
+	openTrackingImport := false
 	for _, query := range i.Queries {
 		if usesBatch([]Query{query}) {
 			continue
@@ -308,6 +309,9 @@ func (i *importer) queryImports(filename string) fileImports {
 			if query.Cmd != metadata.CmdCopyFrom {
 				anyNonCopyFrom = true
 			}
+		}
+		if query.EnableOpenTracing {
+			openTrackingImport = true
 		}
 	}
 
@@ -392,6 +396,9 @@ func (i *importer) queryImports(filename string) fileImports {
 
 	if anyNonCopyFrom {
 		std["context"] = struct{}{}
+	}
+	if openTrackingImport {
+		pkg[ImportSpec{Path: "github.com/opentracing/opentracing-go"}] = struct{}{}
 	}
 
 	sqlpkg := parseDriver(i.Options.SqlPackage)

--- a/internal/codegen/golang/opts/options.go
+++ b/internal/codegen/golang/opts/options.go
@@ -10,6 +10,7 @@ import (
 )
 
 type Options struct {
+	EnableOpenTracing           bool              `json:"enable_open_tracing" yaml:"enable_open_tracing"`
 	EmitInterface               bool              `json:"emit_interface" yaml:"emit_interface"`
 	EmitJsonTags                bool              `json:"emit_json_tags" yaml:"emit_json_tags"`
 	JsonTagsIdUppercase         bool              `json:"json_tags_id_uppercase" yaml:"json_tags_id_uppercase"`

--- a/internal/codegen/golang/query.go
+++ b/internal/codegen/golang/query.go
@@ -256,15 +256,16 @@ func (v QueryValue) VariableForField(f Field) string {
 
 // A struct used to generate methods and fields on the Queries struct
 type Query struct {
-	Cmd          string
-	Comments     []string
-	MethodName   string
-	FieldName    string
-	ConstantName string
-	SQL          string
-	SourceName   string
-	Ret          QueryValue
-	Arg          QueryValue
+	Cmd               string
+	Comments          []string
+	MethodName        string
+	FieldName         string
+	ConstantName      string
+	SQL               string
+	SourceName        string
+	EnableOpenTracing bool
+	Ret               QueryValue
+	Arg               QueryValue
 	// Used for :copyfrom
 	Table *plugin.Identifier
 }

--- a/internal/codegen/golang/result.go
+++ b/internal/codegen/golang/result.go
@@ -217,14 +217,15 @@ func buildQueries(req *plugin.GenerateRequest, options *opts.Options, structs []
 		}
 
 		gq := Query{
-			Cmd:          query.Cmd,
-			ConstantName: constantName,
-			FieldName:    sdk.LowerTitle(query.Name) + "Stmt",
-			MethodName:   query.Name,
-			SourceName:   query.Filename,
-			SQL:          query.Text,
-			Comments:     comments,
-			Table:        query.InsertIntoTable,
+			Cmd:               query.Cmd,
+			ConstantName:      constantName,
+			FieldName:         sdk.LowerTitle(query.Name) + "Stmt",
+			MethodName:        query.Name,
+			SourceName:        query.Filename,
+			SQL:               query.Text,
+			Comments:          comments,
+			Table:             query.InsertIntoTable,
+			EnableOpenTracing: options.EnableOpenTracing,
 		}
 		sqlpkg := parseDriver(options.SqlPackage)
 

--- a/internal/codegen/golang/templates/stdlib/queryCode.tmpl
+++ b/internal/codegen/golang/templates/stdlib/queryCode.tmpl
@@ -23,6 +23,10 @@ type {{.Ret.Type}} struct { {{- range .Ret.Struct.Fields}}
 {{range .Comments}}//{{.}}
 {{end -}}
 func (q *Queries) {{.MethodName}}(ctx context.Context, {{ dbarg }} {{.Arg.Pair}}) ({{.Ret.DefineType}}, error) {
+    {{if eq .EnableOpenTracing true}}
+    span, ctx := opentracing.StartSpanFromContext(ctx, "{{.MethodName}}")
+    defer span.Finish()
+    {{end}}
     {{- template "queryCodeStdExec" . }}
 	{{- if or (ne .Arg.Pair .Ret.Pair) (ne .Arg.DefineType .Ret.DefineType) }}
 	var {{.Ret.Name}} {{.Ret.Type}}
@@ -36,6 +40,10 @@ func (q *Queries) {{.MethodName}}(ctx context.Context, {{ dbarg }} {{.Arg.Pair}}
 {{range .Comments}}//{{.}}
 {{end -}}
 func (q *Queries) {{.MethodName}}(ctx context.Context, {{ dbarg }} {{.Arg.Pair}}) ([]{{.Ret.DefineType}}, error) {
+    {{if eq .EnableOpenTracing true}}
+    span, ctx := opentracing.StartSpanFromContext(ctx, "{{.MethodName}}")
+    defer span.Finish()
+    {{end}}
     {{- template "queryCodeStdExec" . }}
     if err != nil {
         return nil, err
@@ -67,6 +75,10 @@ func (q *Queries) {{.MethodName}}(ctx context.Context, {{ dbarg }} {{.Arg.Pair}}
 {{range .Comments}}//{{.}}
 {{end -}}
 func (q *Queries) {{.MethodName}}(ctx context.Context, {{ dbarg }} {{.Arg.Pair}}) error {
+    {{if eq .EnableOpenTracing true}}
+    span, ctx := opentracing.StartSpanFromContext(ctx, "{{.MethodName}}")
+    defer span.Finish()
+    {{end}}
     {{- template "queryCodeStdExec" . }}
     return err
 }
@@ -76,6 +88,10 @@ func (q *Queries) {{.MethodName}}(ctx context.Context, {{ dbarg }} {{.Arg.Pair}}
 {{range .Comments}}//{{.}}
 {{end -}}
 func (q *Queries) {{.MethodName}}(ctx context.Context, {{ dbarg }} {{.Arg.Pair}}) (int64, error) {
+    {{if eq .EnableOpenTracing true}}
+    span, ctx := opentracing.StartSpanFromContext(ctx, "{{.MethodName}}")
+    defer span.Finish()
+    {{end}}
     {{- template "queryCodeStdExec" . }}
     if err != nil {
         return 0, err
@@ -88,6 +104,10 @@ func (q *Queries) {{.MethodName}}(ctx context.Context, {{ dbarg }} {{.Arg.Pair}}
 {{range .Comments}}//{{.}}
 {{end -}}
 func (q *Queries) {{.MethodName}}(ctx context.Context, {{ dbarg }} {{.Arg.Pair}}) (int64, error) {
+    {{if eq .EnableOpenTracing true}}
+    span, ctx := opentracing.StartSpanFromContext(ctx, "{{.MethodName}}")
+    defer span.Finish()
+    {{end}}
     {{- template "queryCodeStdExec" . }}
     if err != nil {
         return 0, err
@@ -100,6 +120,10 @@ func (q *Queries) {{.MethodName}}(ctx context.Context, {{ dbarg }} {{.Arg.Pair}}
 {{range .Comments}}//{{.}}
 {{end -}}
 func (q *Queries) {{.MethodName}}(ctx context.Context, {{ dbarg }} {{.Arg.Pair}}) (sql.Result, error) {
+    {{if eq .EnableOpenTracing true}}
+    span, ctx := opentracing.StartSpanFromContext(ctx, "{{.MethodName}}")
+    defer span.Finish()
+    {{end}}
     {{- template "queryCodeStdExec" . }}
 }
 {{end}}

--- a/internal/codegen/golang/templates/stdlib/queryCode.tmpl
+++ b/internal/codegen/golang/templates/stdlib/queryCode.tmpl
@@ -23,10 +23,10 @@ type {{.Ret.Type}} struct { {{- range .Ret.Struct.Fields}}
 {{range .Comments}}//{{.}}
 {{end -}}
 func (q *Queries) {{.MethodName}}(ctx context.Context, {{ dbarg }} {{.Arg.Pair}}) ({{.Ret.DefineType}}, error) {
-    {{if eq .EnableOpenTracing true}}
+    {{- if eq .EnableOpenTracing true}}
     span, ctx := opentracing.StartSpanFromContext(ctx, "{{.MethodName}}")
     defer span.Finish()
-    {{end}}
+    {{end -}}
     {{- template "queryCodeStdExec" . }}
 	{{- if or (ne .Arg.Pair .Ret.Pair) (ne .Arg.DefineType .Ret.DefineType) }}
 	var {{.Ret.Name}} {{.Ret.Type}}
@@ -40,10 +40,10 @@ func (q *Queries) {{.MethodName}}(ctx context.Context, {{ dbarg }} {{.Arg.Pair}}
 {{range .Comments}}//{{.}}
 {{end -}}
 func (q *Queries) {{.MethodName}}(ctx context.Context, {{ dbarg }} {{.Arg.Pair}}) ([]{{.Ret.DefineType}}, error) {
-    {{if eq .EnableOpenTracing true}}
+    {{- if eq .EnableOpenTracing true}}
     span, ctx := opentracing.StartSpanFromContext(ctx, "{{.MethodName}}")
     defer span.Finish()
-    {{end}}
+    {{end -}}
     {{- template "queryCodeStdExec" . }}
     if err != nil {
         return nil, err
@@ -75,10 +75,10 @@ func (q *Queries) {{.MethodName}}(ctx context.Context, {{ dbarg }} {{.Arg.Pair}}
 {{range .Comments}}//{{.}}
 {{end -}}
 func (q *Queries) {{.MethodName}}(ctx context.Context, {{ dbarg }} {{.Arg.Pair}}) error {
-    {{if eq .EnableOpenTracing true}}
+    {{- if eq .EnableOpenTracing true}}
     span, ctx := opentracing.StartSpanFromContext(ctx, "{{.MethodName}}")
     defer span.Finish()
-    {{end}}
+    {{end -}}
     {{- template "queryCodeStdExec" . }}
     return err
 }
@@ -88,10 +88,10 @@ func (q *Queries) {{.MethodName}}(ctx context.Context, {{ dbarg }} {{.Arg.Pair}}
 {{range .Comments}}//{{.}}
 {{end -}}
 func (q *Queries) {{.MethodName}}(ctx context.Context, {{ dbarg }} {{.Arg.Pair}}) (int64, error) {
-    {{if eq .EnableOpenTracing true}}
+    {{- if eq .EnableOpenTracing true}}
     span, ctx := opentracing.StartSpanFromContext(ctx, "{{.MethodName}}")
     defer span.Finish()
-    {{end}}
+    {{end -}}
     {{- template "queryCodeStdExec" . }}
     if err != nil {
         return 0, err
@@ -104,10 +104,10 @@ func (q *Queries) {{.MethodName}}(ctx context.Context, {{ dbarg }} {{.Arg.Pair}}
 {{range .Comments}}//{{.}}
 {{end -}}
 func (q *Queries) {{.MethodName}}(ctx context.Context, {{ dbarg }} {{.Arg.Pair}}) (int64, error) {
-    {{if eq .EnableOpenTracing true}}
+    {{- if eq .EnableOpenTracing true}}
     span, ctx := opentracing.StartSpanFromContext(ctx, "{{.MethodName}}")
     defer span.Finish()
-    {{end}}
+    {{end -}}
     {{- template "queryCodeStdExec" . }}
     if err != nil {
         return 0, err
@@ -120,10 +120,10 @@ func (q *Queries) {{.MethodName}}(ctx context.Context, {{ dbarg }} {{.Arg.Pair}}
 {{range .Comments}}//{{.}}
 {{end -}}
 func (q *Queries) {{.MethodName}}(ctx context.Context, {{ dbarg }} {{.Arg.Pair}}) (sql.Result, error) {
-    {{if eq .EnableOpenTracing true}}
+    {{- if eq .EnableOpenTracing true}}
     span, ctx := opentracing.StartSpanFromContext(ctx, "{{.MethodName}}")
     defer span.Finish()
-    {{end}}
+    {{end -}}
     {{- template "queryCodeStdExec" . }}
 }
 {{end}}


### PR DESCRIPTION
it will add `opentracing` in all `query.sql.go` method
```go
span, ctx := opentracing.StartSpanFromContext(ctx, "MethodName")
defer span.Finish()
```

Let me know if I need to make more changes. I have explained it in the README.md file also (this part can be ignored in merge).