### PR TITLE
docs: Fix typo in config

### DIFF
--- a/docs/reference/config.md
+++ b/docs/reference/config.md
@@ -50,7 +50,7 @@ Each mapping in the `sql` collection has the following keys:
   - A mapping to configure database connections. See [database](#database) for the supported keys.
 - `rules`:
   - A collection of rule names to run via `sqlc vet`. See [rules](#rules) for configuration options.
-- `analzyer`:
+- `analyzer`:
   - A mapping to configure query analysis. See [analyzer](#analyzer) for the supported keys.
 - `strict_function_checks`
   - If true, return an error if a called SQL function does not exist. Defaults to `false`.


### PR DESCRIPTION
The PR corrects grammar issue.