### PR TITLE
fix(dbmanager): Drop database if you can't connect

### DIFF
--- a/internal/dbmanager/client.go
+++ b/internal/dbmanager/client.go
@@ -106,6 +106,7 @@ func (m *ManagedClient) CreateDatabase(ctx context.Context, req *CreateDatabaseR
 
 		conn, err := pgx.Connect(ctx, uri.String())
 		if err != nil {
+			pool.Exec(ctx, fmt.Sprintf(`DROP DATABASE "%s" IF EXISTS WITH (FORCE)`, name))
 			return nil, fmt.Errorf("connect %s: %s", name, err)
 		}
 		defer conn.Close(ctx)


### PR DESCRIPTION
If you create a database but can't connect to it, clean up after yourself