### PR TITLE
Update postgresql_type.go - check notNull and emitPointersForNull before SQLDriver

### DIFF
--- a/internal/codegen/golang/postgresql_type.go
+++ b/internal/codegen/golang/postgresql_type.go
@@ -213,15 +213,16 @@ func postgresType(req *plugin.GenerateRequest, options *opts.Options, col *plugi
 		return "sql.NullTime"
 
 	case "pg_catalog.time":
-		if driver == opts.SQLDriverPGXV5 {
-			return "pgtype.Time"
-		}
 		if notNull {
 			return "time.Time"
 		}
 		if emitPointersForNull {
 			return "*time.Time"
 		}
+		if driver == opts.SQLDriverPGXV5 {
+			return "pgtype.Time"
+		}
+		
 		return "sql.NullTime"
 
 	case "pg_catalog.timetz":
@@ -234,27 +235,29 @@ func postgresType(req *plugin.GenerateRequest, options *opts.Options, col *plugi
 		return "sql.NullTime"
 
 	case "pg_catalog.timestamp", "timestamp":
+		if notNull {
+			return "time.Time"
+		}
+		if emitPointersForNull {
+			return "*time.Time"
+		}
 		if driver == opts.SQLDriverPGXV5 {
 			return "pgtype.Timestamp"
 		}
-		if notNull {
-			return "time.Time"
-		}
-		if emitPointersForNull {
-			return "*time.Time"
-		}
+		
 		return "sql.NullTime"
 
 	case "pg_catalog.timestamptz", "timestamptz":
-		if driver == opts.SQLDriverPGXV5 {
-			return "pgtype.Timestamptz"
-		}
 		if notNull {
 			return "time.Time"
 		}
 		if emitPointersForNull {
 			return "*time.Time"
 		}
+		if driver == opts.SQLDriverPGXV5 {
+			return "pgtype.Timestamptz"
+		}
+		
 		return "sql.NullTime"
 
 	case "text", "pg_catalog.varchar", "pg_catalog.bpchar", "string", "citext", "name":
@@ -270,14 +273,15 @@ func postgresType(req *plugin.GenerateRequest, options *opts.Options, col *plugi
 		return "sql.NullString"
 
 	case "uuid":
-		if driver == opts.SQLDriverPGXV5 {
-			return "pgtype.UUID"
-		}
+		
 		if notNull {
 			return "uuid.UUID"
 		}
 		if emitPointersForNull {
 			return "*uuid.UUID"
+		}
+		if driver == opts.SQLDriverPGXV5 {
+			return "pgtype.UUID"
 		}
 		return "uuid.NullUUID"
 


### PR DESCRIPTION
this fixes the issue where despite having emit_pointers_for_null_types set to true, the generate models don't use pointers for timestamp field.