### PR TITLE
Allow selective disabling of rules per query

### DIFF
--- a/docs/howto/vet.md
+++ b/docs/howto/vet.md
@@ -276,7 +276,7 @@ SELECT * FROM authors
 WHERE id = ? LIMIT 1;
 ```
 
-To skip all rules for a query, you can provide the `@sqlc-vet-disable` annotation without any options. 
+To skip all rules for a query, you can provide the `@sqlc-vet-disable` annotation without any parameters. 
 
 ```sql
 /* name: GetAuthor :one */

--- a/docs/howto/vet.md
+++ b/docs/howto/vet.md
@@ -259,7 +259,24 @@ rules:
 ### Opting-out of lint rules
 
 For any query, you can tell `sqlc vet` not to evaluate lint rules using the
-`@sqlc-vet-disable` query annotation.
+`@sqlc-vet-disable` query annotation. The annotation accepts a list of rules to ignore.
+
+```sql
+/* name: GetAuthor :one */
+/* @sqlc-vet-disable sqlc/db-prepare no-pg */
+SELECT * FROM authors
+WHERE id = ? LIMIT 1;
+```
+The rules can also be split across lines.
+```sql
+/* name: GetAuthor :one */
+/* @sqlc-vet-disable sqlc/db-prepare */
+/* @sqlc-vet-disable no-pg */
+SELECT * FROM authors
+WHERE id = ? LIMIT 1;
+```
+
+To skip all rules for a query, you can provide the `@sqlc-vet-disable` annotation without any options. 
 
 ```sql
 /* name: GetAuthor :one */

--- a/internal/cmd/vet.go
+++ b/internal/cmd/vet.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"github.com/sqlc-dev/sqlc/internal/constants"
 	"io"
 	"log"
 	"os"
@@ -37,9 +38,6 @@ import (
 var ErrFailedChecks = errors.New("failed checks")
 
 var pjson = protojson.UnmarshalOptions{AllowPartial: true, DiscardUnknown: true}
-
-const RuleDbPrepare = "sqlc/db-prepare"
-const QueryFlagSqlcVetDisable = "@sqlc-vet-disable"
 
 func NewCmdVet() *cobra.Command {
 	return &cobra.Command{
@@ -110,7 +108,7 @@ func Vet(ctx context.Context, dir, filename string, opts *Options) error {
 	}
 
 	rules := map[string]rule{
-		RuleDbPrepare: {NeedsPrepare: true},
+		constants.QueryRuleDbPrepare: {NeedsPrepare: true},
 	}
 
 	for _, c := range conf.Rules {
@@ -540,7 +538,7 @@ func (c *checker) checkSQL(ctx context.Context, s config.SQL) error {
 	cfg := vetConfig(req)
 	for i, query := range req.Queries {
 		md := result.Queries[i].Metadata
-		if md.Flags[QueryFlagSqlcVetDisable] {
+		if md.Flags[constants.QueryFlagSqlcVetDisable] {
 			// If the vet disable flag is specified without any rules listed, all rules are ignored.
 			if len(md.RuleSkiplist) == 0 {
 				if debug.Active {

--- a/internal/cmd/vet.go
+++ b/internal/cmd/vet.go
@@ -11,6 +11,7 @@ import (
 	"os"
 	"path/filepath"
 	"runtime/trace"
+	"slices"
 	"strings"
 	"time"
 
@@ -538,11 +539,23 @@ func (c *checker) checkSQL(ctx context.Context, s config.SQL) error {
 	req := codeGenRequest(result, combo)
 	cfg := vetConfig(req)
 	for i, query := range req.Queries {
-		if result.Queries[i].Metadata.Flags[QueryFlagSqlcVetDisable] {
-			if debug.Active {
-				log.Printf("Skipping vet rules for query: %s\n", query.Name)
+		md := result.Queries[i].Metadata
+		if md.Flags[QueryFlagSqlcVetDisable] {
+			// If the vet disable flag is specified without any rules listed, all rules are ignored.
+			if len(md.RuleSkiplist) == 0 {
+				if debug.Active {
+					log.Printf("Skipping all vet rules for query: %s\n", query.Name)
+				}
+				continue
 			}
-			continue
+
+			// Rules which are listed to be disabled but not declared in the config file are rejected.
+			for r := range md.RuleSkiplist {
+				if !slices.Contains(s.Rules, r) {
+					fmt.Fprintf(c.Stderr, "%s: %s: rule-check error: rule %q does not exist in the config file\n", query.Filename, query.Name, r)
+					errored = true
+				}
+			}
 		}
 
 		evalMap := map[string]any{
@@ -551,74 +564,81 @@ func (c *checker) checkSQL(ctx context.Context, s config.SQL) error {
 		}
 
 		for _, name := range s.Rules {
-			rule, ok := c.Rules[name]
-			if !ok {
-				return fmt.Errorf("type-check error: a rule with the name '%s' does not exist", name)
-			}
+			if _, skip := md.RuleSkiplist[name]; skip {
+				if debug.Active {
+					log.Printf("Skipping vet rule %q for query: %s\n", name, query.Name)
+				}
+			} else {
+				rule, ok := c.Rules[name]
+				if !ok {
+					return fmt.Errorf("type-check error: a rule with the name '%s' does not exist", name)
+				}
 
-			if rule.NeedsPrepare {
-				if prep == nil {
-					fmt.Fprintf(c.Stderr, "%s: %s: %s: error preparing query: database connection required\n", query.Filename, query.Name, name)
-					errored = true
+				if rule.NeedsPrepare {
+					if prep == nil {
+						fmt.Fprintf(c.Stderr, "%s: %s: %s: error preparing query: database connection required\n", query.Filename, query.Name, name)
+						errored = true
+						continue
+					}
+					prepName := fmt.Sprintf("sqlc_vet_%d_%d", time.Now().Unix(), i)
+					if err := prep.Prepare(ctx, prepName, query.Text); err != nil {
+						fmt.Fprintf(c.Stderr, "%s: %s: %s: error preparing query: %s\n", query.Filename, query.Name, name, err)
+						errored = true
+						continue
+					}
+				}
+
+				// short-circuit for "sqlc/db-prepare" rule which doesn't have a CEL program
+				if rule.Program == nil {
 					continue
 				}
-				prepName := fmt.Sprintf("sqlc_vet_%d_%d", time.Now().Unix(), i)
-				if err := prep.Prepare(ctx, prepName, query.Text); err != nil {
-					fmt.Fprintf(c.Stderr, "%s: %s: %s: error preparing query: %s\n", query.Filename, query.Name, name, err)
-					errored = true
-					continue
-				}
-			}
 
-			// short-circuit for "sqlc/db-prepare" rule which doesn't have a CEL program
-			if rule.Program == nil {
-				continue
-			}
+				// Get explain output for this query if we need it
+				_, pgsqlOK := evalMap["postgresql"]
+				_, mysqlOK := evalMap["mysql"]
+				if rule.NeedsExplain && !(pgsqlOK || mysqlOK) {
+					if expl == nil {
+						fmt.Fprintf(c.Stderr, "%s: %s: %s: error explaining query: database connection required\n", query.Filename, query.Name, name)
+						errored = true
+						continue
+					}
+					engineOutput, err := expl.Explain(ctx, query.Text, query.Params...)
+					if err != nil {
+						fmt.Fprintf(c.Stderr, "%s: %s: %s: error explaining query: %s\n", query.Filename, query.Name, name, err)
+						errored = true
+						continue
+					}
 
-			// Get explain output for this query if we need it
-			_, pgsqlOK := evalMap["postgresql"]
-			_, mysqlOK := evalMap["mysql"]
-			if rule.NeedsExplain && !(pgsqlOK || mysqlOK) {
-				if expl == nil {
-					fmt.Fprintf(c.Stderr, "%s: %s: %s: error explaining query: database connection required\n", query.Filename, query.Name, name)
-					errored = true
-					continue
+					evalMap["postgresql"] = engineOutput.PostgreSQL
+					evalMap["mysql"] = engineOutput.MySQL
 				}
-				engineOutput, err := expl.Explain(ctx, query.Text, query.Params...)
+
+				if debug.Debug.DumpVetEnv {
+					fmt.Printf("vars for rule '%s' evaluating against query '%s':\n", name, query.Name)
+					debug.DumpAsJSON(evalMap)
+				}
+
+				out, _, err := (*rule.Program).Eval(evalMap)
 				if err != nil {
-					fmt.Fprintf(c.Stderr, "%s: %s: %s: error explaining query: %s\n", query.Filename, query.Name, name, err)
+					return err
+				}
+				tripped, ok := out.Value().(bool)
+				if !ok {
+					return fmt.Errorf("expression returned non-bool value: %v", out.Value())
+				}
+				if tripped {
+					// TODO: Get line numbers in the output
+					if rule.Message == "" {
+						fmt.Fprintf(c.Stderr, "%s: %s: %s\n", query.Filename, query.Name, name)
+					} else {
+						fmt.Fprintf(c.Stderr, "%s: %s: %s: %s\n", query.Filename, query.Name, name, rule.Message)
+					}
 					errored = true
-					continue
 				}
-
-				evalMap["postgresql"] = engineOutput.PostgreSQL
-				evalMap["mysql"] = engineOutput.MySQL
-			}
-
-			if debug.Debug.DumpVetEnv {
-				fmt.Printf("vars for rule '%s' evaluating against query '%s':\n", name, query.Name)
-				debug.DumpAsJSON(evalMap)
-			}
-
-			out, _, err := (*rule.Program).Eval(evalMap)
-			if err != nil {
-				return err
-			}
-			tripped, ok := out.Value().(bool)
-			if !ok {
-				return fmt.Errorf("expression returned non-bool value: %v", out.Value())
-			}
-			if tripped {
-				// TODO: Get line numbers in the output
-				if rule.Message == "" {
-					fmt.Fprintf(c.Stderr, "%s: %s: %s\n", query.Filename, query.Name, name)
-				} else {
-					fmt.Fprintf(c.Stderr, "%s: %s: %s: %s\n", query.Filename, query.Name, name, rule.Message)
-				}
-				errored = true
 			}
 		}
 	}
+
 	if errored {
 		return ErrFailedChecks
 	}

--- a/internal/compiler/parse.go
+++ b/internal/compiler/parse.go
@@ -65,7 +65,7 @@ func (c *Compiler) parseQuery(stmt ast.Node, src string, o opts.Parser) (*Query,
 		return nil, err
 	}
 
-	md.Params, md.Flags, md.RuleSkiplist, err = metadata.ParseParamsAndFlags(cleanedComments)
+	md.Params, md.Flags, md.RuleSkiplist, err = metadata.ParseCommentFlags(cleanedComments)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/compiler/parse.go
+++ b/internal/compiler/parse.go
@@ -65,7 +65,7 @@ func (c *Compiler) parseQuery(stmt ast.Node, src string, o opts.Parser) (*Query,
 		return nil, err
 	}
 
-	md.Params, md.Flags, err = metadata.ParseParamsAndFlags(cleanedComments)
+	md.Params, md.Flags, md.RuleSkiplist, err = metadata.ParseParamsAndFlags(cleanedComments)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/constants/query.go
+++ b/internal/constants/query.go
@@ -1,0 +1,12 @@
+package constants
+
+// Flags
+const (
+	QueryFlagParam          = "@param"
+	QueryFlagSqlcVetDisable = "@sqlc-vet-disable"
+)
+
+// Rules
+const (
+	QueryRuleDbPrepare = "sqlc/db-prepare"
+)

--- a/internal/endtoend/testdata/vet_disable/query.sql
+++ b/internal/endtoend/testdata/vet_disable/query.sql
@@ -1,6 +1,29 @@
--- name: SkipVet :exec
+-- name: RunVetAll :exec
+SELECT true;
+
+-- name: SkipVetAll :exec
 -- @sqlc-vet-disable
 SELECT true;
 
--- name: RunVet :exec
+-- name: SkipVetSingleLine :exec
+-- @sqlc-vet-disable always-fail no-exec
+SELECT true;
+
+-- name: SkipVetMultiLine :exec
+-- @sqlc-vet-disable always-fail
+-- @sqlc-vet-disable no-exec
+SELECT true;
+
+-- name: SkipVet_always_fail :exec
+-- @sqlc-vet-disable always-fail
+SELECT true;
+
+-- name: SkipVet_no_exec :exec
+-- @sqlc-vet-disable no-exec
+SELECT true;
+
+-- name: SkipVetInvalidRule :exec
+-- @sqlc-vet-disable always-fail
+-- @sqlc-vet-disable block-delete
+-- @sqlc-vet-disable no-exec
 SELECT true;

--- a/internal/endtoend/testdata/vet_disable/sqlc.yaml
+++ b/internal/endtoend/testdata/vet_disable/sqlc.yaml
@@ -9,7 +9,13 @@ sql:
         out: "db"
     rules:
       - always-fail
+      - no-exec
 rules:
   - name: always-fail
     message: "Fail"
     rule: "true"
+
+  - name: no-exec
+    message: "don't use exec"
+    rule: |
+      query.cmd == "exec"

--- a/internal/endtoend/testdata/vet_disable/stderr.txt
+++ b/internal/endtoend/testdata/vet_disable/stderr.txt
@@ -1,1 +1,5 @@
-query.sql: RunVet: always-fail: Fail
+query.sql: RunVetAll: always-fail: Fail
+query.sql: RunVetAll: no-exec: don't use exec
+query.sql: SkipVet_always_fail: no-exec: don't use exec
+query.sql: SkipVet_no_exec: always-fail: Fail
+query.sql: SkipVetInvalidRule: rule-check error: rule "block-delete" does not exist in the config file

--- a/internal/metadata/meta.go
+++ b/internal/metadata/meta.go
@@ -3,6 +3,7 @@ package metadata
 import (
 	"bufio"
 	"fmt"
+	"github.com/sqlc-dev/sqlc/internal/constants"
 	"strings"
 	"unicode"
 
@@ -134,7 +135,7 @@ func ParseParamsAndFlags(comments []string) (map[string]string, map[string]bool,
 		}
 
 		switch token {
-		case "@param":
+		case constants.QueryFlagParam:
 			s.Scan()
 			name := s.Text()
 			var rest []string
@@ -144,7 +145,7 @@ func ParseParamsAndFlags(comments []string) (map[string]string, map[string]bool,
 			}
 			params[name] = strings.Join(rest, " ")
 
-		case "@sqlc-vet-disable":
+		case constants.QueryFlagSqlcVetDisable:
 			flags[token] = true
 
 			// Vet rules can all be disabled in the same line or split across lines .i.e.

--- a/internal/metadata/meta.go
+++ b/internal/metadata/meta.go
@@ -118,7 +118,9 @@ func ParseQueryNameAndType(t string, commentStyle CommentSyntax) (string, string
 	return "", "", nil
 }
 
-func ParseParamsAndFlags(comments []string) (map[string]string, map[string]bool, map[string]struct{}, error) {
+// ParseCommentFlags processes the comments provided with queries to determine the metadata params, flags and rules to skip.
+// All flags in query comments are prefixed with `@`, e.g. @param, @@sqlc-vet-disable.
+func ParseCommentFlags(comments []string) (map[string]string, map[string]bool, map[string]struct{}, error) {
 	params := make(map[string]string)
 	flags := make(map[string]bool)
 	ruleSkiplist := make(map[string]struct{})

--- a/internal/metadata/meta_test.go
+++ b/internal/metadata/meta_test.go
@@ -79,7 +79,7 @@ func TestParseQueryParams(t *testing.T) {
 			" @param @invalid UUID ",
 		},
 	} {
-		params, _, _, err := ParseParamsAndFlags(comments)
+		params, _, _, err := ParseCommentFlags(comments)
 		if err != nil {
 			t.Errorf("expected comments to parse, got err: %s", err)
 		}
@@ -125,7 +125,7 @@ func TestParseQueryFlags(t *testing.T) {
 			" @param @flag-bar UUID",
 		},
 	} {
-		_, flags, _, err := ParseParamsAndFlags(comments)
+		_, flags, _, err := ParseCommentFlags(comments)
 		if err != nil {
 			t.Errorf("expected comments to parse, got err: %s", err)
 		}
@@ -158,7 +158,7 @@ func TestParseQueryRuleBlocklist(t *testing.T) {
 			" @sqlc-vet-disable delete-without-where ",
 		},
 	} {
-		_, flags, ruleBlocklist, err := ParseParamsAndFlags(comments)
+		_, flags, ruleBlocklist, err := ParseCommentFlags(comments)
 		if err != nil {
 			t.Errorf("expected comments to parse, got err: %s", err)
 		}

--- a/internal/metadata/meta_test.go
+++ b/internal/metadata/meta_test.go
@@ -1,6 +1,8 @@
 package metadata
 
-import "testing"
+import (
+	"testing"
+)
 
 func TestParseQueryNameAndType(t *testing.T) {
 
@@ -77,7 +79,7 @@ func TestParseQueryParams(t *testing.T) {
 			" @param @invalid UUID ",
 		},
 	} {
-		params, _, err := ParseParamsAndFlags(comments)
+		params, _, _, err := ParseParamsAndFlags(comments)
 		if err != nil {
 			t.Errorf("expected comments to parse, got err: %s", err)
 		}
@@ -123,7 +125,7 @@ func TestParseQueryFlags(t *testing.T) {
 			" @param @flag-bar UUID",
 		},
 	} {
-		_, flags, err := ParseParamsAndFlags(comments)
+		_, flags, _, err := ParseParamsAndFlags(comments)
 		if err != nil {
 			t.Errorf("expected comments to parse, got err: %s", err)
 		}
@@ -134,6 +136,47 @@ func TestParseQueryFlags(t *testing.T) {
 
 		if flags["@flag-bar"] {
 			t.Errorf("unexpected flag found")
+		}
+	}
+}
+
+func TestParseQueryRuleBlocklist(t *testing.T) {
+	for _, comments := range [][]string{
+		{
+			" name: CreateFoo :one",
+			" @sqlc-vet-disable sqlc/db-prepare delete-without-where ",
+		},
+		{
+			" name: CreateFoo :one ",
+			" @sqlc-vet-disable sqlc/db-prepare ",
+			" @sqlc-vet-disable delete-without-where ",
+		},
+		{
+			" name: CreateFoo :one",
+			" @sqlc-vet-disable sqlc/db-prepare ",
+			" update-without where",
+			" @sqlc-vet-disable delete-without-where ",
+		},
+	} {
+		_, flags, ruleBlocklist, err := ParseParamsAndFlags(comments)
+		if err != nil {
+			t.Errorf("expected comments to parse, got err: %s", err)
+		}
+
+		if !flags["@sqlc-vet-disable"] {
+			t.Errorf("expected @sqlc-vet-disable flag not found")
+		}
+
+		if _, ok := ruleBlocklist["sqlc/db-prepare"]; !ok {
+			t.Errorf("expected rule not found in blocklist")
+		}
+
+		if _, ok := ruleBlocklist["delete-without-where"]; !ok {
+			t.Errorf("expected rule not found in blocklist")
+		}
+
+		if _, ok := ruleBlocklist["update-without-where"]; ok {
+			t.Errorf("unexpected rule found in blocklist")
 		}
 	}
 }

--- a/internal/metadata/meta_test.go
+++ b/internal/metadata/meta_test.go
@@ -140,7 +140,7 @@ func TestParseQueryFlags(t *testing.T) {
 	}
 }
 
-func TestParseQueryRuleBlocklist(t *testing.T) {
+func TestParseQueryRuleSkiplist(t *testing.T) {
 	for _, comments := range [][]string{
 		{
 			" name: CreateFoo :one",
@@ -158,7 +158,7 @@ func TestParseQueryRuleBlocklist(t *testing.T) {
 			" @sqlc-vet-disable delete-without-where ",
 		},
 	} {
-		_, flags, ruleBlocklist, err := ParseCommentFlags(comments)
+		_, flags, ruleSkiplist, err := ParseCommentFlags(comments)
 		if err != nil {
 			t.Errorf("expected comments to parse, got err: %s", err)
 		}
@@ -167,16 +167,16 @@ func TestParseQueryRuleBlocklist(t *testing.T) {
 			t.Errorf("expected @sqlc-vet-disable flag not found")
 		}
 
-		if _, ok := ruleBlocklist["sqlc/db-prepare"]; !ok {
-			t.Errorf("expected rule not found in blocklist")
+		if _, ok := ruleSkiplist["sqlc/db-prepare"]; !ok {
+			t.Errorf("expected rule not found in skiplist")
 		}
 
-		if _, ok := ruleBlocklist["delete-without-where"]; !ok {
-			t.Errorf("expected rule not found in blocklist")
+		if _, ok := ruleSkiplist["delete-without-where"]; !ok {
+			t.Errorf("expected rule not found in skiplist")
 		}
 
-		if _, ok := ruleBlocklist["update-without-where"]; ok {
-			t.Errorf("unexpected rule found in blocklist")
+		if _, ok := ruleSkiplist["update-without-where"]; ok {
+			t.Errorf("unexpected rule found in skiplist")
 		}
 	}
 }


### PR DESCRIPTION
This resolves #3619 and has some minor refactor in regards to reusable constants.

As mentioned there, the `@sqlc-vet-disable` query annotation now accepts a list of rules to skip:
```sql
/* @sqlc-vet-disable sqlc/db-prepare no-pg */
```
Providing just `/* @sqlc-vet-disable */` without any parameters retains the previous behaviour of skipping all rules for a query.