### PR TITLE
hacky support for Postgres schemas w/ runtime interpolation

### DIFF
--- a/internal/codegen/golang/gen.go
+++ b/internal/codegen/golang/gen.go
@@ -37,6 +37,7 @@ type tmplCtx struct {
 	EmitMethodsWithDBArgument bool
 	EmitEnumValidMethod       bool
 	EmitAllEnumValues         bool
+	UseSchemaPlaceholder      bool
 	UsesCopyFrom              bool
 	UsesBatch                 bool
 	OmitSqlcVersion           bool
@@ -177,6 +178,7 @@ func generate(req *plugin.GenerateRequest, options *opts.Options, enums []Enum, 
 		EmitMethodsWithDBArgument: options.EmitMethodsWithDbArgument,
 		EmitEnumValidMethod:       options.EmitEnumValidMethod,
 		EmitAllEnumValues:         options.EmitAllEnumValues,
+		UseSchemaPlaceholder:      options.UseSchemaPlaceholder,
 		UsesCopyFrom:              usesCopyFrom(queries),
 		UsesBatch:                 usesBatch(queries),
 		SQLDriver:                 parseDriver(options.SqlPackage),

--- a/internal/codegen/golang/imports.go
+++ b/internal/codegen/golang/imports.go
@@ -124,6 +124,10 @@ func (i *importer) dbImports() fileImports {
 		{Path: "context"},
 	}
 
+	if i.Options.UseSchemaPlaceholder {
+		std = append(std, ImportSpec{Path: "strings"})
+	}
+
 	sqlpkg := parseDriver(i.Options.SqlPackage)
 	switch sqlpkg {
 	case opts.SQLDriverPGXV4:

--- a/internal/codegen/golang/opts/options.go
+++ b/internal/codegen/golang/opts/options.go
@@ -44,6 +44,7 @@ type Options struct {
 	OmitUnusedStructs           bool              `json:"omit_unused_structs,omitempty" yaml:"omit_unused_structs"`
 	BuildTags                   string            `json:"build_tags,omitempty" yaml:"build_tags"`
 	Initialisms                 *[]string         `json:"initialisms,omitempty" yaml:"initialisms"`
+	UseSchemaPlaceholder        bool              `json:"use_schema_placeholder,omitempty" yaml:"use_schema_placeholder"`
 
 	InitialismsMap map[string]struct{} `json:"-" yaml:"-"`
 }

--- a/internal/codegen/golang/query.go
+++ b/internal/codegen/golang/query.go
@@ -278,7 +278,7 @@ func (q Query) hasRetType() bool {
 func (q Query) TableIdentifierAsGoSlice() string {
 	escapedNames := make([]string, 0, 3)
 	for _, p := range []string{q.Table.Catalog, q.Table.Schema, q.Table.Name} {
-		if p != "" {
+		if p != "" && p != "sqlc_schema_placeholder" {
 			escapedNames = append(escapedNames, fmt.Sprintf("%q", p))
 		}
 	}

--- a/internal/codegen/golang/struct.go
+++ b/internal/codegen/golang/struct.go
@@ -17,6 +17,7 @@ type Struct struct {
 }
 
 func StructName(name string, options *opts.Options) string {
+	name = strings.TrimPrefix(name, "sqlc_schema_placeholder")
 	if rename := options.Rename[name]; rename != "" {
 		return rename
 	}

--- a/internal/codegen/golang/templates/pgx/dbCode.tmpl
+++ b/internal/codegen/golang/templates/pgx/dbCode.tmpl
@@ -12,7 +12,10 @@ type DBTX interface {
 {{- end }}
 }
 
-{{ if .EmitMethodsWithDBArgument}}
+{{ if and .EmitMethodsWithDBArgument .UseSchemaPlaceholder  }}
+func New(schema string) *Queries {
+	return &Queries{schema: schema}
+{{- else if .EmitMethodsWithDBArgument}}
 func New() *Queries {
 	return &Queries{}
 {{- else -}}
@@ -25,7 +28,16 @@ type Queries struct {
     {{if not .EmitMethodsWithDBArgument}}
 	db DBTX
     {{end}}
+    {{if .UseSchemaPlaceholder}}
+	schema string
+    {{end}}
 }
+
+{{if .UseSchemaPlaceholder}}
+func (q *Queries) interpolateSchemaName(query string) string {
+	return strings.ReplaceAll(query, "sqlc_schema_placeholder.", q.schema+".")
+}
+{{end -}}
 
 {{if not .EmitMethodsWithDBArgument}}
 func (q *Queries) WithTx(tx pgx.Tx) *Queries {

--- a/internal/codegen/golang/templates/pgx/queryCode.tmpl
+++ b/internal/codegen/golang/templates/pgx/queryCode.tmpl
@@ -28,7 +28,7 @@ type {{.Ret.Type}} struct { {{- range .Ret.Struct.Fields}}
 {{end -}}
 {{- if $.EmitMethodsWithDBArgument -}}
 func (q *Queries) {{.MethodName}}(ctx context.Context, db DBTX, {{.Arg.Pair}}) ({{.Ret.DefineType}}, error) {
-	row := db.QueryRow(ctx, {{.ConstantName}}, {{.Arg.Params}})
+	row := db.QueryRow(ctx, {{ if $.UseSchemaPlaceholder }}q.interpolateSchemaName({{.ConstantName}}){{else}}{{.ConstantName}}{{end}}, {{.Arg.Params}})
 {{- else -}}
 func (q *Queries) {{.MethodName}}(ctx context.Context, {{.Arg.Pair}}) ({{.Ret.DefineType}}, error) {
 	row := q.db.QueryRow(ctx, {{.ConstantName}}, {{.Arg.Params}})
@@ -46,7 +46,7 @@ func (q *Queries) {{.MethodName}}(ctx context.Context, {{.Arg.Pair}}) ({{.Ret.De
 {{end -}}
 {{- if $.EmitMethodsWithDBArgument -}}
 func (q *Queries) {{.MethodName}}(ctx context.Context, db DBTX, {{.Arg.Pair}}) ([]{{.Ret.DefineType}}, error) {
-	rows, err := db.Query(ctx, {{.ConstantName}}, {{.Arg.Params}})
+	rows, err := db.Query(ctx, {{ if $.UseSchemaPlaceholder }}q.interpolateSchemaName({{.ConstantName}}){{else}}{{.ConstantName}}{{end}}, {{.Arg.Params}})
 {{- else -}}
 func (q *Queries) {{.MethodName}}(ctx context.Context, {{.Arg.Pair}}) ([]{{.Ret.DefineType}}, error) {
 	rows, err := q.db.Query(ctx, {{.ConstantName}}, {{.Arg.Params}})
@@ -79,7 +79,7 @@ func (q *Queries) {{.MethodName}}(ctx context.Context, {{.Arg.Pair}}) ([]{{.Ret.
 {{end -}}
 {{- if $.EmitMethodsWithDBArgument -}}
 func (q *Queries) {{.MethodName}}(ctx context.Context, db DBTX, {{.Arg.Pair}}) error {
-	_, err := db.Exec(ctx, {{.ConstantName}}, {{.Arg.Params}})
+	_, err := db.Exec(ctx, {{ if $.UseSchemaPlaceholder }}q.interpolateSchemaName({{.ConstantName}}){{else}}{{.ConstantName}}{{end}}, {{.Arg.Params}})
 {{- else -}}
 func (q *Queries) {{.MethodName}}(ctx context.Context, {{.Arg.Pair}}) error {
 	_, err := q.db.Exec(ctx, {{.ConstantName}}, {{.Arg.Params}})
@@ -93,7 +93,7 @@ func (q *Queries) {{.MethodName}}(ctx context.Context, {{.Arg.Pair}}) error {
 {{end -}}
 {{if $.EmitMethodsWithDBArgument -}}
 func (q *Queries) {{.MethodName}}(ctx context.Context, db DBTX, {{.Arg.Pair}}) (int64, error) {
-	result, err := db.Exec(ctx, {{.ConstantName}}, {{.Arg.Params}})
+	result, err := db.Exec(ctx, {{ if $.UseSchemaPlaceholder }}q.interpolateSchemaName({{.ConstantName}}){{else}}{{.ConstantName}}{{end}}, {{.Arg.Params}})
 {{- else -}}
 func (q *Queries) {{.MethodName}}(ctx context.Context, {{.Arg.Pair}}) (int64, error) {
 	result, err := q.db.Exec(ctx, {{.ConstantName}}, {{.Arg.Params}})
@@ -110,7 +110,7 @@ func (q *Queries) {{.MethodName}}(ctx context.Context, {{.Arg.Pair}}) (int64, er
 {{end -}}
 {{- if $.EmitMethodsWithDBArgument -}}
 func (q *Queries) {{.MethodName}}(ctx context.Context, db DBTX, {{.Arg.Pair}}) (pgconn.CommandTag, error) {
-	return db.Exec(ctx, {{.ConstantName}}, {{.Arg.Params}})
+	return db.Exec(ctx, {{ if $.UseSchemaPlaceholder }}q.interpolateSchemaName({{.ConstantName}}){{else}}{{.ConstantName}}{{end}}, {{.Arg.Params}})
 {{- else -}}
 func (q *Queries) {{.MethodName}}(ctx context.Context, {{.Arg.Pair}}) (pgconn.CommandTag, error) {
 	return q.db.Exec(ctx, {{.ConstantName}}, {{.Arg.Params}})


### PR DESCRIPTION
Hi @kyleconroy and @andrewmbenton 👋 @brandur and I have recently been looking more into making [River](https://github.com/riverqueue/river) fully support isolation at the Postgres schema level (that is, allowing different River clients to be configured to use different [Postgres schemas](https://www.postgresql.org/docs/current/ddl-schemas.html)). Our initial hope was to be able to rely on the `search_path` connection param as [recommended by pgx](https://github.com/jackc/pgx/issues/1013) and https://github.com/sqlc-dev/sqlc/discussions/2635 for this purpose.

Unfortunately, one of our users [quickly discovered](https://github.com/riverqueue/river/issues/345) that [this approach is basically incompatible with pgbouncer](https://github.com/pgbouncer/pgbouncer/issues/89). As far as I know the only ways to make this work with pgbouncer and sqlc would be:

1. Explicitly `SET search_path` prior to any query, _within a transaction_. This is error prone and has perf penalties in the form of added round trips.
2. Configure pgbouncer to isolate client pools for specific schemas at the user level. This is a pain to configure and precludes mixing and matching multiple schemas within a single conn pool. Not great.
3. Hypothetically, configure the database queries to explicitly specify the schema prefix on every query where it's required. I say hypothetically because this is of course not supported by sqlc today due to the fact that the schema can't be parameterized (it must be explicitly inserted into the SQL string).

I decided to spend chunk of time last night seeing if I could hack a way to achieve option (3) in sqlc. It actually wasn't too difficult to achieve in a hacky way, though doing so did cement my dislike of Go's `text/template` 😆 This draft PR shows one potential path for achieving this using a new `use_schema_placeholder` option, which when enabled causes all queries to be passed through a runtime string replacement on the known prefix placeholder `sqlc_schema_placeholder.`. It's definitely ugly and probably shouldn't be shipped in any form that resembles this PR, but I did want to at least raise it as a possible proof-of-concept.

Here's [a corresponding River commit](https://github.com/riverqueue/river/compare/bg-sqlc-hacky-schema-support) showing the queries that I updated to make use of the placeholder prefix. This sqlc PR does actually build and generate fully functional code for being able to use arbitrary schemas specified at runtime as shown in that commit.

I have lots of ideas for how this could be improved or done differently from the way I've done here (caching, maybe make this customizable per-query [ala Ecto](https://hexdocs.pm/ecto/Ecto.Query.html#module-query-prefix) instead of being statically wired into `Queries`, etc.), but rather than spin my wheels on them I thought I'd use this draft PR to start a discussion around if and how this might be achieved in sqlc given the fact that the previously recommended approach is not actually viable for those using pgbouncer in the most common way.

I also want to highlight that this is fairly distinct from allowing arbitrary runtime SQL substitution, because a schema prefix can be strictly validated to avoid i.e. injection concerns.

Related issues:

* https://github.com/sqlc-dev/sqlc/issues/2633
* https://github.com/sqlc-dev/sqlc/discussions/2635