### PR TITLE
fix error in same name column reference "id" is ambiguous

### DIFF
--- a/internal/compiler/resolve.go
+++ b/internal/compiler/resolve.go
@@ -67,8 +67,19 @@ func (comp *Compiler) resolveCatalogRefs(qc *QueryCatalog, rvs []*ast.RangeVar, 
 				continue
 			}
 			// If the table name doesn't exist, first check if it's a CTE
-			if _, qcerr := qc.GetTable(fqn); qcerr != nil {
+			cteTable, qcerr := qc.GetTable(fqn)
+			if qcerr != nil {
 				return nil, err
+			}
+			err = indexTable(catalog.Table{
+				Rel:     cteTable.Rel,
+				Columns: RevertConvertColumns(cteTable.Columns),
+			})
+			if err != nil {
+				return nil, err
+			}
+			if rv.Alias != nil {
+				aliasMap[*rv.Alias.Aliasname] = fqn
 			}
 			continue
 		}


### PR DESCRIPTION
example:
CREATE TABLE IF NOT EXISTS `app`
(
    `id`                        INT          NOT NULL AUTO_INCREMENT,
    `parent_app_id`             INT          NOT NULL DEFAULT 0 COMMENT '合并父应用id',
    PRIMARY KEY (`id`) USING BTREE
) AUTO_INCREMENT = 105 COMMENT = 'API所属的应用信息';

CREATE TABLE IF NOT EXISTS `user_account` (
    `id` BIGINT NOT NULL AUTO_INCREMENT COMMENT '主键id',
    `name` VARCHAR(255) COMMENT '账号名称',
    PRIMARY KEY (`id`) USING BTREE
) AUTO_INCREMENT = 1 COMMENT='账号表，存储账号的基本信息和安全评分';

-- name: GetUserAccountAllChildIDs :exec
WITH app_user_account_id AS (
    SELECT tua.id,
           tua.name,
           CAST(IFNULL(tb.id, ta.id) AS SIGNED) AS parent_app_id
    FROM user_account AS tua
             LEFT JOIN app AS ta ON ta.id = tua.app_id
             LEFT JOIN app as tb ON ta.parent_app_id = tb.id
    WHERE tua.masked_sign = 1 AND tua.deleted_sign = 1
      AND ta.masked_sign = 1
      AND ta.deleted_sign = 1
)
SELECT a.name
FROM app_user_account_id AS a
LEFT JOIN app_user_account_id AS b ON b.id IN (sqlc.slice('account_id_set')) AND a.name = b.name AND a.parent_app_id = b.parent_app_id;