### PR TITLE
fix(dbmanager): use correct SQL to drop databases

### DIFF
--- a/internal/dbmanager/client.go
+++ b/internal/dbmanager/client.go
@@ -106,7 +106,7 @@ func (m *ManagedClient) CreateDatabase(ctx context.Context, req *CreateDatabaseR
 
 		conn, err := pgx.Connect(ctx, uri.String())
 		if err != nil {
-			pool.Exec(ctx, fmt.Sprintf(`DROP DATABASE "%s" IF EXISTS WITH (FORCE)`, name))
+			pool.Exec(ctx, fmt.Sprintf(`DROP DATABASE IF EXISTS "%s" WITH (FORCE)`, name))
 			return nil, fmt.Errorf("connect %s: %s", name, err)
 		}
 		defer conn.Close(ctx)
@@ -123,7 +123,7 @@ func (m *ManagedClient) CreateDatabase(ctx context.Context, req *CreateDatabaseR
 		}
 
 		if migrationErr != nil {
-			pool.Exec(ctx, fmt.Sprintf(`DROP DATABASE "%s" IF EXISTS WITH (FORCE)`, name))
+			pool.Exec(ctx, fmt.Sprintf(`DROP DATABASE IF EXISTS "%s" WITH (FORCE)`, name))
 			return nil, migrationErr
 		}
 


### PR DESCRIPTION
Before this patch, `ManagedClient.CreateDatabase` could issue the following SQL:

```
DROP DATABASE mydb IF EXISTS WITH (FORCE)
```

which is not standard SQL and does not work with PostgreSQL. See https://www.postgresql.org/docs/current/sql-dropdatabase.html

This patch fixes to code to issue:

```
DROP DATABASE IF EXISTS mydb WITH (FORCE)
```

@kyleconroy , this patch fixes the DROP DATABASE syntax error introduced in https://github.com/sqlc-dev/sqlc/pull/3525 and https://github.com/sqlc-dev/sqlc/pull/3421