### PR TITLE
docs: Fix sqlite package import

### DIFF
--- a/docs/tutorials/getting-started-sqlite.md
+++ b/docs/tutorials/getting-started-sqlite.md
@@ -189,7 +189,7 @@ func main() {
 Before this code will compile you'll need to fetch the relevant SQLite driver:
 
 ```shell
-go get github.com/mattn/go-sqlite3
+go get modernc.org/sqlite
 go build ./...
 ```
 


### PR DESCRIPTION
The docs still reference the previously used `mattn/go-sqlite3`