### PR TITLE
docs: add missing documentation about copyfrom

### DIFF
--- a/docs/reference/config.md
+++ b/docs/reference/config.md
@@ -135,6 +135,8 @@ The `gen` mapping supports the following keys:
   - Output directory for generated code.
 - `sql_package`:
   - Either `pgx/v4`, `pgx/v5` or `database/sql`. Defaults to `database/sql`.
+- `sql_driver`:
+  - Either `github.com/jackc/pgx/v4`, `github.com/jackc/pgx/v5`, `github.com/lib/pq` or `github.com/go-sql-driver/mysql`. No defaults, required if  query annotation `:copyfrom` is used.
 - `emit_db_tags`:
   - If true, add DB tags to generated structs. Defaults to `false`.
 - `emit_prepared_queries`:

--- a/docs/reference/config.md
+++ b/docs/reference/config.md
@@ -136,7 +136,7 @@ The `gen` mapping supports the following keys:
 - `sql_package`:
   - Either `pgx/v4`, `pgx/v5` or `database/sql`. Defaults to `database/sql`.
 - `sql_driver`:
-  - Either `github.com/jackc/pgx/v4`, `github.com/jackc/pgx/v5`, `github.com/lib/pq` or `github.com/go-sql-driver/mysql`. No defaults, required if  query annotation `:copyfrom` is used.
+  - Either `github.com/jackc/pgx/v4`, `github.com/jackc/pgx/v5`, `github.com/lib/pq` or `github.com/go-sql-driver/mysql`. No defaults. Required if query annotation `:copyfrom` is used.
 - `emit_db_tags`:
   - If true, add DB tags to generated structs. Defaults to `false`.
 - `emit_prepared_queries`:

--- a/docs/reference/query-annotations.md
+++ b/docs/reference/query-annotations.md
@@ -222,3 +222,9 @@ func (b *CreateBookBatchResults) Close() error {
 	//...
 }
 ```
+
+## `:copyfrom`
+
+__NOTE: This command is driver and package specific, see [how to insert](../howto/insert.md#using-copyfrom)
+
+This command is used to insert rows a lot faster than sequential inserts.


### PR DESCRIPTION
Closes #3582

# Description

Adds documentation for `:copyfrom` query annotation.
Adds config reference for `sql_driver` required by `:copyfrom`.

# Tests

None, this affects documentation only. Config json schema was not affected, `sql_driver` is already part of the schema.

# Comment

Please squash before merging ( squash & merge on GH )