### PR TITLE
docs: Update tutorial to use modernc.sql/sqlite

### DIFF
--- a/docs/tutorials/getting-started-sqlite.md
+++ b/docs/tutorials/getting-started-sqlite.md
@@ -128,7 +128,7 @@ import (
 	"log"
 	"reflect"
 
-	_ "github.com/mattn/go-sqlite3"
+	_ "modernc.org/sqlite"
 
 	"tutorial.sqlc.dev/app/tutorial"
 )
@@ -139,7 +139,7 @@ var ddl string
 func run() error {
 	ctx := context.Background()
 
-	db, err := sql.Open("sqlite3", ":memory:")
+	db, err := sql.Open("sqlite", ":memory:")
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
sqlc 1.25 removed the cgo dependency; updated the tutorial docs for sqlite to reflect this.