### PR TITLE
Update postgresql_type.go: accept "timestamp" as a case

### DIFF
--- a/internal/codegen/golang/postgresql_type.go
+++ b/internal/codegen/golang/postgresql_type.go
@@ -233,7 +233,7 @@ func postgresType(req *plugin.GenerateRequest, options *opts.Options, col *plugi
 		}
 		return "sql.NullTime"
 
-	case "pg_catalog.timestamp":
+	case "pg_catalog.timestamp", "timestamp":
 		if driver == opts.SQLDriverPGXV5 {
 			return "pgtype.Timestamp"
 		}


### PR DESCRIPTION
the only type accepted as a case for postgres type `timestamp` is `pg_catalog.timestamp`. It would be better if `timestamp` was also accepted directly, just as `timestamptz` is.