### PR TITLE
fix(cmd): Read correct environment variable for remote

### DIFF
--- a/internal/cmd/cmd.go
+++ b/internal/cmd/cmd.go
@@ -149,7 +149,7 @@ func ParseEnv(c *cobra.Command) Env {
 	return Env{
 		DryRun:   dr != nil && dr.Changed,
 		Debug:    opts.DebugFromEnv(),
-		Remote:   r != nil && nr.Value.String() == "true",
+		Remote:   r != nil && r.Value.String() == "true",
 		NoRemote: nr != nil && nr.Value.String() == "true",
 	}
 }


### PR DESCRIPTION
Didnt look much into details but there seems to be a typo here