### PR TITLE
fix(dbmanager): Add leading slash to db uri path rewrite

### DIFF
--- a/internal/dbmanager/client.go
+++ b/internal/dbmanager/client.go
@@ -72,7 +72,7 @@ func (m *ManagedClient) CreateDatabase(ctx context.Context, req *CreateDatabaseR
 	if err != nil {
 		return nil, err
 	}
-	uri.Path = name
+	uri.Path = "/" + name
 
 	key := uri.String()
 	_, err, _ = flight.Do(key, func() (interface{}, error) {


### PR DESCRIPTION
Lack of leading slash was causing database connections to fail whenever dbmanager tried to access a newly-created database.