### PR TITLE
Passing SQLite comments to the generated struct

### DIFF
--- a/internal/engine/sqlite/convert.go
+++ b/internal/engine/sqlite/convert.go
@@ -107,24 +107,57 @@ func (c *cc) convertAttach_stmtContext(n *parser.Attach_stmtContext) ast.Node {
 }
 
 func (c *cc) convertCreate_table_stmtContext(n *parser.Create_table_stmtContext) ast.Node {
+	tokenStream := n.GetParser().GetTokenStream().(*antlr.CommonTokenStream)
+
 	stmt := &ast.CreateTableStmt{
 		Name:        parseTableName(n),
 		IfNotExists: n.EXISTS_() != nil,
+		Comment:     comment(tokenStream, n, false),
 	}
+
 	for _, idef := range n.AllColumn_def() {
 		if def, ok := idef.(*parser.Column_defContext); ok {
 			typeName := "any"
 			if def.Type_name() != nil {
 				typeName = def.Type_name().GetText()
 			}
+
 			stmt.Cols = append(stmt.Cols, &ast.ColumnDef{
 				Colname:   identifier(def.Column_name().GetText()),
 				IsNotNull: hasNotNullConstraint(def.AllColumn_constraint()),
 				TypeName:  &ast.TypeName{Name: typeName},
+				Comment:   comment(tokenStream, def, true),
 			})
+
 		}
 	}
 	return stmt
+}
+
+// comment returns the comment associated with the given context. The parameter right indicates whether the comment is
+// to the right or to the left of the context.
+func comment(tokenStream *antlr.CommonTokenStream, ctx antlr.ParserRuleContext, right bool) string {
+	var (
+		hiddenTokens []antlr.Token
+		comment      string
+	)
+
+	if right {
+		hiddenTokens = tokenStream.GetHiddenTokensToRight(ctx.GetStop().GetTokenIndex()+1, antlr.TokenHiddenChannel)
+	} else {
+		hiddenTokens = tokenStream.GetHiddenTokensToLeft(ctx.GetStart().GetTokenIndex(), antlr.TokenHiddenChannel)
+	}
+
+	for _, token := range hiddenTokens {
+		// Filter for single-line comments
+		if token.GetTokenType() == parser.SQLiteLexerSINGLE_LINE_COMMENT {
+			// Remove "--" and leading/trailing whitespaces
+			comment = strings.TrimSpace(strings.TrimPrefix(token.GetText(), "--"))
+			return comment
+		}
+	}
+
+	return ""
 }
 
 func (c *cc) convertCreate_virtual_table_stmtContext(n *parser.Create_virtual_table_stmtContext) ast.Node {

--- a/internal/engine/sqlite/parse.go
+++ b/internal/engine/sqlite/parse.go
@@ -50,6 +50,7 @@ func (p *Parser) Parse(r io.Reader) ([]ast.Statement, error) {
 	pp.AddErrorListener(el)
 	// pp.BuildParseTrees = true
 	tree := pp.Parse()
+
 	if el.err != "" {
 		return nil, errors.New(el.err)
 	}
@@ -83,6 +84,7 @@ func (p *Parser) Parse(r io.Reader) ([]ast.Statement, error) {
 			loc = stmt.GetStop().GetStop() + 2
 		}
 	}
+
 	return stmts, nil
 }
 


### PR DESCRIPTION
This is a partial solution for #3430 for sqlite, which may or may not be adaptable for other engines. It basically looks for single-line comments before the CREATE command and in-between column definitions.
