### PR TITLE
chore: remove deprecated build tags

### DIFF
--- a/examples/authors/mysql/db_test.go
+++ b/examples/authors/mysql/db_test.go
@@ -1,5 +1,4 @@
 //go:build examples
-// +build examples
 
 package authors
 

--- a/examples/authors/postgresql/db_test.go
+++ b/examples/authors/postgresql/db_test.go
@@ -1,5 +1,4 @@
 //go:build examples
-// +build examples
 
 package authors
 

--- a/examples/authors/sqlite/db_test.go
+++ b/examples/authors/sqlite/db_test.go
@@ -1,5 +1,4 @@
 //go:build examples
-// +build examples
 
 package authors
 

--- a/examples/batch/postgresql/db_test.go
+++ b/examples/batch/postgresql/db_test.go
@@ -1,5 +1,4 @@
 //go:build examples
-// +build examples
 
 package batch
 

--- a/examples/booktest/mysql/db_test.go
+++ b/examples/booktest/mysql/db_test.go
@@ -1,5 +1,4 @@
 //go:build examples
-// +build examples
 
 package booktest
 

--- a/examples/booktest/postgresql/db_test.go
+++ b/examples/booktest/postgresql/db_test.go
@@ -1,5 +1,4 @@
 //go:build examples
-// +build examples
 
 package booktest
 

--- a/examples/booktest/sqlite/db_test.go
+++ b/examples/booktest/sqlite/db_test.go
@@ -1,5 +1,4 @@
 //go:build examples
-// +build examples
 
 package booktest
 

--- a/examples/ondeck/mysql/db_test.go
+++ b/examples/ondeck/mysql/db_test.go
@@ -1,5 +1,4 @@
 //go:build examples
-// +build examples
 
 package ondeck
 

--- a/examples/ondeck/postgresql/db_test.go
+++ b/examples/ondeck/postgresql/db_test.go
@@ -1,5 +1,4 @@
 //go:build examples
-// +build examples
 
 package ondeck
 

--- a/examples/ondeck/sqlite/db_test.go
+++ b/examples/ondeck/sqlite/db_test.go
@@ -1,5 +1,4 @@
 //go:build examples
-// +build examples
 
 package ondeck
 

--- a/internal/endtoend/vet_test.go
+++ b/internal/endtoend/vet_test.go
@@ -1,5 +1,4 @@
 //go:build examples
-// +build examples
 
 package main
 

--- a/internal/engine/postgresql/parse_default.go
+++ b/internal/engine/postgresql/parse_default.go
@@ -1,5 +1,4 @@
 //go:build !windows && cgo
-// +build !windows,cgo
 
 package postgresql
 

--- a/internal/engine/postgresql/parse_wasi.go
+++ b/internal/engine/postgresql/parse_wasi.go
@@ -1,5 +1,4 @@
 //go:build windows || !cgo
-// +build windows !cgo
 
 package postgresql
 

--- a/internal/engine/postgresql/parser/parser_default.go
+++ b/internal/engine/postgresql/parser/parser_default.go
@@ -1,5 +1,4 @@
 //go:build !windows && cgo
-// +build !windows,cgo
 
 package parser
 

--- a/internal/engine/postgresql/parser/parser_wasi.go
+++ b/internal/engine/postgresql/parser/parser_wasi.go
@@ -1,5 +1,4 @@
 //go:build windows || !cgo
-// +build windows !cgo
 
 package parser
 


### PR DESCRIPTION
This PR removes outdated in Go 1.21 `// +build` comments by running the command:
```
go fix -fix buildtag ./...
```

From the https://pkg.go.dev/cmd/go#hdr-Build_constraints:

> Go versions 1.16 and earlier used a different syntax for build constraints, with a "// +build" prefix. The gofmt command will add an equivalent //go:build constraint when encountering the older syntax.

