### PR TITLE
new community generator plugin for PHP

### DIFF
--- a/docs/reference/language-support.rst
+++ b/docs/reference/language-support.rst
@@ -16,14 +16,15 @@ Community language support
 
 New languages can be added via :doc:`plugins <../guides/plugins>`.
 
-========  =================================  ===============  ============  ===============
-Language  Plugin                             MySQL            PostgreSQL    SQLite
-========  =================================  ===============  ============  ===============
-F#        `kaashyapan/sqlc-gen-fsharp`_      Not implemented  Beta          Beta
-C#        `DaredevilOSS/sqlc-gen-csharp`_    Beta             Beta          Beta
-Ruby      `DaredevilOSS/sqlc-gen-ruby`_      Beta             Beta          Beta
-[Any]     `fdietze/sqlc-gen-from-template`_  Stable           Stable        Stable
-========  =================================  ===============  ============  ===============
+========  =================================  ===============  ===============  ===============
+Language  Plugin                             MySQL            PostgreSQL       SQLite
+========  =================================  ===============  ===============  ===============
+F#        `kaashyapan/sqlc-gen-fsharp`_      Not implemented  Beta             Beta
+C#        `DaredevilOSS/sqlc-gen-csharp`_    Beta             Beta             Beta
+Ruby      `DaredevilOSS/sqlc-gen-ruby`_      Beta             Beta             Beta
+PHP       `lcarilla/sqlc-plugin-php-dbal`_   Beta             Not implemented  Not implemented
+[Any]     `fdietze/sqlc-gen-from-template`_  Stable           Stable           Stable
+========  =================================  ===============  ===============  ===============
 
 .. _sqlc-gen-go: https://github.com/sqlc-dev/sqlc-gen-go
 .. _kaashyapan/sqlc-gen-fsharp: https://github.com/kaashyapan/sqlc-gen-fsharp
@@ -33,6 +34,7 @@ Ruby      `DaredevilOSS/sqlc-gen-ruby`_      Beta             Beta          Beta
 .. _DaredevilOSS/sqlc-gen-csharp: https://github.com/DaredevilOSS/sqlc-gen-csharp
 .. _DaredevilOSS/sqlc-gen-ruby: https://github.com/DaredevilOSS/sqlc-gen-ruby
 .. _fdietze/sqlc-gen-from-template: https://github.com/fdietze/sqlc-gen-from-template
+.. _lcarilla/sqlc-plugin-php-dbal: https://github.com/lcarilla/sqlc-plugin-php-dbal
 
 Future language support
 ************************


### PR DESCRIPTION
hey,
i started working on a generator plugin for PHP with doctrine DBAL (see https://github.com/lcarilla/sqlc-plugin-php-dbal, i forked the kotlin plugin to have a base structure to build upon).
as of now it only supports mysql but i plan to properly integrate postgres and deal with issues with the plugin that might arise.
feel free to merge this PR which lists it under the Community language support section on the plugins page