### PR TITLE
fix(golang): escape q field name

### DIFF
--- a/internal/codegen/golang/reserved.go
+++ b/internal/codegen/golang/reserved.go
@@ -59,6 +59,8 @@ func IsReserved(s string) bool {
 		return true
 	case "var":
 		return true
+	case "q":
+		return true
 	default:
 		return false
 	}

--- a/internal/endtoend/testdata/params_go_keywords/postgresql/go/models.go
+++ b/internal/endtoend/testdata/params_go_keywords/postgresql/go/models.go
@@ -34,4 +34,5 @@ type GoKeyword struct {
 	Import      pgtype.Text
 	Return      pgtype.Text
 	Var         pgtype.Text
+	Q           pgtype.Text
 }

--- a/internal/endtoend/testdata/params_go_keywords/postgresql/go/query.sql.go
+++ b/internal/endtoend/testdata/params_go_keywords/postgresql/go/query.sql.go
@@ -173,6 +173,15 @@ func (q *Queries) KeywordPackage(ctx context.Context, package_ string) error {
 	return err
 }
 
+const keywordQ = `-- name: KeywordQ :exec
+SELECT $1::text
+`
+
+func (q *Queries) KeywordQ(ctx context.Context, q_ string) error {
+	_, err := q.db.Exec(ctx, keywordQ, q_)
+	return err
+}
+
 const keywordRange = `-- name: KeywordRange :exec
 SELECT $1::text
 `
@@ -432,6 +441,17 @@ func (q *Queries) SelectPackage(ctx context.Context) (pgtype.Text, error) {
 	var package_ pgtype.Text
 	err := row.Scan(&package_)
 	return package_, err
+}
+
+const selectQ = `-- name: SelectQ :one
+SELECT "q" FROM go_keywords
+`
+
+func (q *Queries) SelectQ(ctx context.Context) (pgtype.Text, error) {
+	row := q.db.QueryRow(ctx, selectQ)
+	var q_ pgtype.Text
+	err := row.Scan(&q_)
+	return q_, err
 }
 
 const selectRange = `-- name: SelectRange :one

--- a/internal/endtoend/testdata/params_go_keywords/postgresql/query.sql
+++ b/internal/endtoend/testdata/params_go_keywords/postgresql/query.sql
@@ -73,6 +73,9 @@ SELECT sqlc.arg('return')::text;
 -- name: KeywordVar :exec
 SELECT sqlc.arg('var')::text;
 
+-- name: KeywordQ :exec
+SELECT sqlc.arg('q')::text;
+
 -- name: SelectBreak :one
 SELECT "break" FROM go_keywords;
 
@@ -147,3 +150,6 @@ SELECT "return" FROM go_keywords;
 
 -- name: SelectVar :one
 SELECT "var" FROM go_keywords;
+
+-- name: SelectQ :one
+SELECT "q" FROM go_keywords;

--- a/internal/endtoend/testdata/params_go_keywords/postgresql/schema.sql
+++ b/internal/endtoend/testdata/params_go_keywords/postgresql/schema.sql
@@ -23,5 +23,6 @@ CREATE TABLE go_keywords (
     "for" TEXT,
     "import" TEXT,
     "return" TEXT,
-    "var" TEXT
+    "var" TEXT,
+    "q" TEXT
 );


### PR DESCRIPTION
Adds `q` to the reserve keywords.

Although not a golang keyword per se, it works as one since `q` is reserved as a shorthand for `Queries` in the generated code so there's no need to rename the reserved keywords list.

Fixes #3627.