### PR TITLE
examples: Add missing Close calls

### DIFF
--- a/examples/authors/sqlite/db_test.go
+++ b/examples/authors/sqlite/db_test.go
@@ -12,6 +12,7 @@ import (
 
 func TestAuthors(t *testing.T) {
 	sdb, cleanup := sqltest.SQLite(t, []string{"schema.sql"})
+	defer sdb.Close()
 	defer cleanup()
 
 	ctx := context.Background()

--- a/examples/booktest/sqlite/db_test.go
+++ b/examples/booktest/sqlite/db_test.go
@@ -18,6 +18,7 @@ const (
 
 func TestBooks(t *testing.T) {
 	db, cleanup := sqltest.SQLite(t, []string{"schema.sql"})
+	defer sdb.Close()
 	defer cleanup()
 
 	ctx := context.Background()

--- a/examples/booktest/sqlite/db_test.go
+++ b/examples/booktest/sqlite/db_test.go
@@ -18,7 +18,7 @@ const (
 
 func TestBooks(t *testing.T) {
 	db, cleanup := sqltest.SQLite(t, []string{"schema.sql"})
-	defer sdb.Close()
+	defer db.Close()
 	defer cleanup()
 
 	ctx := context.Background()

--- a/examples/ondeck/sqlite/db_test.go
+++ b/examples/ondeck/sqlite/db_test.go
@@ -149,6 +149,7 @@ func TestPrepared(t *testing.T) {
 	t.Parallel()
 
 	sdb, cleanup := sqltest.SQLite(t, []string{"schema"})
+	defer sdb.Close()
 	defer cleanup()
 
 	q, err := Prepare(context.Background(), sdb)
@@ -163,6 +164,7 @@ func TestQueries(t *testing.T) {
 	t.Parallel()
 
 	sdb, cleanup := sqltest.SQLite(t, []string{"schema"})
+	defer sdb.Close()
 	defer cleanup()
 
 	runOnDeckQueries(t, New(sdb))

--- a/internal/sqltest/sqlite.go
+++ b/internal/sqltest/sqlite.go
@@ -16,6 +16,9 @@ func SQLite(t *testing.T, migrations []string) (*sql.DB, func()) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	if err := source.Close(); err != nil {
+		t.Fatal(err)
+	}
 	return CreateSQLiteDatabase(t, source.Name(), migrations)
 }
 


### PR DESCRIPTION
The PR fixes `sqltest.SQLite` usages and implementation by adding the missing `sdb.Close()` and `source.Close()`.

`sqltest.SQLite` returns `*sql.DB`, which we need to close as shown here:
https://github.com/sqlc-dev/sqlc/blob/9cf5dbce1eaef8e81770d64c0fa07f02581f50a6/internal/endtoend/vet_test.go#L57-L59

[`os.CreateTemp`](https://pkg.go.dev/os#CreateTemp) creates a new temporary file in the directory `dir`, opens the file for reading and writing, and returns the resulting file. We also need to close it.