### PR TITLE
docs: add link to java plugin

### DIFF
--- a/docs/reference/language-support.rst
+++ b/docs/reference/language-support.rst
@@ -23,6 +23,7 @@ F#        `kaashyapan/sqlc-gen-fsharp`_      Not implemented  Beta             B
 C#        `DaredevilOSS/sqlc-gen-csharp`_    Beta             Beta             Beta
 Ruby      `DaredevilOSS/sqlc-gen-ruby`_      Beta             Beta             Beta
 PHP       `lcarilla/sqlc-plugin-php-dbal`_   Beta             Not implemented  Not implemented
+Java      `tandemdude/sqlc-gen-java`_        Not implemented  Beta             Not implemented
 [Any]     `fdietze/sqlc-gen-from-template`_  Stable           Stable           Stable
 ========  =================================  ===============  ===============  ===============
 
@@ -35,6 +36,7 @@ PHP       `lcarilla/sqlc-plugin-php-dbal`_   Beta             Not implemented  N
 .. _DaredevilOSS/sqlc-gen-ruby: https://github.com/DaredevilOSS/sqlc-gen-ruby
 .. _fdietze/sqlc-gen-from-template: https://github.com/fdietze/sqlc-gen-from-template
 .. _lcarilla/sqlc-plugin-php-dbal: https://github.com/lcarilla/sqlc-plugin-php-dbal
+.. _tandemdude/sqlc-gen-java: https://github.com/tandemdude/sqlc-gen-java
 
 Future language support
 ************************


### PR DESCRIPTION
I've been working on a plugin to [generate Java code](https://github.com/tandemdude/sqlc-gen-java) (so I can use it in my personal projects). This PR adds it to the list of community plugins. Currently working on finishing postgres support so I can start work on MySQL support. Hopefully someone can find it useful!