### PR TITLE
fix: Do not close wazero module on error (#3758)

### DIFF
--- a/internal/ext/wasm/wasm.go
+++ b/internal/ext/wasm/wasm.go
@@ -222,7 +222,7 @@ func (r *Runner) Invoke(ctx context.Context, method string, args any, reply any,
 	}
 
 	result, err := runtimeAndCode.rt.InstantiateModule(ctx, runtimeAndCode.code, conf)
-	if result != nil {
+	if err == nil {
 		defer result.Close(ctx)
 	}
 	if cerr := checkError(err, stderr); cerr != nil {


### PR DESCRIPTION
Fixes #3758

wazero takes care not to leak modules when `InstantiateModule` returns an error.

~This means that sqlc will call `result.Close` a second time if a non nil module was returned, which causes a segfault.~

Edit: this statement is wrong. See my comment below for the correct explanation of the segfault.