### PR TITLE
Make `sqlc.embed` compatible with `pgFormatter` and `sql-formatter`

### DIFF
--- a/examples/batch/postgresql/querier.go
+++ b/examples/batch/postgresql/querier.go
@@ -19,6 +19,7 @@ type Querier interface {
 	DeleteBookNamedFunc(ctx context.Context, bookID []int32) *DeleteBookNamedFuncBatchResults
 	DeleteBookNamedSign(ctx context.Context, bookID []int32) *DeleteBookNamedSignBatchResults
 	GetAuthor(ctx context.Context, authorID int32) (Author, error)
+	GetAuthorWithFirstBook(ctx context.Context, authorID []int32) *GetAuthorWithFirstBookBatchResults
 	GetBiography(ctx context.Context, authorID []int32) *GetBiographyBatchResults
 	UpdateBook(ctx context.Context, arg []UpdateBookParams) *UpdateBookBatchResults
 }

--- a/examples/batch/postgresql/query.sql
+++ b/examples/batch/postgresql/query.sql
@@ -54,3 +54,9 @@ WHERE book_id = $3;
 -- name: GetBiography :batchone
 SELECT biography FROM authors
 WHERE author_id = $1;
+
+-- name: GetAuthorWithFirstBook :batchone
+SELECT sqlc.embed (books), sqlc.embed (authors)
+FROM authors
+INNER JOIN books ON authors.author_id = books.author_id
+WHERE authors.author_id = $1;


### PR DESCRIPTION
### What does this PR fixed?
- This PR addresses issues with SQL formatting tools [pgFormatter](https://www.postgresql.org/about/news/pgformatter-v55-released-2589/) and [sql-formatter](https://github.com/sql-formatter-org/sql-formatter). These tools are used to format SQL, similar to how `go fmt` formats Go code.
- Both formatters, by default, add spaces before function calls. This changes `sqlc.embed(name)` to `sqlc.embed (name)`, which `sqlc` cannot parse correctly:
```bash
$ cd example/batch

$ sqlc generate                                                                                                                                                                                                                                   
> # package batch
> postgresql/query.sql:10:1: edited query syntax is invalid: syntax error at or near ")"
```