### PR TITLE
Introducing sqlc Guru on Gurubase.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # sqlc: A SQL Compiler
 
 ![go](https://github.com/sqlc-dev/sqlc/workflows/go/badge.svg)
-[![Go Report Card](https://goreportcard.com/badge/github.com/sqlc-dev/sqlc)](https://goreportcard.com/report/github.com/sqlc-dev/sqlc)
+[![Go Report Card](https://goreportcard.com/badge/github.com/sqlc-dev/sqlc)](https://goreportcard.com/report/github.com/sqlc-dev/sqlc) [![Gurubase](https://img.shields.io/badge/Gurubase-Ask%20sqlc%20Guru-006BFF)](https://gurubase.io/g/sqlc)
 
 sqlc generates **type-safe code** from SQL. Here's how it works:
 


### PR DESCRIPTION
Hello team,

We are the maintainers of [Anteon](https://github.com/getanteon/anteon). Recently, we created Gurubase.io with the mission of building a centralized, open-source, tool-focused knowledge base. Each "guru" in Gurubase is equipped with custom knowledge to answer user questions based on data related to the respective tool.

We’re excited to let you know that [sqlc Guru](https://gurubase.io/g/sqlc) has been manually added to Gurubase. sqlc Guru uses the data from this repo and data from the [docs](https://docs.sqlc.dev) to answer questions by leveraging the LLM.

This PR introduces the "sqlc Guru", showcasing that sqlc now has an AI assistant available to help users with their questions. We’d love to hear your feedback on this contribution.

You also have the option to maintain the "sqlc Guru" by following the instructions in the [Gurubase Repo](https://github.com/getanteon/gurubase?tab=readme-ov-file#how-to-claim-a-guru) and to add an ASK AI widget to the sqlc documentation website as detailed [here](https://github.com/getanteon/gurubase?tab=readme-ov-file#widget).

If you’d prefer us to disable sqlc Guru in Gurubase, just let us know that's totally fine.
