### PR TITLE
build: Upgrade to Go 1.23.6

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,7 @@ jobs:
     - uses: actions/checkout@v4
     - uses: actions/setup-go@v5
       with:
-        go-version: '1.23.5'
+        go-version: '1.23.6'
 
     - name: install gotestsum
       run: go install gotest.tools/gotestsum@latest
@@ -78,6 +78,6 @@ jobs:
     - uses: actions/checkout@v4
     - uses: actions/setup-go@v5
       with:
-        go-version: '1.23.5'
+        go-version: '1.23.6'
     - run: go install golang.org/x/vuln/cmd/govulncheck@latest
     - run: govulncheck ./...


### PR DESCRIPTION
This PR silences vulncheck.

```
Run govulncheck ./...
  govulncheck ./...
  shell: /usr/bin/bash -e {0}
=== Symbol Results ===

Vulnerability #1: GO-[2](https://github.com/sqlc-dev/sqlc/actions/runs/13201723883/job/36855116383#step:5:2)025-3447
    Timing sidechannel for P-256 on ppc64le in crypto/internal/nistec
  More info: https://pkg.go.dev/vuln/GO-2025-[3](https://github.com/sqlc-dev/sqlc/actions/runs/13201723883/job/36855116383#step:5:3)447
  Standard library
    Found in: crypto/internal/nistec@go1.23.5
    Fixed in: crypto/internal/nistec@go1.23.6
    Platforms: ppc6[4](https://github.com/sqlc-dev/sqlc/actions/runs/13201723883/job/36855116383#step:5:5)le
    Example traces found:
Error:       #1: internal/engine/postgresql/analyzer/analyze.go:217:3[5](https://github.com/sqlc-dev/sqlc/actions/runs/13201723883/job/36855116383#step:5:6): analyzer.Analyzer.Analyze calls pgxpool.ParseConfig, which eventually calls nistec.P25[6](https://github.com/sqlc-dev/sqlc/actions/runs/13201723883/job/36855116383#step:5:7)Point.ScalarBaseMult
Error:       #2: internal/cmd/generate.go:145:14: cmd.Generate calls fmt.Fprintf, which eventually calls nistec.P256Point.ScalarMult
Error:       #3: internal/engine/sqlite/parser/sqlite_parser.go:[12](https://github.com/sqlc-dev/sqlc/actions/runs/13201723883/job/36855116383#step:5:13)14:20: parser.SQLiteParserInit calls sync.Once.Do, which eventually calls nistec.P256Point.SetBytes

Your code is affected by 1 vulnerability from the Go standard library.
This scan found no other vulnerabilities in packages you import or modules you
require.
Use '-show verbose' for more details.
```

Related: #3822