### PR TITLE
Fix redundant rows.Close() calls in queryCode.tmpl

### DIFF
--- a/internal/codegen/golang/templates/stdlib/queryCode.tmpl
+++ b/internal/codegen/golang/templates/stdlib/queryCode.tmpl
@@ -53,9 +53,6 @@ func (q *Queries) {{.MethodName}}(ctx context.Context, {{ dbarg }} {{.Arg.Pair}}
         }
         items = append(items, {{.Ret.ReturnName}})
     }
-    if err := rows.Close(); err != nil {
-        return nil, err
-    }
     if err := rows.Err(); err != nil {
         return nil, err
     }

--- a/internal/endtoend/testdata/any/stdlib/go/query.sql.go
+++ b/internal/endtoend/testdata/any/stdlib/go/query.sql.go
@@ -31,9 +31,6 @@ func (q *Queries) Any(ctx context.Context, dollar_1 []int64) ([]int64, error) {
 		}
 		items = append(items, id)
 	}
-	if err := rows.Close(); err != nil {
-		return nil, err
-	}
 	if err := rows.Err(); err != nil {
 		return nil, err
 	}

--- a/internal/endtoend/testdata/array_in/stdlib/go/query.sql.go
+++ b/internal/endtoend/testdata/array_in/stdlib/go/query.sql.go
@@ -34,9 +34,6 @@ func (q *Queries) In(ctx context.Context, arg InParams) ([]int32, error) {
 		}
 		items = append(items, id)
 	}
-	if err := rows.Close(); err != nil {
-		return nil, err
-	}
 	if err := rows.Err(); err != nil {
 		return nil, err
 	}

--- a/internal/endtoend/testdata/array_text/stdlib/go/query.sql.go
+++ b/internal/endtoend/testdata/array_text/stdlib/go/query.sql.go
@@ -29,9 +29,6 @@ func (q *Queries) TextArray(ctx context.Context) ([][]string, error) {
 		}
 		items = append(items, tags)
 	}
-	if err := rows.Close(); err != nil {
-		return nil, err
-	}
 	if err := rows.Err(); err != nil {
 		return nil, err
 	}

--- a/internal/endtoend/testdata/array_text_join/stdlib/go/query.sql.go
+++ b/internal/endtoend/testdata/array_text_join/stdlib/go/query.sql.go
@@ -31,9 +31,6 @@ func (q *Queries) JoinTextArray(ctx context.Context) ([][]string, error) {
 		}
 		items = append(items, info)
 	}
-	if err := rows.Close(); err != nil {
-		return nil, err
-	}
 	if err := rows.Err(); err != nil {
 		return nil, err
 	}

--- a/internal/endtoend/testdata/between_args/mysql/go/query.sql.go
+++ b/internal/endtoend/testdata/between_args/mysql/go/query.sql.go
@@ -34,9 +34,6 @@ func (q *Queries) GetBetweenPrices(ctx context.Context, arg GetBetweenPricesPara
 		}
 		items = append(items, i)
 	}
-	if err := rows.Close(); err != nil {
-		return nil, err
-	}
 	if err := rows.Err(); err != nil {
 		return nil, err
 	}
@@ -67,9 +64,6 @@ func (q *Queries) GetBetweenPricesNamed(ctx context.Context, arg GetBetweenPrice
 			return nil, err
 		}
 		items = append(items, i)
-	}
-	if err := rows.Close(); err != nil {
-		return nil, err
 	}
 	if err := rows.Err(); err != nil {
 		return nil, err
@@ -102,9 +96,6 @@ func (q *Queries) GetBetweenPricesTable(ctx context.Context, arg GetBetweenPrice
 		}
 		items = append(items, i)
 	}
-	if err := rows.Close(); err != nil {
-		return nil, err
-	}
 	if err := rows.Err(); err != nil {
 		return nil, err
 	}
@@ -135,9 +126,6 @@ func (q *Queries) GetBetweenPricesTableAlias(ctx context.Context, arg GetBetween
 			return nil, err
 		}
 		items = append(items, i)
-	}
-	if err := rows.Close(); err != nil {
-		return nil, err
 	}
 	if err := rows.Err(); err != nil {
 		return nil, err

--- a/internal/endtoend/testdata/between_args/sqlite/go/query.sql.go
+++ b/internal/endtoend/testdata/between_args/sqlite/go/query.sql.go
@@ -34,9 +34,6 @@ func (q *Queries) GetBetweenPrices(ctx context.Context, arg GetBetweenPricesPara
 		}
 		items = append(items, i)
 	}
-	if err := rows.Close(); err != nil {
-		return nil, err
-	}
 	if err := rows.Err(); err != nil {
 		return nil, err
 	}
@@ -68,9 +65,6 @@ func (q *Queries) GetBetweenPricesTable(ctx context.Context, arg GetBetweenPrice
 		}
 		items = append(items, i)
 	}
-	if err := rows.Close(); err != nil {
-		return nil, err
-	}
 	if err := rows.Err(); err != nil {
 		return nil, err
 	}
@@ -101,9 +95,6 @@ func (q *Queries) GetBetweenPricesTableAlias(ctx context.Context, arg GetBetween
 			return nil, err
 		}
 		items = append(items, i)
-	}
-	if err := rows.Close(); err != nil {
-		return nil, err
 	}
 	if err := rows.Err(); err != nil {
 		return nil, err

--- a/internal/endtoend/testdata/build_tags/postgresql/stdlib/go/query.sql.go
+++ b/internal/endtoend/testdata/build_tags/postgresql/stdlib/go/query.sql.go
@@ -74,9 +74,6 @@ func (q *Queries) ListAuthors(ctx context.Context) ([]Author, error) {
 		}
 		items = append(items, i)
 	}
-	if err := rows.Close(); err != nil {
-		return nil, err
-	}
 	if err := rows.Err(); err != nil {
 		return nil, err
 	}

--- a/internal/endtoend/testdata/case_stmt_bool/stdlib/go/query.sql.go
+++ b/internal/endtoend/testdata/case_stmt_bool/stdlib/go/query.sql.go
@@ -31,9 +31,6 @@ func (q *Queries) CaseStatementBoolean(ctx context.Context, id string) ([]bool, 
 		}
 		items = append(items, is_one)
 	}
-	if err := rows.Close(); err != nil {
-		return nil, err
-	}
 	if err := rows.Err(); err != nil {
 		return nil, err
 	}

--- a/internal/endtoend/testdata/case_text/stdlib/go/query.sql.go
+++ b/internal/endtoend/testdata/case_text/stdlib/go/query.sql.go
@@ -31,9 +31,6 @@ func (q *Queries) CaseStatementText(ctx context.Context, id string) ([]string, e
 		}
 		items = append(items, is_one)
 	}
-	if err := rows.Close(); err != nil {
-		return nil, err
-	}
 	if err := rows.Err(); err != nil {
 		return nil, err
 	}

--- a/internal/endtoend/testdata/cast_coalesce/stdlib/go/query.sql.go
+++ b/internal/endtoend/testdata/cast_coalesce/stdlib/go/query.sql.go
@@ -28,9 +28,6 @@ func (q *Queries) CastCoalesce(ctx context.Context) ([]string, error) {
 		}
 		items = append(items, login)
 	}
-	if err := rows.Close(); err != nil {
-		return nil, err
-	}
 	if err := rows.Err(); err != nil {
 		return nil, err
 	}

--- a/internal/endtoend/testdata/cast_null/stdlib/go/query.sql.go
+++ b/internal/endtoend/testdata/cast_null/stdlib/go/query.sql.go
@@ -45,9 +45,6 @@ func (q *Queries) ListNullable(ctx context.Context) ([]ListNullableRow, error) {
 		}
 		items = append(items, i)
 	}
-	if err := rows.Close(); err != nil {
-		return nil, err
-	}
 	if err := rows.Err(); err != nil {
 		return nil, err
 	}

--- a/internal/endtoend/testdata/cast_param/sqlite/go/query.sql.go
+++ b/internal/endtoend/testdata/cast_param/sqlite/go/query.sql.go
@@ -29,9 +29,6 @@ func (q *Queries) GetData(ctx context.Context, allowInvalid bool) ([]MyTable, er
 		}
 		items = append(items, i)
 	}
-	if err := rows.Close(); err != nil {
-		return nil, err
-	}
 	if err := rows.Err(); err != nil {
 		return nil, err
 	}

--- a/internal/endtoend/testdata/citext/stdlib/go/query.sql.go
+++ b/internal/endtoend/testdata/citext/stdlib/go/query.sql.go
@@ -28,9 +28,6 @@ func (q *Queries) GetCitexts(ctx context.Context) ([]Foo, error) {
 		}
 		items = append(items, i)
 	}
-	if err := rows.Close(); err != nil {
-		return nil, err
-	}
 	if err := rows.Err(); err != nil {
 		return nil, err
 	}

--- a/internal/endtoend/testdata/coalesce/mysql/go/query.sql.go
+++ b/internal/endtoend/testdata/coalesce/mysql/go/query.sql.go
@@ -29,9 +29,6 @@ func (q *Queries) Coalesce(ctx context.Context) ([]string, error) {
 		}
 		items = append(items, login)
 	}
-	if err := rows.Close(); err != nil {
-		return nil, err
-	}
 	if err := rows.Err(); err != nil {
 		return nil, err
 	}
@@ -62,9 +59,6 @@ func (q *Queries) CoalesceColumns(ctx context.Context) ([]CoalesceColumnsRow, er
 			return nil, err
 		}
 		items = append(items, i)
-	}
-	if err := rows.Close(); err != nil {
-		return nil, err
 	}
 	if err := rows.Err(); err != nil {
 		return nil, err

--- a/internal/endtoend/testdata/coalesce/postgresql/stdlib/go/query.sql.go
+++ b/internal/endtoend/testdata/coalesce/postgresql/stdlib/go/query.sql.go
@@ -29,9 +29,6 @@ func (q *Queries) CoalesceNumeric(ctx context.Context) ([]int64, error) {
 		}
 		items = append(items, login)
 	}
-	if err := rows.Close(); err != nil {
-		return nil, err
-	}
 	if err := rows.Err(); err != nil {
 		return nil, err
 	}
@@ -63,9 +60,6 @@ func (q *Queries) CoalesceNumericColumns(ctx context.Context) ([]CoalesceNumeric
 		}
 		items = append(items, i)
 	}
-	if err := rows.Close(); err != nil {
-		return nil, err
-	}
 	if err := rows.Err(); err != nil {
 		return nil, err
 	}
@@ -96,9 +90,6 @@ func (q *Queries) CoalesceNumericNull(ctx context.Context) ([]CoalesceNumericNul
 		}
 		items = append(items, i)
 	}
-	if err := rows.Close(); err != nil {
-		return nil, err
-	}
 	if err := rows.Err(); err != nil {
 		return nil, err
 	}
@@ -123,9 +114,6 @@ func (q *Queries) CoalesceString(ctx context.Context) ([]string, error) {
 			return nil, err
 		}
 		items = append(items, login)
-	}
-	if err := rows.Close(); err != nil {
-		return nil, err
 	}
 	if err := rows.Err(); err != nil {
 		return nil, err
@@ -158,9 +146,6 @@ func (q *Queries) CoalesceStringColumns(ctx context.Context) ([]CoalesceStringCo
 		}
 		items = append(items, i)
 	}
-	if err := rows.Close(); err != nil {
-		return nil, err
-	}
 	if err := rows.Err(); err != nil {
 		return nil, err
 	}
@@ -190,9 +175,6 @@ func (q *Queries) CoalesceStringNull(ctx context.Context) ([]CoalesceStringNullR
 			return nil, err
 		}
 		items = append(items, i)
-	}
-	if err := rows.Close(); err != nil {
-		return nil, err
 	}
 	if err := rows.Err(); err != nil {
 		return nil, err

--- a/internal/endtoend/testdata/coalesce/sqlite/go/query.sql.go
+++ b/internal/endtoend/testdata/coalesce/sqlite/go/query.sql.go
@@ -29,9 +29,6 @@ func (q *Queries) Coalesce(ctx context.Context) ([]string, error) {
 		}
 		items = append(items, login)
 	}
-	if err := rows.Close(); err != nil {
-		return nil, err
-	}
 	if err := rows.Err(); err != nil {
 		return nil, err
 	}
@@ -62,9 +59,6 @@ func (q *Queries) CoalesceColumns(ctx context.Context) ([]CoalesceColumnsRow, er
 			return nil, err
 		}
 		items = append(items, i)
-	}
-	if err := rows.Close(); err != nil {
-		return nil, err
 	}
 	if err := rows.Err(); err != nil {
 		return nil, err

--- a/internal/endtoend/testdata/coalesce_as/mysql/go/query.sql.go
+++ b/internal/endtoend/testdata/coalesce_as/mysql/go/query.sql.go
@@ -35,9 +35,6 @@ func (q *Queries) SumBaz(ctx context.Context) ([]SumBazRow, error) {
 		}
 		items = append(items, i)
 	}
-	if err := rows.Close(); err != nil {
-		return nil, err
-	}
 	if err := rows.Err(); err != nil {
 		return nil, err
 	}

--- a/internal/endtoend/testdata/coalesce_as/postgresql/stdlib/go/query.sql.go
+++ b/internal/endtoend/testdata/coalesce_as/postgresql/stdlib/go/query.sql.go
@@ -35,9 +35,6 @@ func (q *Queries) SumBaz(ctx context.Context) ([]SumBazRow, error) {
 		}
 		items = append(items, i)
 	}
-	if err := rows.Close(); err != nil {
-		return nil, err
-	}
 	if err := rows.Err(); err != nil {
 		return nil, err
 	}

--- a/internal/endtoend/testdata/coalesce_as/sqlite/go/query.sql.go
+++ b/internal/endtoend/testdata/coalesce_as/sqlite/go/query.sql.go
@@ -35,9 +35,6 @@ func (q *Queries) SumBaz(ctx context.Context) ([]SumBazRow, error) {
 		}
 		items = append(items, i)
 	}
-	if err := rows.Close(); err != nil {
-		return nil, err
-	}
 	if err := rows.Err(); err != nil {
 		return nil, err
 	}

--- a/internal/endtoend/testdata/coalesce_join/postgresql/go/query.sql.go
+++ b/internal/endtoend/testdata/coalesce_join/postgresql/go/query.sql.go
@@ -34,9 +34,6 @@ func (q *Queries) GetBar(ctx context.Context) ([]GetBarRow, error) {
 		}
 		items = append(items, i)
 	}
-	if err := rows.Close(); err != nil {
-		return nil, err
-	}
 	if err := rows.Err(); err != nil {
 		return nil, err
 	}

--- a/internal/endtoend/testdata/comment_on/postgresql/stdlib/go/query.sql.go
+++ b/internal/endtoend/testdata/comment_on/postgresql/stdlib/go/query.sql.go
@@ -27,9 +27,6 @@ func (q *Queries) ListBar(ctx context.Context) ([]string, error) {
 		}
 		items = append(items, baz)
 	}
-	if err := rows.Close(); err != nil {
-		return nil, err
-	}
 	if err := rows.Err(); err != nil {
 		return nil, err
 	}
@@ -53,9 +50,6 @@ func (q *Queries) ListBat(ctx context.Context) ([]string, error) {
 			return nil, err
 		}
 		items = append(items, baz)
-	}
-	if err := rows.Close(); err != nil {
-		return nil, err
 	}
 	if err := rows.Err(); err != nil {
 		return nil, err

--- a/internal/endtoend/testdata/comparisons/mysql/go/query.sql.go
+++ b/internal/endtoend/testdata/comparisons/mysql/go/query.sql.go
@@ -27,9 +27,6 @@ func (q *Queries) AlsoNotEqual(ctx context.Context) ([]bool, error) {
 		}
 		items = append(items, column_1)
 	}
-	if err := rows.Close(); err != nil {
-		return nil, err
-	}
 	if err := rows.Err(); err != nil {
 		return nil, err
 	}
@@ -53,9 +50,6 @@ func (q *Queries) Equal(ctx context.Context) ([]bool, error) {
 			return nil, err
 		}
 		items = append(items, column_1)
-	}
-	if err := rows.Close(); err != nil {
-		return nil, err
 	}
 	if err := rows.Err(); err != nil {
 		return nil, err
@@ -81,9 +75,6 @@ func (q *Queries) GreaterThan(ctx context.Context) ([]bool, error) {
 		}
 		items = append(items, column_1)
 	}
-	if err := rows.Close(); err != nil {
-		return nil, err
-	}
 	if err := rows.Err(); err != nil {
 		return nil, err
 	}
@@ -107,9 +98,6 @@ func (q *Queries) GreaterThanOrEqual(ctx context.Context) ([]bool, error) {
 			return nil, err
 		}
 		items = append(items, column_1)
-	}
-	if err := rows.Close(); err != nil {
-		return nil, err
 	}
 	if err := rows.Err(); err != nil {
 		return nil, err
@@ -135,9 +123,6 @@ func (q *Queries) IsNotNull(ctx context.Context) ([]bool, error) {
 		}
 		items = append(items, column_1)
 	}
-	if err := rows.Close(); err != nil {
-		return nil, err
-	}
 	if err := rows.Err(); err != nil {
 		return nil, err
 	}
@@ -161,9 +146,6 @@ func (q *Queries) IsNull(ctx context.Context) ([]bool, error) {
 			return nil, err
 		}
 		items = append(items, column_1)
-	}
-	if err := rows.Close(); err != nil {
-		return nil, err
 	}
 	if err := rows.Err(); err != nil {
 		return nil, err
@@ -189,9 +171,6 @@ func (q *Queries) LessThan(ctx context.Context) ([]bool, error) {
 		}
 		items = append(items, column_1)
 	}
-	if err := rows.Close(); err != nil {
-		return nil, err
-	}
 	if err := rows.Err(); err != nil {
 		return nil, err
 	}
@@ -216,9 +195,6 @@ func (q *Queries) LessThanOrEqual(ctx context.Context) ([]bool, error) {
 		}
 		items = append(items, column_1)
 	}
-	if err := rows.Close(); err != nil {
-		return nil, err
-	}
 	if err := rows.Err(); err != nil {
 		return nil, err
 	}
@@ -242,9 +218,6 @@ func (q *Queries) NotEqual(ctx context.Context) ([]bool, error) {
 			return nil, err
 		}
 		items = append(items, column_1)
-	}
-	if err := rows.Close(); err != nil {
-		return nil, err
 	}
 	if err := rows.Err(); err != nil {
 		return nil, err

--- a/internal/endtoend/testdata/comparisons/postgresql/stdlib/go/query.sql.go
+++ b/internal/endtoend/testdata/comparisons/postgresql/stdlib/go/query.sql.go
@@ -27,9 +27,6 @@ func (q *Queries) AlsoNotEqual(ctx context.Context) ([]bool, error) {
 		}
 		items = append(items, column_1)
 	}
-	if err := rows.Close(); err != nil {
-		return nil, err
-	}
 	if err := rows.Err(); err != nil {
 		return nil, err
 	}
@@ -53,9 +50,6 @@ func (q *Queries) Equal(ctx context.Context) ([]bool, error) {
 			return nil, err
 		}
 		items = append(items, column_1)
-	}
-	if err := rows.Close(); err != nil {
-		return nil, err
 	}
 	if err := rows.Err(); err != nil {
 		return nil, err
@@ -81,9 +75,6 @@ func (q *Queries) GreaterThan(ctx context.Context) ([]bool, error) {
 		}
 		items = append(items, column_1)
 	}
-	if err := rows.Close(); err != nil {
-		return nil, err
-	}
 	if err := rows.Err(); err != nil {
 		return nil, err
 	}
@@ -107,9 +98,6 @@ func (q *Queries) GreaterThanOrEqual(ctx context.Context) ([]bool, error) {
 			return nil, err
 		}
 		items = append(items, column_1)
-	}
-	if err := rows.Close(); err != nil {
-		return nil, err
 	}
 	if err := rows.Err(); err != nil {
 		return nil, err
@@ -135,9 +123,6 @@ func (q *Queries) LessThan(ctx context.Context) ([]bool, error) {
 		}
 		items = append(items, column_1)
 	}
-	if err := rows.Close(); err != nil {
-		return nil, err
-	}
 	if err := rows.Err(); err != nil {
 		return nil, err
 	}
@@ -162,9 +147,6 @@ func (q *Queries) LessThanOrEqual(ctx context.Context) ([]bool, error) {
 		}
 		items = append(items, column_1)
 	}
-	if err := rows.Close(); err != nil {
-		return nil, err
-	}
 	if err := rows.Err(); err != nil {
 		return nil, err
 	}
@@ -188,9 +170,6 @@ func (q *Queries) NotEqual(ctx context.Context) ([]bool, error) {
 			return nil, err
 		}
 		items = append(items, column_1)
-	}
-	if err := rows.Close(); err != nil {
-		return nil, err
 	}
 	if err := rows.Err(); err != nil {
 		return nil, err

--- a/internal/endtoend/testdata/comparisons/sqlite/go/query.sql.go
+++ b/internal/endtoend/testdata/comparisons/sqlite/go/query.sql.go
@@ -27,9 +27,6 @@ func (q *Queries) AlsoNotEqual(ctx context.Context) ([]bool, error) {
 		}
 		items = append(items, column_1)
 	}
-	if err := rows.Close(); err != nil {
-		return nil, err
-	}
 	if err := rows.Err(); err != nil {
 		return nil, err
 	}
@@ -53,9 +50,6 @@ func (q *Queries) Equal(ctx context.Context) ([]bool, error) {
 			return nil, err
 		}
 		items = append(items, column_1)
-	}
-	if err := rows.Close(); err != nil {
-		return nil, err
 	}
 	if err := rows.Err(); err != nil {
 		return nil, err
@@ -81,9 +75,6 @@ func (q *Queries) GreaterThan(ctx context.Context) ([]bool, error) {
 		}
 		items = append(items, column_1)
 	}
-	if err := rows.Close(); err != nil {
-		return nil, err
-	}
 	if err := rows.Err(); err != nil {
 		return nil, err
 	}
@@ -107,9 +98,6 @@ func (q *Queries) GreaterThanOrEqual(ctx context.Context) ([]bool, error) {
 			return nil, err
 		}
 		items = append(items, column_1)
-	}
-	if err := rows.Close(); err != nil {
-		return nil, err
 	}
 	if err := rows.Err(); err != nil {
 		return nil, err
@@ -135,9 +123,6 @@ func (q *Queries) LessThan(ctx context.Context) ([]bool, error) {
 		}
 		items = append(items, column_1)
 	}
-	if err := rows.Close(); err != nil {
-		return nil, err
-	}
 	if err := rows.Err(); err != nil {
 		return nil, err
 	}
@@ -162,9 +147,6 @@ func (q *Queries) LessThanOrEqual(ctx context.Context) ([]bool, error) {
 		}
 		items = append(items, column_1)
 	}
-	if err := rows.Close(); err != nil {
-		return nil, err
-	}
 	if err := rows.Err(); err != nil {
 		return nil, err
 	}
@@ -188,9 +170,6 @@ func (q *Queries) NotEqual(ctx context.Context) ([]bool, error) {
 			return nil, err
 		}
 		items = append(items, column_1)
-	}
-	if err := rows.Close(); err != nil {
-		return nil, err
 	}
 	if err := rows.Err(); err != nil {
 		return nil, err

--- a/internal/endtoend/testdata/composite_type/stdlib/go/query.sql.go
+++ b/internal/endtoend/testdata/composite_type/stdlib/go/query.sql.go
@@ -27,9 +27,6 @@ func (q *Queries) ListPaths(ctx context.Context) ([]FooPath, error) {
 		}
 		items = append(items, i)
 	}
-	if err := rows.Close(); err != nil {
-		return nil, err
-	}
 	if err := rows.Err(); err != nil {
 		return nil, err
 	}

--- a/internal/endtoend/testdata/create_materialized_view/postgresql/go/query.sql.go
+++ b/internal/endtoend/testdata/create_materialized_view/postgresql/go/query.sql.go
@@ -27,9 +27,6 @@ func (q *Queries) GetFirst(ctx context.Context) ([]string, error) {
 		}
 		items = append(items, val)
 	}
-	if err := rows.Close(); err != nil {
-		return nil, err
-	}
 	if err := rows.Err(); err != nil {
 		return nil, err
 	}

--- a/internal/endtoend/testdata/create_table_as/postgresql/go/query.sql.go
+++ b/internal/endtoend/testdata/create_table_as/postgresql/go/query.sql.go
@@ -27,9 +27,6 @@ func (q *Queries) GetFirst(ctx context.Context) ([]string, error) {
 		}
 		items = append(items, val)
 	}
-	if err := rows.Close(); err != nil {
-		return nil, err
-	}
 	if err := rows.Err(); err != nil {
 		return nil, err
 	}

--- a/internal/endtoend/testdata/create_table_like/mysql/go/query.sql.go
+++ b/internal/endtoend/testdata/create_table_like/mysql/go/query.sql.go
@@ -32,9 +32,6 @@ func (q *Queries) GetAll(ctx context.Context) ([]SuperUser, error) {
 		}
 		items = append(items, i)
 	}
-	if err := rows.Close(); err != nil {
-		return nil, err
-	}
 	if err := rows.Err(); err != nil {
 		return nil, err
 	}

--- a/internal/endtoend/testdata/create_table_like/postgresql/go/query.sql.go
+++ b/internal/endtoend/testdata/create_table_like/postgresql/go/query.sql.go
@@ -32,9 +32,6 @@ func (q *Queries) GetAll(ctx context.Context) ([]SuperUser, error) {
 		}
 		items = append(items, i)
 	}
-	if err := rows.Close(); err != nil {
-		return nil, err
-	}
 	if err := rows.Err(); err != nil {
 		return nil, err
 	}

--- a/internal/endtoend/testdata/create_view/mysql/go/query.sql.go
+++ b/internal/endtoend/testdata/create_view/mysql/go/query.sql.go
@@ -27,9 +27,6 @@ func (q *Queries) GetFirst(ctx context.Context) ([]string, error) {
 		}
 		items = append(items, val)
 	}
-	if err := rows.Close(); err != nil {
-		return nil, err
-	}
 	if err := rows.Err(); err != nil {
 		return nil, err
 	}
@@ -53,9 +50,6 @@ func (q *Queries) GetSecond(ctx context.Context) ([]SecondView, error) {
 			return nil, err
 		}
 		items = append(items, i)
-	}
-	if err := rows.Close(); err != nil {
-		return nil, err
 	}
 	if err := rows.Err(); err != nil {
 		return nil, err

--- a/internal/endtoend/testdata/create_view/postgresql/go/query.sql.go
+++ b/internal/endtoend/testdata/create_view/postgresql/go/query.sql.go
@@ -28,9 +28,6 @@ func (q *Queries) GetFirst(ctx context.Context) ([]string, error) {
 		}
 		items = append(items, val)
 	}
-	if err := rows.Close(); err != nil {
-		return nil, err
-	}
 	if err := rows.Err(); err != nil {
 		return nil, err
 	}
@@ -54,9 +51,6 @@ func (q *Queries) GetSecond(ctx context.Context, val2 sql.NullInt32) ([]SecondVi
 			return nil, err
 		}
 		items = append(items, i)
-	}
-	if err := rows.Close(); err != nil {
-		return nil, err
 	}
 	if err := rows.Err(); err != nil {
 		return nil, err

--- a/internal/endtoend/testdata/create_view/sqlite/go/query.sql.go
+++ b/internal/endtoend/testdata/create_view/sqlite/go/query.sql.go
@@ -28,9 +28,6 @@ func (q *Queries) GetFirst(ctx context.Context) ([]string, error) {
 		}
 		items = append(items, val)
 	}
-	if err := rows.Close(); err != nil {
-		return nil, err
-	}
 	if err := rows.Err(); err != nil {
 		return nil, err
 	}
@@ -54,9 +51,6 @@ func (q *Queries) GetSecond(ctx context.Context, val2 sql.NullInt64) ([]SecondVi
 			return nil, err
 		}
 		items = append(items, i)
-	}
-	if err := rows.Close(); err != nil {
-		return nil, err
 	}
 	if err := rows.Err(); err != nil {
 		return nil, err

--- a/internal/endtoend/testdata/cte_count/mysql/go/query.sql.go
+++ b/internal/endtoend/testdata/cte_count/mysql/go/query.sql.go
@@ -38,9 +38,6 @@ func (q *Queries) CTECount(ctx context.Context) ([]CTECountRow, error) {
 		}
 		items = append(items, i)
 	}
-	if err := rows.Close(); err != nil {
-		return nil, err
-	}
 	if err := rows.Err(); err != nil {
 		return nil, err
 	}

--- a/internal/endtoend/testdata/cte_count/stdlib/go/query.sql.go
+++ b/internal/endtoend/testdata/cte_count/stdlib/go/query.sql.go
@@ -38,9 +38,6 @@ func (q *Queries) CTECount(ctx context.Context) ([]CTECountRow, error) {
 		}
 		items = append(items, i)
 	}
-	if err := rows.Close(); err != nil {
-		return nil, err
-	}
 	if err := rows.Err(); err != nil {
 		return nil, err
 	}

--- a/internal/endtoend/testdata/cte_filter/mysql/go/query.sql.go
+++ b/internal/endtoend/testdata/cte_filter/mysql/go/query.sql.go
@@ -31,9 +31,6 @@ func (q *Queries) CTEFilter(ctx context.Context, ready bool) ([]int64, error) {
 		}
 		items = append(items, count)
 	}
-	if err := rows.Close(); err != nil {
-		return nil, err
-	}
 	if err := rows.Err(); err != nil {
 		return nil, err
 	}

--- a/internal/endtoend/testdata/cte_filter/stdlib/go/query.sql.go
+++ b/internal/endtoend/testdata/cte_filter/stdlib/go/query.sql.go
@@ -31,9 +31,6 @@ func (q *Queries) CTEFilter(ctx context.Context, ready bool) ([]int64, error) {
 		}
 		items = append(items, count)
 	}
-	if err := rows.Close(); err != nil {
-		return nil, err
-	}
 	if err := rows.Err(); err != nil {
 		return nil, err
 	}

--- a/internal/endtoend/testdata/cte_in_delete/stdlib/go/query.sql.go
+++ b/internal/endtoend/testdata/cte_in_delete/stdlib/go/query.sql.go
@@ -31,9 +31,6 @@ func (q *Queries) DeleteReadyWithCTE(ctx context.Context) ([]int32, error) {
 		}
 		items = append(items, id)
 	}
-	if err := rows.Close(); err != nil {
-		return nil, err
-	}
 	if err := rows.Err(); err != nil {
 		return nil, err
 	}

--- a/internal/endtoend/testdata/cte_recursive/mysql/go/query.sql.go
+++ b/internal/endtoend/testdata/cte_recursive/mysql/go/query.sql.go
@@ -40,9 +40,6 @@ func (q *Queries) CTERecursive(ctx context.Context, id int32) ([]CTERecursiveRow
 		}
 		items = append(items, i)
 	}
-	if err := rows.Close(); err != nil {
-		return nil, err
-	}
 	if err := rows.Err(); err != nil {
 		return nil, err
 	}

--- a/internal/endtoend/testdata/cte_recursive/stdlib/go/query.sql.go
+++ b/internal/endtoend/testdata/cte_recursive/stdlib/go/query.sql.go
@@ -40,9 +40,6 @@ func (q *Queries) CTERecursive(ctx context.Context, id int32) ([]CTERecursiveRow
 		}
 		items = append(items, i)
 	}
-	if err := rows.Close(); err != nil {
-		return nil, err
-	}
 	if err := rows.Err(); err != nil {
 		return nil, err
 	}

--- a/internal/endtoend/testdata/cte_recursive_star/postgresql/pgx/go/query.sql.go
+++ b/internal/endtoend/testdata/cte_recursive_star/postgresql/pgx/go/query.sql.go
@@ -26,7 +26,7 @@ type GetDictTreeRow struct {
 	ParentCode string
 	Label      string
 	Value      pgtype.Text
-	Path       []string
+	Path       interface{}
 	Depth      int32
 }
 

--- a/internal/endtoend/testdata/data_type_boolean/mysql/db/query.sql.go
+++ b/internal/endtoend/testdata/data_type_boolean/mysql/db/query.sql.go
@@ -27,9 +27,6 @@ func (q *Queries) ListBar(ctx context.Context) ([]Bar, error) {
 		}
 		items = append(items, i)
 	}
-	if err := rows.Close(); err != nil {
-		return nil, err
-	}
 	if err := rows.Err(); err != nil {
 		return nil, err
 	}
@@ -53,9 +50,6 @@ func (q *Queries) ListFoo(ctx context.Context) ([]Foo, error) {
 			return nil, err
 		}
 		items = append(items, i)
-	}
-	if err := rows.Close(); err != nil {
-		return nil, err
 	}
 	if err := rows.Err(); err != nil {
 		return nil, err

--- a/internal/endtoend/testdata/data_type_boolean/postgresql/stdlib/go/query.sql.go
+++ b/internal/endtoend/testdata/data_type_boolean/postgresql/stdlib/go/query.sql.go
@@ -27,9 +27,6 @@ func (q *Queries) ListBar(ctx context.Context) ([]Bar, error) {
 		}
 		items = append(items, i)
 	}
-	if err := rows.Close(); err != nil {
-		return nil, err
-	}
 	if err := rows.Err(); err != nil {
 		return nil, err
 	}
@@ -53,9 +50,6 @@ func (q *Queries) ListFoo(ctx context.Context) ([]Foo, error) {
 			return nil, err
 		}
 		items = append(items, i)
-	}
-	if err := rows.Close(); err != nil {
-		return nil, err
 	}
 	if err := rows.Err(); err != nil {
 		return nil, err

--- a/internal/endtoend/testdata/data_type_boolean/sqlite/db/query.sql.go
+++ b/internal/endtoend/testdata/data_type_boolean/sqlite/db/query.sql.go
@@ -27,9 +27,6 @@ func (q *Queries) ListBar(ctx context.Context) ([]Bar, error) {
 		}
 		items = append(items, i)
 	}
-	if err := rows.Close(); err != nil {
-		return nil, err
-	}
 	if err := rows.Err(); err != nil {
 		return nil, err
 	}
@@ -53,9 +50,6 @@ func (q *Queries) ListFoo(ctx context.Context) ([]Foo, error) {
 			return nil, err
 		}
 		items = append(items, i)
-	}
-	if err := rows.Close(); err != nil {
-		return nil, err
 	}
 	if err := rows.Err(); err != nil {
 		return nil, err

--- a/internal/endtoend/testdata/ddl_alter_table_add_column/sqlite/go/query.sql.go
+++ b/internal/endtoend/testdata/ddl_alter_table_add_column/sqlite/go/query.sql.go
@@ -27,9 +27,6 @@ func (q *Queries) Placeholder(ctx context.Context) ([]Venue, error) {
 		}
 		items = append(items, i)
 	}
-	if err := rows.Close(); err != nil {
-		return nil, err
-	}
 	if err := rows.Err(); err != nil {
 		return nil, err
 	}

--- a/internal/endtoend/testdata/ddl_alter_table_rename/sqlite/go/query.sql.go
+++ b/internal/endtoend/testdata/ddl_alter_table_rename/sqlite/go/query.sql.go
@@ -28,9 +28,6 @@ func (q *Queries) Placeholder(ctx context.Context) ([]sql.NullString, error) {
 		}
 		items = append(items, name)
 	}
-	if err := rows.Close(); err != nil {
-		return nil, err
-	}
 	if err := rows.Err(); err != nil {
 		return nil, err
 	}

--- a/internal/endtoend/testdata/ddl_alter_table_rename_column/sqlite/go/query.sql.go
+++ b/internal/endtoend/testdata/ddl_alter_table_rename_column/sqlite/go/query.sql.go
@@ -28,9 +28,6 @@ func (q *Queries) Placeholder(ctx context.Context) ([]sql.NullString, error) {
 		}
 		items = append(items, boo)
 	}
-	if err := rows.Close(); err != nil {
-		return nil, err
-	}
 	if err := rows.Err(); err != nil {
 		return nil, err
 	}

--- a/internal/endtoend/testdata/ddl_alter_type_rename/postgresql/stdlib/go/query.sql.go
+++ b/internal/endtoend/testdata/ddl_alter_type_rename/postgresql/stdlib/go/query.sql.go
@@ -27,9 +27,6 @@ func (q *Queries) ListAuthors(ctx context.Context) ([]LogLine, error) {
 		}
 		items = append(items, i)
 	}
-	if err := rows.Close(); err != nil {
-		return nil, err
-	}
 	if err := rows.Err(); err != nil {
 		return nil, err
 	}

--- a/internal/endtoend/testdata/ddl_alter_type_rename_and_update_columns/postgresql/stdlib/go/query.sql.go
+++ b/internal/endtoend/testdata/ddl_alter_type_rename_and_update_columns/postgresql/stdlib/go/query.sql.go
@@ -27,9 +27,6 @@ func (q *Queries) ListAuthors(ctx context.Context) ([]LogLine, error) {
 		}
 		items = append(items, i)
 	}
-	if err := rows.Close(); err != nil {
-		return nil, err
-	}
 	if err := rows.Err(); err != nil {
 		return nil, err
 	}

--- a/internal/endtoend/testdata/ddl_alter_type_set_schema/postgresql/stdlib/go/query.sql.go
+++ b/internal/endtoend/testdata/ddl_alter_type_set_schema/postgresql/stdlib/go/query.sql.go
@@ -27,9 +27,6 @@ func (q *Queries) ListAuthors(ctx context.Context) ([]LogLine, error) {
 		}
 		items = append(items, i)
 	}
-	if err := rows.Close(); err != nil {
-		return nil, err
-	}
 	if err := rows.Err(); err != nil {
 		return nil, err
 	}

--- a/internal/endtoend/testdata/ddl_create_enum/mysql/go/query.sql.go
+++ b/internal/endtoend/testdata/ddl_create_enum/mysql/go/query.sql.go
@@ -27,9 +27,6 @@ func (q *Queries) ListFoo(ctx context.Context) ([]Foo, error) {
 		}
 		items = append(items, i)
 	}
-	if err := rows.Close(); err != nil {
-		return nil, err
-	}
 	if err := rows.Err(); err != nil {
 		return nil, err
 	}

--- a/internal/endtoend/testdata/ddl_create_enum/postgresql/stdlib/go/query.sql.go
+++ b/internal/endtoend/testdata/ddl_create_enum/postgresql/stdlib/go/query.sql.go
@@ -27,9 +27,6 @@ func (q *Queries) ListFoo(ctx context.Context) ([]Foobar, error) {
 		}
 		items = append(items, val)
 	}
-	if err := rows.Close(); err != nil {
-		return nil, err
-	}
 	if err := rows.Err(); err != nil {
 		return nil, err
 	}

--- a/internal/endtoend/testdata/ddl_create_table_inherits/postgresql/stdlib/go/query.sql.go
+++ b/internal/endtoend/testdata/ddl_create_table_inherits/postgresql/stdlib/go/query.sql.go
@@ -27,9 +27,6 @@ func (q *Queries) GetAllOrganisations(ctx context.Context) ([]Organisation, erro
 		}
 		items = append(items, i)
 	}
-	if err := rows.Close(); err != nil {
-		return nil, err
-	}
 	if err := rows.Err(); err != nil {
 		return nil, err
 	}
@@ -53,9 +50,6 @@ func (q *Queries) GetAllParties(ctx context.Context) ([]Party, error) {
 			return nil, err
 		}
 		items = append(items, i)
-	}
-	if err := rows.Close(); err != nil {
-		return nil, err
 	}
 	if err := rows.Err(); err != nil {
 		return nil, err
@@ -85,9 +79,6 @@ func (q *Queries) GetAllPeople(ctx context.Context) ([]Person, error) {
 			return nil, err
 		}
 		items = append(items, i)
-	}
-	if err := rows.Close(); err != nil {
-		return nil, err
 	}
 	if err := rows.Err(); err != nil {
 		return nil, err

--- a/internal/endtoend/testdata/diff_no_output/go/query.sql.go
+++ b/internal/endtoend/testdata/diff_no_output/go/query.sql.go
@@ -62,9 +62,6 @@ func (q *Queries) ListAuthors(ctx context.Context) ([]Author, error) {
 		}
 		items = append(items, i)
 	}
-	if err := rows.Close(); err != nil {
-		return nil, err
-	}
 	if err := rows.Err(); err != nil {
 		return nil, err
 	}

--- a/internal/endtoend/testdata/diff_output/go/query.sql.go
+++ b/internal/endtoend/testdata/diff_output/go/query.sql.go
@@ -31,16 +31,6 @@ func (q *Queries) CreateAuthor(ctx context.Context, arg CreateAuthorParams) (Aut
 	return i, err
 }
 
-const deleteAuthor = `-- name: DeleteAuthor :exec
-DELETE FROM authors
-WHERE id = $1
-`
-
-func (q *Queries) DeleteAuthor(ctx context.Context, id int64) error {
-	_, err := q.db.ExecContext(ctx, deleteAuthor, id)
-	return err
-}
-
 const getAuthor = `-- name: GetAuthor :one
 SELECT id, name, bio FROM authors
 WHERE id = $1 LIMIT 1
@@ -55,7 +45,7 @@ func (q *Queries) GetAuthor(ctx context.Context, id int64) (Author, error) {
 
 const listAuthors = `-- name: ListAuthors :many
 SELECT id, name, bio FROM authors
-ORDER BY name
+ORDER BY bio
 `
 
 func (q *Queries) ListAuthors(ctx context.Context) ([]Author, error) {
@@ -72,11 +62,19 @@ func (q *Queries) ListAuthors(ctx context.Context) ([]Author, error) {
 		}
 		items = append(items, i)
 	}
-	if err := rows.Close(); err != nil {
-		return nil, err
-	}
 	if err := rows.Err(); err != nil {
 		return nil, err
 	}
 	return items, nil
+}
+
+const selectOne = `-- name: SelectOne :one
+SELECT 1
+`
+
+func (q *Queries) SelectOne(ctx context.Context) (int32, error) {
+	row := q.db.QueryRowContext(ctx, selectOne)
+	var column_1 int32
+	err := row.Scan(&column_1)
+	return column_1, err
 }

--- a/internal/endtoend/testdata/emit_db_and_json_tags/mysql/go/query.sql.go
+++ b/internal/endtoend/testdata/emit_db_and_json_tags/mysql/go/query.sql.go
@@ -32,9 +32,6 @@ func (q *Queries) GetAll(ctx context.Context) ([]User, error) {
 		}
 		items = append(items, i)
 	}
-	if err := rows.Close(); err != nil {
-		return nil, err
-	}
 	if err := rows.Err(); err != nil {
 		return nil, err
 	}

--- a/internal/endtoend/testdata/emit_db_and_json_tags/postgresql/stdlib/go/query.sql.go
+++ b/internal/endtoend/testdata/emit_db_and_json_tags/postgresql/stdlib/go/query.sql.go
@@ -32,9 +32,6 @@ func (q *Queries) GetAll(ctx context.Context) ([]User, error) {
 		}
 		items = append(items, i)
 	}
-	if err := rows.Close(); err != nil {
-		return nil, err
-	}
 	if err := rows.Err(); err != nil {
 		return nil, err
 	}

--- a/internal/endtoend/testdata/emit_db_and_json_tags/sqlite/go/query.sql.go
+++ b/internal/endtoend/testdata/emit_db_and_json_tags/sqlite/go/query.sql.go
@@ -32,9 +32,6 @@ func (q *Queries) GetAll(ctx context.Context) ([]User, error) {
 		}
 		items = append(items, i)
 	}
-	if err := rows.Close(); err != nil {
-		return nil, err
-	}
 	if err := rows.Err(); err != nil {
 		return nil, err
 	}

--- a/internal/endtoend/testdata/emit_db_tags/mysql/go/query.sql.go
+++ b/internal/endtoend/testdata/emit_db_tags/mysql/go/query.sql.go
@@ -32,9 +32,6 @@ func (q *Queries) GetAll(ctx context.Context) ([]User, error) {
 		}
 		items = append(items, i)
 	}
-	if err := rows.Close(); err != nil {
-		return nil, err
-	}
 	if err := rows.Err(); err != nil {
 		return nil, err
 	}

--- a/internal/endtoend/testdata/emit_db_tags/postgresql/stdlib/go/query.sql.go
+++ b/internal/endtoend/testdata/emit_db_tags/postgresql/stdlib/go/query.sql.go
@@ -32,9 +32,6 @@ func (q *Queries) GetAll(ctx context.Context) ([]User, error) {
 		}
 		items = append(items, i)
 	}
-	if err := rows.Close(); err != nil {
-		return nil, err
-	}
 	if err := rows.Err(); err != nil {
 		return nil, err
 	}

--- a/internal/endtoend/testdata/emit_db_tags/sqlite/go/query.sql.go
+++ b/internal/endtoend/testdata/emit_db_tags/sqlite/go/query.sql.go
@@ -32,9 +32,6 @@ func (q *Queries) GetAll(ctx context.Context) ([]User, error) {
 		}
 		items = append(items, i)
 	}
-	if err := rows.Close(); err != nil {
-		return nil, err
-	}
 	if err := rows.Err(); err != nil {
 		return nil, err
 	}

--- a/internal/endtoend/testdata/emit_empty_slices/stdlib/go/query.sql.go
+++ b/internal/endtoend/testdata/emit_empty_slices/stdlib/go/query.sql.go
@@ -27,9 +27,6 @@ func (q *Queries) ListBar(ctx context.Context) ([]int32, error) {
 		}
 		items = append(items, id)
 	}
-	if err := rows.Close(); err != nil {
-		return nil, err
-	}
 	if err := rows.Err(); err != nil {
 		return nil, err
 	}

--- a/internal/endtoend/testdata/emit_methods_with_db_argument/mysql/go/query.sql.go
+++ b/internal/endtoend/testdata/emit_methods_with_db_argument/mysql/go/query.sql.go
@@ -32,9 +32,6 @@ func (q *Queries) GetAll(ctx context.Context, db DBTX) ([]User, error) {
 		}
 		items = append(items, i)
 	}
-	if err := rows.Close(); err != nil {
-		return nil, err
-	}
 	if err := rows.Err(); err != nil {
 		return nil, err
 	}

--- a/internal/endtoend/testdata/emit_methods_with_db_argument/postgresql/stdlib/go/query.sql.go
+++ b/internal/endtoend/testdata/emit_methods_with_db_argument/postgresql/stdlib/go/query.sql.go
@@ -32,9 +32,6 @@ func (q *Queries) GetAll(ctx context.Context, db DBTX) ([]User, error) {
 		}
 		items = append(items, i)
 	}
-	if err := rows.Close(); err != nil {
-		return nil, err
-	}
 	if err := rows.Err(); err != nil {
 		return nil, err
 	}

--- a/internal/endtoend/testdata/emit_methods_with_db_argument/sqlite/go/query.sql.go
+++ b/internal/endtoend/testdata/emit_methods_with_db_argument/sqlite/go/query.sql.go
@@ -32,9 +32,6 @@ func (q *Queries) GetAll(ctx context.Context, db DBTX) ([]User, error) {
 		}
 		items = append(items, i)
 	}
-	if err := rows.Close(); err != nil {
-		return nil, err
-	}
 	if err := rows.Err(); err != nil {
 		return nil, err
 	}

--- a/internal/endtoend/testdata/emit_result_and_params_struct_pointers/mysql/go/query.sql.go
+++ b/internal/endtoend/testdata/emit_result_and_params_struct_pointers/mysql/go/query.sql.go
@@ -28,9 +28,6 @@ func (q *Queries) GetAll(ctx context.Context) ([]*Foo, error) {
 		}
 		items = append(items, &i)
 	}
-	if err := rows.Close(); err != nil {
-		return nil, err
-	}
 	if err := rows.Err(); err != nil {
 		return nil, err
 	}
@@ -54,9 +51,6 @@ func (q *Queries) GetAllAByB(ctx context.Context, b sql.NullInt32) ([]sql.NullIn
 			return nil, err
 		}
 		items = append(items, a)
-	}
-	if err := rows.Close(); err != nil {
-		return nil, err
 	}
 	if err := rows.Err(); err != nil {
 		return nil, err

--- a/internal/endtoend/testdata/emit_sql_as_comment/stdlib/go/query.sql.go
+++ b/internal/endtoend/testdata/emit_sql_as_comment/stdlib/go/query.sql.go
@@ -34,9 +34,6 @@ func (q *Queries) ListBar(ctx context.Context) ([]int32, error) {
 		}
 		items = append(items, id)
 	}
-	if err := rows.Close(); err != nil {
-		return nil, err
-	}
 	if err := rows.Err(); err != nil {
 		return nil, err
 	}

--- a/internal/endtoend/testdata/enum/mysql/go/query.sql.go
+++ b/internal/endtoend/testdata/enum/mysql/go/query.sql.go
@@ -50,9 +50,6 @@ func (q *Queries) GetAll(ctx context.Context, db DBTX) ([]User, error) {
 		}
 		items = append(items, i)
 	}
-	if err := rows.Close(); err != nil {
-		return nil, err
-	}
 	if err := rows.Err(); err != nil {
 		return nil, err
 	}

--- a/internal/endtoend/testdata/enum/postgresql/stdlib/go/query.sql.go
+++ b/internal/endtoend/testdata/enum/postgresql/stdlib/go/query.sql.go
@@ -50,9 +50,6 @@ func (q *Queries) GetAll(ctx context.Context, db DBTX) ([]User, error) {
 		}
 		items = append(items, i)
 	}
-	if err := rows.Close(); err != nil {
-		return nil, err
-	}
 	if err := rows.Err(); err != nil {
 		return nil, err
 	}

--- a/internal/endtoend/testdata/enum_column/mysql/go/query.sql.go
+++ b/internal/endtoend/testdata/enum_column/mysql/go/query.sql.go
@@ -34,9 +34,6 @@ func (q *Queries) ListAuthors(ctx context.Context) ([]Author, error) {
 		}
 		items = append(items, i)
 	}
-	if err := rows.Close(); err != nil {
-		return nil, err
-	}
 	if err := rows.Err(); err != nil {
 		return nil, err
 	}
@@ -60,9 +57,6 @@ func (q *Queries) ListBooks(ctx context.Context) ([]Book, error) {
 			return nil, err
 		}
 		items = append(items, i)
-	}
-	if err := rows.Close(); err != nil {
-		return nil, err
 	}
 	if err := rows.Err(); err != nil {
 		return nil, err

--- a/internal/endtoend/testdata/enum_ordering/postgresql/stdlib/go/query.sql.go
+++ b/internal/endtoend/testdata/enum_ordering/postgresql/stdlib/go/query.sql.go
@@ -27,9 +27,6 @@ func (q *Queries) GetAll(ctx context.Context) ([]int32, error) {
 		}
 		items = append(items, id)
 	}
-	if err := rows.Close(); err != nil {
-		return nil, err
-	}
 	if err := rows.Err(); err != nil {
 		return nil, err
 	}

--- a/internal/endtoend/testdata/func_aggregate/pganalyze/go/query.sql.go
+++ b/internal/endtoend/testdata/func_aggregate/pganalyze/go/query.sql.go
@@ -14,9 +14,9 @@ select percentile_disc(0.5) within group (order by authors.name)
 from authors
 `
 
-func (q *Queries) Percentile(ctx context.Context) (string, error) {
+func (q *Queries) Percentile(ctx context.Context) (interface{}, error) {
 	row := q.db.QueryRowContext(ctx, percentile)
-	var percentile_disc string
+	var percentile_disc interface{}
 	err := row.Scan(&percentile_disc)
 	return percentile_disc, err
 }

--- a/internal/endtoend/testdata/func_match_types/mysql/go/query.sql.go
+++ b/internal/endtoend/testdata/func_match_types/mysql/go/query.sql.go
@@ -35,9 +35,6 @@ func (q *Queries) AuthorPages(ctx context.Context) ([]AuthorPagesRow, error) {
 		}
 		items = append(items, i)
 	}
-	if err := rows.Close(); err != nil {
-		return nil, err
-	}
 	if err := rows.Err(); err != nil {
 		return nil, err
 	}

--- a/internal/endtoend/testdata/func_match_types/postgresql/go/query.sql.go
+++ b/internal/endtoend/testdata/func_match_types/postgresql/go/query.sql.go
@@ -35,9 +35,6 @@ func (q *Queries) AuthorPages(ctx context.Context) ([]AuthorPagesRow, error) {
 		}
 		items = append(items, i)
 	}
-	if err := rows.Close(); err != nil {
-		return nil, err
-	}
 	if err := rows.Err(); err != nil {
 		return nil, err
 	}

--- a/internal/endtoend/testdata/func_match_types/sqlite/go/query.sql.go
+++ b/internal/endtoend/testdata/func_match_types/sqlite/go/query.sql.go
@@ -36,9 +36,6 @@ func (q *Queries) AuthorPages(ctx context.Context) ([]AuthorPagesRow, error) {
 		}
 		items = append(items, i)
 	}
-	if err := rows.Close(); err != nil {
-		return nil, err
-	}
 	if err := rows.Err(); err != nil {
 		return nil, err
 	}

--- a/internal/endtoend/testdata/func_return_date/postgresql/pganalyze/go/query.sql.go
+++ b/internal/endtoend/testdata/func_return_date/postgresql/pganalyze/go/query.sql.go
@@ -7,17 +7,15 @@ package querytest
 
 import (
 	"context"
-
-	"github.com/jackc/pgx/v5/pgtype"
 )
 
 const getDate = `-- name: GetDate :one
 SELECT now from NOW()
 `
 
-func (q *Queries) GetDate(ctx context.Context) (pgtype.Timestamptz, error) {
+func (q *Queries) GetDate(ctx context.Context) (interface{}, error) {
 	row := q.db.QueryRow(ctx, getDate)
-	var now pgtype.Timestamptz
+	var now interface{}
 	err := row.Scan(&now)
 	return now, err
 }

--- a/internal/endtoend/testdata/func_return_series/postgresql/stdlib/go/query.sql.go
+++ b/internal/endtoend/testdata/func_return_series/postgresql/stdlib/go/query.sql.go
@@ -34,9 +34,6 @@ func (q *Queries) GenerateSeries(ctx context.Context, arg GenerateSeriesParams) 
 		}
 		items = append(items, column_1)
 	}
-	if err := rows.Close(); err != nil {
-		return nil, err
-	}
 	if err := rows.Err(); err != nil {
 		return nil, err
 	}

--- a/internal/endtoend/testdata/golang_initialisms_empty/db/query.sql.go
+++ b/internal/endtoend/testdata/golang_initialisms_empty/db/query.sql.go
@@ -28,9 +28,6 @@ func (q *Queries) SelectFoo(ctx context.Context) ([]sql.NullString, error) {
 		}
 		items = append(items, bar_id)
 	}
-	if err := rows.Close(); err != nil {
-		return nil, err
-	}
 	if err := rows.Err(); err != nil {
 		return nil, err
 	}

--- a/internal/endtoend/testdata/golang_initialisms_url/db/query.sql.go
+++ b/internal/endtoend/testdata/golang_initialisms_url/db/query.sql.go
@@ -27,9 +27,6 @@ func (q *Queries) SelectFoo(ctx context.Context) ([]Foo, error) {
 		}
 		items = append(items, i)
 	}
-	if err := rows.Close(); err != nil {
-		return nil, err
-	}
 	if err := rows.Err(); err != nil {
 		return nil, err
 	}

--- a/internal/endtoend/testdata/having/mysql/go/query.sql.go
+++ b/internal/endtoend/testdata/having/mysql/go/query.sql.go
@@ -30,9 +30,6 @@ func (q *Queries) ColdCities(ctx context.Context, tempLo int32) ([]string, error
 		}
 		items = append(items, city)
 	}
-	if err := rows.Close(); err != nil {
-		return nil, err
-	}
 	if err := rows.Err(); err != nil {
 		return nil, err
 	}

--- a/internal/endtoend/testdata/having/postgresql/go/query.sql.go
+++ b/internal/endtoend/testdata/having/postgresql/go/query.sql.go
@@ -30,9 +30,6 @@ func (q *Queries) ColdCities(ctx context.Context, tempLo int32) ([]string, error
 		}
 		items = append(items, city)
 	}
-	if err := rows.Close(); err != nil {
-		return nil, err
-	}
 	if err := rows.Err(); err != nil {
 		return nil, err
 	}

--- a/internal/endtoend/testdata/hstore/stdlib/go/hstore.sql.go
+++ b/internal/endtoend/testdata/hstore/stdlib/go/hstore.sql.go
@@ -27,9 +27,6 @@ func (q *Queries) ListBar(ctx context.Context) ([]interface{}, error) {
 		}
 		items = append(items, bar)
 	}
-	if err := rows.Close(); err != nil {
-		return nil, err
-	}
 	if err := rows.Err(); err != nil {
 		return nil, err
 	}
@@ -53,9 +50,6 @@ func (q *Queries) ListBaz(ctx context.Context) ([]interface{}, error) {
 			return nil, err
 		}
 		items = append(items, baz)
-	}
-	if err := rows.Close(); err != nil {
-		return nil, err
 	}
 	if err := rows.Err(); err != nil {
 		return nil, err

--- a/internal/endtoend/testdata/identical_tables/mysql/go/query.sql.go
+++ b/internal/endtoend/testdata/identical_tables/mysql/go/query.sql.go
@@ -27,9 +27,6 @@ func (q *Queries) IdenticalTable(ctx context.Context) ([]string, error) {
 		}
 		items = append(items, id)
 	}
-	if err := rows.Close(); err != nil {
-		return nil, err
-	}
 	if err := rows.Err(); err != nil {
 		return nil, err
 	}

--- a/internal/endtoend/testdata/identical_tables/postgresql/stdlib/go/query.sql.go
+++ b/internal/endtoend/testdata/identical_tables/postgresql/stdlib/go/query.sql.go
@@ -27,9 +27,6 @@ func (q *Queries) IdenticalTable(ctx context.Context) ([]string, error) {
 		}
 		items = append(items, id)
 	}
-	if err := rows.Close(); err != nil {
-		return nil, err
-	}
 	if err := rows.Err(); err != nil {
 		return nil, err
 	}

--- a/internal/endtoend/testdata/identical_tables/sqlite/go/query.sql.go
+++ b/internal/endtoend/testdata/identical_tables/sqlite/go/query.sql.go
@@ -27,9 +27,6 @@ func (q *Queries) IdenticalTable(ctx context.Context) ([]string, error) {
 		}
 		items = append(items, id)
 	}
-	if err := rows.Close(); err != nil {
-		return nil, err
-	}
 	if err := rows.Err(); err != nil {
 		return nil, err
 	}

--- a/internal/endtoend/testdata/identifier_case_sensitivity/db/query.sql.go
+++ b/internal/endtoend/testdata/identifier_case_sensitivity/db/query.sql.go
@@ -68,9 +68,6 @@ func (q *Queries) ListAuthors(ctx context.Context) ([]Author, error) {
 		}
 		items = append(items, i)
 	}
-	if err := rows.Close(); err != nil {
-		return nil, err
-	}
 	if err := rows.Err(); err != nil {
 		return nil, err
 	}

--- a/internal/endtoend/testdata/in_union/mysql/go/query.sql.go
+++ b/internal/endtoend/testdata/in_union/mysql/go/query.sql.go
@@ -28,9 +28,6 @@ func (q *Queries) GetAuthors(ctx context.Context) ([]Author, error) {
 		}
 		items = append(items, i)
 	}
-	if err := rows.Close(); err != nil {
-		return nil, err
-	}
 	if err := rows.Err(); err != nil {
 		return nil, err
 	}

--- a/internal/endtoend/testdata/inflection/mysql/go/query.sql.go
+++ b/internal/endtoend/testdata/inflection/mysql/go/query.sql.go
@@ -27,9 +27,6 @@ func (q *Queries) GetProductMetadata(ctx context.Context) ([]string, error) {
 		}
 		items = append(items, id)
 	}
-	if err := rows.Close(); err != nil {
-		return nil, err
-	}
 	if err := rows.Err(); err != nil {
 		return nil, err
 	}
@@ -53,9 +50,6 @@ func (q *Queries) ListCalories(ctx context.Context) ([]string, error) {
 			return nil, err
 		}
 		items = append(items, id)
-	}
-	if err := rows.Close(); err != nil {
-		return nil, err
 	}
 	if err := rows.Err(); err != nil {
 		return nil, err
@@ -81,9 +75,6 @@ func (q *Queries) ListCampuses(ctx context.Context) ([]string, error) {
 		}
 		items = append(items, id)
 	}
-	if err := rows.Close(); err != nil {
-		return nil, err
-	}
 	if err := rows.Err(); err != nil {
 		return nil, err
 	}
@@ -108,9 +99,6 @@ func (q *Queries) ListMetadata(ctx context.Context) ([]string, error) {
 		}
 		items = append(items, id)
 	}
-	if err := rows.Close(); err != nil {
-		return nil, err
-	}
 	if err := rows.Err(); err != nil {
 		return nil, err
 	}
@@ -134,9 +122,6 @@ func (q *Queries) ListStudents(ctx context.Context) ([]string, error) {
 			return nil, err
 		}
 		items = append(items, id)
-	}
-	if err := rows.Close(); err != nil {
-		return nil, err
 	}
 	if err := rows.Err(); err != nil {
 		return nil, err

--- a/internal/endtoend/testdata/inflection/postgresql/stdlib/go/query.sql.go
+++ b/internal/endtoend/testdata/inflection/postgresql/stdlib/go/query.sql.go
@@ -27,9 +27,6 @@ func (q *Queries) GetProductMetadata(ctx context.Context) ([]string, error) {
 		}
 		items = append(items, id)
 	}
-	if err := rows.Close(); err != nil {
-		return nil, err
-	}
 	if err := rows.Err(); err != nil {
 		return nil, err
 	}
@@ -53,9 +50,6 @@ func (q *Queries) ListCalories(ctx context.Context) ([]string, error) {
 			return nil, err
 		}
 		items = append(items, id)
-	}
-	if err := rows.Close(); err != nil {
-		return nil, err
 	}
 	if err := rows.Err(); err != nil {
 		return nil, err
@@ -81,9 +75,6 @@ func (q *Queries) ListCampuses(ctx context.Context) ([]string, error) {
 		}
 		items = append(items, id)
 	}
-	if err := rows.Close(); err != nil {
-		return nil, err
-	}
 	if err := rows.Err(); err != nil {
 		return nil, err
 	}
@@ -108,9 +99,6 @@ func (q *Queries) ListMetadata(ctx context.Context) ([]string, error) {
 		}
 		items = append(items, id)
 	}
-	if err := rows.Close(); err != nil {
-		return nil, err
-	}
 	if err := rows.Err(); err != nil {
 		return nil, err
 	}
@@ -134,9 +122,6 @@ func (q *Queries) ListStudents(ctx context.Context) ([]string, error) {
 			return nil, err
 		}
 		items = append(items, id)
-	}
-	if err := rows.Close(); err != nil {
-		return nil, err
 	}
 	if err := rows.Err(); err != nil {
 		return nil, err

--- a/internal/endtoend/testdata/inflection/sqlite/go/query.sql.go
+++ b/internal/endtoend/testdata/inflection/sqlite/go/query.sql.go
@@ -27,9 +27,6 @@ func (q *Queries) GetProductMetadata(ctx context.Context) ([]string, error) {
 		}
 		items = append(items, id)
 	}
-	if err := rows.Close(); err != nil {
-		return nil, err
-	}
 	if err := rows.Err(); err != nil {
 		return nil, err
 	}
@@ -53,9 +50,6 @@ func (q *Queries) ListCalories(ctx context.Context) ([]string, error) {
 			return nil, err
 		}
 		items = append(items, id)
-	}
-	if err := rows.Close(); err != nil {
-		return nil, err
 	}
 	if err := rows.Err(); err != nil {
 		return nil, err
@@ -81,9 +75,6 @@ func (q *Queries) ListCampuses(ctx context.Context) ([]string, error) {
 		}
 		items = append(items, id)
 	}
-	if err := rows.Close(); err != nil {
-		return nil, err
-	}
 	if err := rows.Err(); err != nil {
 		return nil, err
 	}
@@ -108,9 +99,6 @@ func (q *Queries) ListMetadata(ctx context.Context) ([]string, error) {
 		}
 		items = append(items, id)
 	}
-	if err := rows.Close(); err != nil {
-		return nil, err
-	}
 	if err := rows.Err(); err != nil {
 		return nil, err
 	}
@@ -134,9 +122,6 @@ func (q *Queries) ListStudents(ctx context.Context) ([]string, error) {
 			return nil, err
 		}
 		items = append(items, id)
-	}
-	if err := rows.Close(); err != nil {
-		return nil, err
 	}
 	if err := rows.Err(); err != nil {
 		return nil, err

--- a/internal/endtoend/testdata/interval/stdlib/go/query.sql.go
+++ b/internal/endtoend/testdata/interval/stdlib/go/query.sql.go
@@ -27,9 +27,6 @@ func (q *Queries) Get(ctx context.Context, limit int32) ([]Foo, error) {
 		}
 		items = append(items, i)
 	}
-	if err := rows.Close(); err != nil {
-		return nil, err
-	}
 	if err := rows.Err(); err != nil {
 		return nil, err
 	}

--- a/internal/endtoend/testdata/join_alias/mysql/go/query.sql.go
+++ b/internal/endtoend/testdata/join_alias/mysql/go/query.sql.go
@@ -37,9 +37,6 @@ func (q *Queries) AliasExpand(ctx context.Context, id uint64) ([]AliasExpandRow,
 		}
 		items = append(items, i)
 	}
-	if err := rows.Close(); err != nil {
-		return nil, err
-	}
 	if err := rows.Err(); err != nil {
 		return nil, err
 	}
@@ -71,9 +68,6 @@ func (q *Queries) AliasJoin(ctx context.Context, id uint64) ([]AliasJoinRow, err
 			return nil, err
 		}
 		items = append(items, i)
-	}
-	if err := rows.Close(); err != nil {
-		return nil, err
 	}
 	if err := rows.Err(); err != nil {
 		return nil, err

--- a/internal/endtoend/testdata/join_alias/postgresql/stdlib/go/query.sql.go
+++ b/internal/endtoend/testdata/join_alias/postgresql/stdlib/go/query.sql.go
@@ -37,9 +37,6 @@ func (q *Queries) AliasExpand(ctx context.Context, id int32) ([]AliasExpandRow, 
 		}
 		items = append(items, i)
 	}
-	if err := rows.Close(); err != nil {
-		return nil, err
-	}
 	if err := rows.Err(); err != nil {
 		return nil, err
 	}
@@ -71,9 +68,6 @@ func (q *Queries) AliasJoin(ctx context.Context, id int32) ([]AliasJoinRow, erro
 			return nil, err
 		}
 		items = append(items, i)
-	}
-	if err := rows.Close(); err != nil {
-		return nil, err
 	}
 	if err := rows.Err(); err != nil {
 		return nil, err

--- a/internal/endtoend/testdata/join_alias/sqlite/go/query.sql.go
+++ b/internal/endtoend/testdata/join_alias/sqlite/go/query.sql.go
@@ -37,9 +37,6 @@ func (q *Queries) AliasExpand(ctx context.Context, id int64) ([]AliasExpandRow, 
 		}
 		items = append(items, i)
 	}
-	if err := rows.Close(); err != nil {
-		return nil, err
-	}
 	if err := rows.Err(); err != nil {
 		return nil, err
 	}
@@ -71,9 +68,6 @@ func (q *Queries) AliasJoin(ctx context.Context, id int64) ([]AliasJoinRow, erro
 			return nil, err
 		}
 		items = append(items, i)
-	}
-	if err := rows.Close(); err != nil {
-		return nil, err
 	}
 	if err := rows.Err(); err != nil {
 		return nil, err

--- a/internal/endtoend/testdata/join_clauses_order/postgresql/go/query.sql.go
+++ b/internal/endtoend/testdata/join_clauses_order/postgresql/go/query.sql.go
@@ -37,9 +37,6 @@ func (q *Queries) TestInnerLeft(ctx context.Context) ([]TestInnerLeftRow, error)
 		}
 		items = append(items, i)
 	}
-	if err := rows.Close(); err != nil {
-		return nil, err
-	}
 	if err := rows.Err(); err != nil {
 		return nil, err
 	}
@@ -83,9 +80,6 @@ func (q *Queries) TestInnerLeftInnerLeft(ctx context.Context) ([]TestInnerLeftIn
 		}
 		items = append(items, i)
 	}
-	if err := rows.Close(); err != nil {
-		return nil, err
-	}
 	if err := rows.Err(); err != nil {
 		return nil, err
 	}
@@ -118,9 +112,6 @@ func (q *Queries) TestLeftInner(ctx context.Context) ([]TestLeftInnerRow, error)
 			return nil, err
 		}
 		items = append(items, i)
-	}
-	if err := rows.Close(); err != nil {
-		return nil, err
 	}
 	if err := rows.Err(); err != nil {
 		return nil, err
@@ -164,9 +155,6 @@ func (q *Queries) TestLeftInnerLeftInner(ctx context.Context) ([]TestLeftInnerLe
 			return nil, err
 		}
 		items = append(items, i)
-	}
-	if err := rows.Close(); err != nil {
-		return nil, err
 	}
 	if err := rows.Err(); err != nil {
 		return nil, err

--- a/internal/endtoend/testdata/join_from/mysql/go/query.sql.go
+++ b/internal/endtoend/testdata/join_from/mysql/go/query.sql.go
@@ -27,9 +27,6 @@ func (q *Queries) MultiFrom(ctx context.Context, login string) ([]string, error)
 		}
 		items = append(items, email)
 	}
-	if err := rows.Close(); err != nil {
-		return nil, err
-	}
 	if err := rows.Err(); err != nil {
 		return nil, err
 	}

--- a/internal/endtoend/testdata/join_from/postgresql/stdlib/go/query.sql.go
+++ b/internal/endtoend/testdata/join_from/postgresql/stdlib/go/query.sql.go
@@ -27,9 +27,6 @@ func (q *Queries) MultiFrom(ctx context.Context, login string) ([]string, error)
 		}
 		items = append(items, email)
 	}
-	if err := rows.Close(); err != nil {
-		return nil, err
-	}
 	if err := rows.Err(); err != nil {
 		return nil, err
 	}

--- a/internal/endtoend/testdata/join_from/sqlite/go/query.sql.go
+++ b/internal/endtoend/testdata/join_from/sqlite/go/query.sql.go
@@ -27,9 +27,6 @@ func (q *Queries) MultiFrom(ctx context.Context, login string) ([]string, error)
 		}
 		items = append(items, email)
 	}
-	if err := rows.Close(); err != nil {
-		return nil, err
-	}
 	if err := rows.Err(); err != nil {
 		return nil, err
 	}

--- a/internal/endtoend/testdata/join_full/postgresql/go/query.sql.go
+++ b/internal/endtoend/testdata/join_full/postgresql/go/query.sql.go
@@ -37,9 +37,6 @@ func (q *Queries) FullJoin(ctx context.Context, id int32) ([]FullJoinRow, error)
 		}
 		items = append(items, i)
 	}
-	if err := rows.Close(); err != nil {
-		return nil, err
-	}
 	if err := rows.Err(); err != nil {
 		return nil, err
 	}

--- a/internal/endtoend/testdata/join_group_by_alias/postgresql/stdlib/go/query.sql.go
+++ b/internal/endtoend/testdata/join_group_by_alias/postgresql/stdlib/go/query.sql.go
@@ -29,9 +29,6 @@ func (q *Queries) ColumnAsGroupBy(ctx context.Context) ([]string, error) {
 		}
 		items = append(items, id)
 	}
-	if err := rows.Close(); err != nil {
-		return nil, err
-	}
 	if err := rows.Err(); err != nil {
 		return nil, err
 	}

--- a/internal/endtoend/testdata/join_inner/postgresql/go/query.sql.go
+++ b/internal/endtoend/testdata/join_inner/postgresql/go/query.sql.go
@@ -32,9 +32,6 @@ func (q *Queries) SelectAllJoined(ctx context.Context, handler sql.NullString) (
 		}
 		items = append(items, id)
 	}
-	if err := rows.Close(); err != nil {
-		return nil, err
-	}
 	if err := rows.Err(); err != nil {
 		return nil, err
 	}
@@ -62,9 +59,6 @@ func (q *Queries) SelectAllJoinedAlias(ctx context.Context, handler sql.NullStri
 			return nil, err
 		}
 		items = append(items, id)
-	}
-	if err := rows.Close(); err != nil {
-		return nil, err
 	}
 	if err := rows.Err(); err != nil {
 		return nil, err

--- a/internal/endtoend/testdata/join_left/mysql/go/query.sql.go
+++ b/internal/endtoend/testdata/join_left/mysql/go/query.sql.go
@@ -48,9 +48,6 @@ func (q *Queries) AllAuthors(ctx context.Context) ([]AllAuthorsRow, error) {
 		}
 		items = append(items, i)
 	}
-	if err := rows.Close(); err != nil {
-		return nil, err
-	}
 	if err := rows.Err(); err != nil {
 		return nil, err
 	}
@@ -93,9 +90,6 @@ func (q *Queries) AllAuthorsAliases(ctx context.Context) ([]AllAuthorsAliasesRow
 			return nil, err
 		}
 		items = append(items, i)
-	}
-	if err := rows.Close(); err != nil {
-		return nil, err
 	}
 	if err := rows.Err(); err != nil {
 		return nil, err
@@ -140,9 +134,6 @@ func (q *Queries) AllAuthorsAliases2(ctx context.Context) ([]AllAuthorsAliases2R
 		}
 		items = append(items, i)
 	}
-	if err := rows.Close(); err != nil {
-		return nil, err
-	}
 	if err := rows.Err(); err != nil {
 		return nil, err
 	}
@@ -185,9 +176,6 @@ func (q *Queries) AllSuperAuthors(ctx context.Context) ([]AllSuperAuthorsRow, er
 			return nil, err
 		}
 		items = append(items, i)
-	}
-	if err := rows.Close(); err != nil {
-		return nil, err
 	}
 	if err := rows.Err(); err != nil {
 		return nil, err
@@ -232,9 +220,6 @@ func (q *Queries) AllSuperAuthorsAliases(ctx context.Context) ([]AllSuperAuthors
 		}
 		items = append(items, i)
 	}
-	if err := rows.Close(); err != nil {
-		return nil, err
-	}
 	if err := rows.Err(); err != nil {
 		return nil, err
 	}
@@ -278,9 +263,6 @@ func (q *Queries) AllSuperAuthorsAliases2(ctx context.Context) ([]AllSuperAuthor
 		}
 		items = append(items, i)
 	}
-	if err := rows.Close(); err != nil {
-		return nil, err
-	}
 	if err := rows.Err(); err != nil {
 		return nil, err
 	}
@@ -314,9 +296,6 @@ func (q *Queries) GetMayors(ctx context.Context) ([]GetMayorsRow, error) {
 			return nil, err
 		}
 		items = append(items, i)
-	}
-	if err := rows.Close(); err != nil {
-		return nil, err
 	}
 	if err := rows.Err(); err != nil {
 		return nil, err
@@ -353,9 +332,6 @@ func (q *Queries) GetMayorsOptional(ctx context.Context) ([]GetMayorsOptionalRow
 			return nil, err
 		}
 		items = append(items, i)
-	}
-	if err := rows.Close(); err != nil {
-		return nil, err
 	}
 	if err := rows.Err(); err != nil {
 		return nil, err
@@ -422,9 +398,6 @@ func (q *Queries) GetSuggestedUsersByID(ctx context.Context) ([]GetSuggestedUser
 			return nil, err
 		}
 		items = append(items, i)
-	}
-	if err := rows.Close(); err != nil {
-		return nil, err
 	}
 	if err := rows.Err(); err != nil {
 		return nil, err

--- a/internal/endtoend/testdata/join_left/postgresql/go/query.sql.go
+++ b/internal/endtoend/testdata/join_left/postgresql/go/query.sql.go
@@ -50,9 +50,6 @@ func (q *Queries) AllAuthors(ctx context.Context) ([]AllAuthorsRow, error) {
 		}
 		items = append(items, i)
 	}
-	if err := rows.Close(); err != nil {
-		return nil, err
-	}
 	if err := rows.Err(); err != nil {
 		return nil, err
 	}
@@ -95,9 +92,6 @@ func (q *Queries) AllAuthorsAliases(ctx context.Context) ([]AllAuthorsAliasesRow
 			return nil, err
 		}
 		items = append(items, i)
-	}
-	if err := rows.Close(); err != nil {
-		return nil, err
 	}
 	if err := rows.Err(); err != nil {
 		return nil, err
@@ -142,9 +136,6 @@ func (q *Queries) AllAuthorsAliases2(ctx context.Context) ([]AllAuthorsAliases2R
 		}
 		items = append(items, i)
 	}
-	if err := rows.Close(); err != nil {
-		return nil, err
-	}
 	if err := rows.Err(); err != nil {
 		return nil, err
 	}
@@ -187,9 +178,6 @@ func (q *Queries) AllSuperAuthors(ctx context.Context) ([]AllSuperAuthorsRow, er
 			return nil, err
 		}
 		items = append(items, i)
-	}
-	if err := rows.Close(); err != nil {
-		return nil, err
 	}
 	if err := rows.Err(); err != nil {
 		return nil, err
@@ -234,9 +222,6 @@ func (q *Queries) AllSuperAuthorsAliases(ctx context.Context) ([]AllSuperAuthors
 		}
 		items = append(items, i)
 	}
-	if err := rows.Close(); err != nil {
-		return nil, err
-	}
 	if err := rows.Err(); err != nil {
 		return nil, err
 	}
@@ -280,9 +265,6 @@ func (q *Queries) AllSuperAuthorsAliases2(ctx context.Context) ([]AllSuperAuthor
 		}
 		items = append(items, i)
 	}
-	if err := rows.Close(); err != nil {
-		return nil, err
-	}
 	if err := rows.Err(); err != nil {
 		return nil, err
 	}
@@ -317,9 +299,6 @@ func (q *Queries) GetMayors(ctx context.Context) ([]GetMayorsRow, error) {
 		}
 		items = append(items, i)
 	}
-	if err := rows.Close(); err != nil {
-		return nil, err
-	}
 	if err := rows.Err(); err != nil {
 		return nil, err
 	}
@@ -353,9 +332,6 @@ func (q *Queries) GetMayorsOptional(ctx context.Context) ([]GetMayorsOptionalRow
 			return nil, err
 		}
 		items = append(items, i)
-	}
-	if err := rows.Close(); err != nil {
-		return nil, err
 	}
 	if err := rows.Err(); err != nil {
 		return nil, err
@@ -428,9 +404,6 @@ func (q *Queries) GetSuggestedUsersByID(ctx context.Context, arg GetSuggestedUse
 			return nil, err
 		}
 		items = append(items, i)
-	}
-	if err := rows.Close(); err != nil {
-		return nil, err
 	}
 	if err := rows.Err(); err != nil {
 		return nil, err

--- a/internal/endtoend/testdata/join_left/sqlite/go/query.sql.go
+++ b/internal/endtoend/testdata/join_left/sqlite/go/query.sql.go
@@ -48,9 +48,6 @@ func (q *Queries) AllAuthors(ctx context.Context) ([]AllAuthorsRow, error) {
 		}
 		items = append(items, i)
 	}
-	if err := rows.Close(); err != nil {
-		return nil, err
-	}
 	if err := rows.Err(); err != nil {
 		return nil, err
 	}
@@ -93,9 +90,6 @@ func (q *Queries) AllAuthorsAliases(ctx context.Context) ([]AllAuthorsAliasesRow
 			return nil, err
 		}
 		items = append(items, i)
-	}
-	if err := rows.Close(); err != nil {
-		return nil, err
 	}
 	if err := rows.Err(); err != nil {
 		return nil, err
@@ -140,9 +134,6 @@ func (q *Queries) AllAuthorsAliases2(ctx context.Context) ([]AllAuthorsAliases2R
 		}
 		items = append(items, i)
 	}
-	if err := rows.Close(); err != nil {
-		return nil, err
-	}
 	if err := rows.Err(); err != nil {
 		return nil, err
 	}
@@ -185,9 +176,6 @@ func (q *Queries) AllSuperAuthors(ctx context.Context) ([]AllSuperAuthorsRow, er
 			return nil, err
 		}
 		items = append(items, i)
-	}
-	if err := rows.Close(); err != nil {
-		return nil, err
 	}
 	if err := rows.Err(); err != nil {
 		return nil, err
@@ -232,9 +220,6 @@ func (q *Queries) AllSuperAuthorsAliases(ctx context.Context) ([]AllSuperAuthors
 		}
 		items = append(items, i)
 	}
-	if err := rows.Close(); err != nil {
-		return nil, err
-	}
 	if err := rows.Err(); err != nil {
 		return nil, err
 	}
@@ -278,9 +263,6 @@ func (q *Queries) AllSuperAuthorsAliases2(ctx context.Context) ([]AllSuperAuthor
 		}
 		items = append(items, i)
 	}
-	if err := rows.Close(); err != nil {
-		return nil, err
-	}
 	if err := rows.Err(); err != nil {
 		return nil, err
 	}
@@ -314,9 +296,6 @@ func (q *Queries) GetMayors(ctx context.Context) ([]GetMayorsRow, error) {
 			return nil, err
 		}
 		items = append(items, i)
-	}
-	if err := rows.Close(); err != nil {
-		return nil, err
 	}
 	if err := rows.Err(); err != nil {
 		return nil, err
@@ -353,9 +332,6 @@ func (q *Queries) GetMayorsOptional(ctx context.Context) ([]GetMayorsOptionalRow
 			return nil, err
 		}
 		items = append(items, i)
-	}
-	if err := rows.Close(); err != nil {
-		return nil, err
 	}
 	if err := rows.Err(); err != nil {
 		return nil, err
@@ -423,9 +399,6 @@ func (q *Queries) GetSuggestedUsersByID(ctx context.Context, userID int64) ([]Ge
 		}
 		items = append(items, i)
 	}
-	if err := rows.Close(); err != nil {
-		return nil, err
-	}
 	if err := rows.Err(); err != nil {
 		return nil, err
 	}
@@ -453,9 +426,6 @@ func (q *Queries) GetSuggestedUsersByID2(ctx context.Context, userID int64) ([]i
 			return nil, err
 		}
 		items = append(items, user_id)
-	}
-	if err := rows.Close(); err != nil {
-		return nil, err
 	}
 	if err := rows.Err(); err != nil {
 		return nil, err

--- a/internal/endtoend/testdata/join_left_same_table/mysql/go/query.sql.go
+++ b/internal/endtoend/testdata/join_left_same_table/mysql/go/query.sql.go
@@ -46,9 +46,6 @@ func (q *Queries) AllAuthors(ctx context.Context) ([]AllAuthorsRow, error) {
 		}
 		items = append(items, i)
 	}
-	if err := rows.Close(); err != nil {
-		return nil, err
-	}
 	if err := rows.Err(); err != nil {
 		return nil, err
 	}

--- a/internal/endtoend/testdata/join_left_same_table/postgres/go/query.sql.go
+++ b/internal/endtoend/testdata/join_left_same_table/postgres/go/query.sql.go
@@ -45,9 +45,6 @@ func (q *Queries) AllAuthors(ctx context.Context) ([]AllAuthorsRow, error) {
 		}
 		items = append(items, i)
 	}
-	if err := rows.Close(); err != nil {
-		return nil, err
-	}
 	if err := rows.Err(); err != nil {
 		return nil, err
 	}

--- a/internal/endtoend/testdata/join_left_same_table/sqlite/go/query.sql.go
+++ b/internal/endtoend/testdata/join_left_same_table/sqlite/go/query.sql.go
@@ -46,9 +46,6 @@ func (q *Queries) AllAuthors(ctx context.Context) ([]AllAuthorsRow, error) {
 		}
 		items = append(items, i)
 	}
-	if err := rows.Close(); err != nil {
-		return nil, err
-	}
 	if err := rows.Err(); err != nil {
 		return nil, err
 	}

--- a/internal/endtoend/testdata/join_order_by/postgresql/pgx/sqlc.yaml
+++ b/internal/endtoend/testdata/join_order_by/postgresql/pgx/sqlc.yaml
@@ -3,6 +3,7 @@ sql:
   - engine: "postgresql"
     schema: "schema.sql"
     queries: "query.sql"
+    strict_order_by: false
     gen:
       go:
         package: "querytest"

--- a/internal/endtoend/testdata/join_order_by_alias/postgresql/stdlib/go/query.sql.go
+++ b/internal/endtoend/testdata/join_order_by_alias/postgresql/stdlib/go/query.sql.go
@@ -29,9 +29,6 @@ func (q *Queries) ColumnAsOrderBy(ctx context.Context) ([]string, error) {
 		}
 		items = append(items, id)
 	}
-	if err := rows.Close(); err != nil {
-		return nil, err
-	}
 	if err := rows.Err(); err != nil {
 		return nil, err
 	}

--- a/internal/endtoend/testdata/join_right/mysql/go/query.sql.go
+++ b/internal/endtoend/testdata/join_right/mysql/go/query.sql.go
@@ -37,9 +37,6 @@ func (q *Queries) RightJoin(ctx context.Context, id int32) ([]RightJoinRow, erro
 		}
 		items = append(items, i)
 	}
-	if err := rows.Close(); err != nil {
-		return nil, err
-	}
 	if err := rows.Err(); err != nil {
 		return nil, err
 	}

--- a/internal/endtoend/testdata/join_right/postgresql/go/query.sql.go
+++ b/internal/endtoend/testdata/join_right/postgresql/go/query.sql.go
@@ -37,9 +37,6 @@ func (q *Queries) RightJoin(ctx context.Context, id int32) ([]RightJoinRow, erro
 		}
 		items = append(items, i)
 	}
-	if err := rows.Close(); err != nil {
-		return nil, err
-	}
 	if err := rows.Err(); err != nil {
 		return nil, err
 	}

--- a/internal/endtoend/testdata/join_two_tables/mysql/go/query.sql.go
+++ b/internal/endtoend/testdata/join_two_tables/mysql/go/query.sql.go
@@ -30,9 +30,6 @@ func (q *Queries) TwoJoins(ctx context.Context) ([]Foo, error) {
 		}
 		items = append(items, i)
 	}
-	if err := rows.Close(); err != nil {
-		return nil, err
-	}
 	if err := rows.Err(); err != nil {
 		return nil, err
 	}

--- a/internal/endtoend/testdata/join_two_tables/postgresql/stdlib/go/query.sql.go
+++ b/internal/endtoend/testdata/join_two_tables/postgresql/stdlib/go/query.sql.go
@@ -30,9 +30,6 @@ func (q *Queries) TwoJoins(ctx context.Context) ([]Foo, error) {
 		}
 		items = append(items, i)
 	}
-	if err := rows.Close(); err != nil {
-		return nil, err
-	}
 	if err := rows.Err(); err != nil {
 		return nil, err
 	}

--- a/internal/endtoend/testdata/join_two_tables/sqlite/go/query.sql.go
+++ b/internal/endtoend/testdata/join_two_tables/sqlite/go/query.sql.go
@@ -30,9 +30,6 @@ func (q *Queries) TwoJoins(ctx context.Context) ([]Foo, error) {
 		}
 		items = append(items, i)
 	}
-	if err := rows.Close(); err != nil {
-		return nil, err
-	}
 	if err := rows.Err(); err != nil {
 		return nil, err
 	}

--- a/internal/endtoend/testdata/join_where_clause/mysql/go/query.sql.go
+++ b/internal/endtoend/testdata/join_where_clause/mysql/go/query.sql.go
@@ -35,9 +35,6 @@ func (q *Queries) JoinNoConstraints(ctx context.Context, arg JoinNoConstraintsPa
 		}
 		items = append(items, barid)
 	}
-	if err := rows.Close(); err != nil {
-		return nil, err
-	}
 	if err := rows.Err(); err != nil {
 		return nil, err
 	}
@@ -70,9 +67,6 @@ func (q *Queries) JoinParamWhereClause(ctx context.Context, arg JoinParamWhereCl
 		}
 		items = append(items, barid)
 	}
-	if err := rows.Close(); err != nil {
-		return nil, err
-	}
 	if err := rows.Err(); err != nil {
 		return nil, err
 	}
@@ -99,9 +93,6 @@ func (q *Queries) JoinWhereClause(ctx context.Context, owner string) ([]uint64, 
 			return nil, err
 		}
 		items = append(items, barid)
-	}
-	if err := rows.Close(); err != nil {
-		return nil, err
 	}
 	if err := rows.Err(); err != nil {
 		return nil, err

--- a/internal/endtoend/testdata/join_where_clause/postgresql/stdlib/go/query.sql.go
+++ b/internal/endtoend/testdata/join_where_clause/postgresql/stdlib/go/query.sql.go
@@ -35,9 +35,6 @@ func (q *Queries) JoinNoConstraints(ctx context.Context, arg JoinNoConstraintsPa
 		}
 		items = append(items, barid)
 	}
-	if err := rows.Close(); err != nil {
-		return nil, err
-	}
 	if err := rows.Err(); err != nil {
 		return nil, err
 	}
@@ -70,9 +67,6 @@ func (q *Queries) JoinParamWhereClause(ctx context.Context, arg JoinParamWhereCl
 		}
 		items = append(items, barid)
 	}
-	if err := rows.Close(); err != nil {
-		return nil, err
-	}
 	if err := rows.Err(); err != nil {
 		return nil, err
 	}
@@ -99,9 +93,6 @@ func (q *Queries) JoinWhereClause(ctx context.Context, owner string) ([]int32, e
 			return nil, err
 		}
 		items = append(items, barid)
-	}
-	if err := rows.Close(); err != nil {
-		return nil, err
 	}
 	if err := rows.Err(); err != nil {
 		return nil, err

--- a/internal/endtoend/testdata/join_where_clause/sqlite/go/query.sql.go
+++ b/internal/endtoend/testdata/join_where_clause/sqlite/go/query.sql.go
@@ -35,9 +35,6 @@ func (q *Queries) JoinNoConstraints(ctx context.Context, arg JoinNoConstraintsPa
 		}
 		items = append(items, barid)
 	}
-	if err := rows.Close(); err != nil {
-		return nil, err
-	}
 	if err := rows.Err(); err != nil {
 		return nil, err
 	}
@@ -70,9 +67,6 @@ func (q *Queries) JoinParamWhereClause(ctx context.Context, arg JoinParamWhereCl
 		}
 		items = append(items, barid)
 	}
-	if err := rows.Close(); err != nil {
-		return nil, err
-	}
 	if err := rows.Err(); err != nil {
 		return nil, err
 	}
@@ -99,9 +93,6 @@ func (q *Queries) JoinWhereClause(ctx context.Context, owner string) ([]int64, e
 			return nil, err
 		}
 		items = append(items, barid)
-	}
-	if err := rows.Close(); err != nil {
-		return nil, err
 	}
 	if err := rows.Err(); err != nil {
 		return nil, err

--- a/internal/endtoend/testdata/json_param_type/postgresql/pgx/go/query.sql.go
+++ b/internal/endtoend/testdata/json_param_type/postgresql/pgx/go/query.sql.go
@@ -7,15 +7,13 @@ package querytest
 
 import (
 	"context"
-
-	"github.com/jackc/pgx/v5/pgtype"
 )
 
 const findByAddress = `-- name: FindByAddress :one
 SELECT id, metadata FROM "user" WHERE "metadata"->>'address1' = $1 LIMIT 1
 `
 
-func (q *Queries) FindByAddress(ctx context.Context, metadata pgtype.Text) (User, error) {
+func (q *Queries) FindByAddress(ctx context.Context, metadata []byte) (User, error) {
 	row := q.db.QueryRow(ctx, findByAddress, metadata)
 	var i User
 	err := row.Scan(&i.ID, &i.Metadata)

--- a/internal/endtoend/testdata/json_tags/camel_case/postgresql/stdlib/go/query.sql.go
+++ b/internal/endtoend/testdata/json_tags/camel_case/postgresql/stdlib/go/query.sql.go
@@ -27,9 +27,6 @@ func (q *Queries) GetAll(ctx context.Context) ([]User, error) {
 		}
 		items = append(items, i)
 	}
-	if err := rows.Close(); err != nil {
-		return nil, err
-	}
 	if err := rows.Err(); err != nil {
 		return nil, err
 	}

--- a/internal/endtoend/testdata/json_tags/pascal_case/postgresql/stdlib/go/query.sql.go
+++ b/internal/endtoend/testdata/json_tags/pascal_case/postgresql/stdlib/go/query.sql.go
@@ -27,9 +27,6 @@ func (q *Queries) GetAll(ctx context.Context) ([]User, error) {
 		}
 		items = append(items, i)
 	}
-	if err := rows.Close(); err != nil {
-		return nil, err
-	}
 	if err := rows.Err(); err != nil {
 		return nil, err
 	}

--- a/internal/endtoend/testdata/json_tags/snake_case/postgresql/stdlib/go/query.sql.go
+++ b/internal/endtoend/testdata/json_tags/snake_case/postgresql/stdlib/go/query.sql.go
@@ -27,9 +27,6 @@ func (q *Queries) GetAll(ctx context.Context) ([]User, error) {
 		}
 		items = append(items, i)
 	}
-	if err := rows.Close(); err != nil {
-		return nil, err
-	}
 	if err := rows.Err(); err != nil {
 		return nil, err
 	}

--- a/internal/endtoend/testdata/limit/sqlite/go/query.sql.go
+++ b/internal/endtoend/testdata/limit/sqlite/go/query.sql.go
@@ -36,9 +36,6 @@ func (q *Queries) LimitMe(ctx context.Context, limit int64) ([]bool, error) {
 		}
 		items = append(items, bar)
 	}
-	if err := rows.Close(); err != nil {
-		return nil, err
-	}
 	if err := rows.Err(); err != nil {
 		return nil, err
 	}

--- a/internal/endtoend/testdata/limit/stdlib/go/query.sql.go
+++ b/internal/endtoend/testdata/limit/stdlib/go/query.sql.go
@@ -27,9 +27,6 @@ func (q *Queries) LimitMe(ctx context.Context, limit int32) ([]bool, error) {
 		}
 		items = append(items, bar)
 	}
-	if err := rows.Close(); err != nil {
-		return nil, err
-	}
 	if err := rows.Err(); err != nil {
 		return nil, err
 	}

--- a/internal/endtoend/testdata/lower/stdlib/go/query.sql.go
+++ b/internal/endtoend/testdata/lower/stdlib/go/query.sql.go
@@ -32,9 +32,6 @@ func (q *Queries) Lower(ctx context.Context, arg LowerParams) ([]string, error) 
 		}
 		items = append(items, bar)
 	}
-	if err := rows.Close(); err != nil {
-		return nil, err
-	}
 	if err := rows.Err(); err != nil {
 		return nil, err
 	}

--- a/internal/endtoend/testdata/lower_switched_order/stdlib/go/query.sql.go
+++ b/internal/endtoend/testdata/lower_switched_order/stdlib/go/query.sql.go
@@ -32,9 +32,6 @@ func (q *Queries) LowerSwitchedOrder(ctx context.Context, arg LowerSwitchedOrder
 		}
 		items = append(items, bar)
 	}
-	if err := rows.Close(); err != nil {
-		return nil, err
-	}
 	if err := rows.Err(); err != nil {
 		return nil, err
 	}

--- a/internal/endtoend/testdata/materialized_views/postgresql/stdlib/go/query.sql.go
+++ b/internal/endtoend/testdata/materialized_views/postgresql/stdlib/go/query.sql.go
@@ -32,9 +32,6 @@ func (q *Queries) ListAuthors(ctx context.Context) ([]Author, error) {
 		}
 		items = append(items, i)
 	}
-	if err := rows.Close(); err != nil {
-		return nil, err
-	}
 	if err := rows.Err(); err != nil {
 		return nil, err
 	}

--- a/internal/endtoend/testdata/mathmatical_operator/stdlib/go/query.sql.go
+++ b/internal/endtoend/testdata/mathmatical_operator/stdlib/go/query.sql.go
@@ -32,9 +32,6 @@ func (q *Queries) Math(ctx context.Context) ([]MathRow, error) {
 		}
 		items = append(items, i)
 	}
-	if err := rows.Close(); err != nil {
-		return nil, err
-	}
 	if err := rows.Err(); err != nil {
 		return nil, err
 	}

--- a/internal/endtoend/testdata/min_max_date/postgresql/pgx/go/query.sql.go
+++ b/internal/endtoend/testdata/min_max_date/postgresql/pgx/go/query.sql.go
@@ -7,8 +7,6 @@ package querytest
 
 import (
 	"context"
-
-	"github.com/jackc/pgx/v5/pgtype"
 )
 
 const activityStats = `-- name: ActivityStats :one
@@ -21,8 +19,8 @@ WHERE account_id = $1
 
 type ActivityStatsRow struct {
 	Numofactivities int64
-	Mindate         pgtype.Timestamptz
-	Maxdate         pgtype.Timestamptz
+	Mindate         interface{}
+	Maxdate         interface{}
 }
 
 func (q *Queries) ActivityStats(ctx context.Context, accountID int64) (ActivityStatsRow, error) {

--- a/internal/endtoend/testdata/multidimension_array/stdlib/go/query.sql.go
+++ b/internal/endtoend/testdata/multidimension_array/stdlib/go/query.sql.go
@@ -29,9 +29,6 @@ func (q *Queries) TextArray(ctx context.Context) ([][][]string, error) {
 		}
 		items = append(items, tags)
 	}
-	if err := rows.Close(); err != nil {
-		return nil, err
-	}
 	if err := rows.Err(); err != nil {
 		return nil, err
 	}

--- a/internal/endtoend/testdata/multischema/stdlib/go/query.sql.go
+++ b/internal/endtoend/testdata/multischema/stdlib/go/query.sql.go
@@ -27,9 +27,6 @@ func (q *Queries) ListBar(ctx context.Context) ([]int32, error) {
 		}
 		items = append(items, id)
 	}
-	if err := rows.Close(); err != nil {
-		return nil, err
-	}
 	if err := rows.Err(); err != nil {
 		return nil, err
 	}
@@ -53,9 +50,6 @@ func (q *Queries) ListFoo(ctx context.Context) ([]Foo, error) {
 			return nil, err
 		}
 		items = append(items, i)
-	}
-	if err := rows.Close(); err != nil {
-		return nil, err
 	}
 	if err := rows.Err(); err != nil {
 		return nil, err

--- a/internal/endtoend/testdata/mysql_reference_manual/aggregate_functions/go/group_concat.sql.go
+++ b/internal/endtoend/testdata/mysql_reference_manual/aggregate_functions/go/group_concat.sql.go
@@ -35,9 +35,6 @@ func (q *Queries) GroupConcat(ctx context.Context) ([]GroupConcatRow, error) {
 		}
 		items = append(items, i)
 	}
-	if err := rows.Close(); err != nil {
-		return nil, err
-	}
 	if err := rows.Err(); err != nil {
 		return nil, err
 	}
@@ -69,9 +66,6 @@ func (q *Queries) GroupConcatOrderBy(ctx context.Context) ([]GroupConcatOrderByR
 			return nil, err
 		}
 		items = append(items, i)
-	}
-	if err := rows.Close(); err != nil {
-		return nil, err
 	}
 	if err := rows.Err(); err != nil {
 		return nil, err

--- a/internal/endtoend/testdata/mysql_vector/mysql/go/query.sql.go
+++ b/internal/endtoend/testdata/mysql_vector/mysql/go/query.sql.go
@@ -38,9 +38,6 @@ func (q *Queries) SelectVector(ctx context.Context) ([]int32, error) {
 		}
 		items = append(items, id)
 	}
-	if err := rows.Close(); err != nil {
-		return nil, err
-	}
 	if err := rows.Err(); err != nil {
 		return nil, err
 	}

--- a/internal/endtoend/testdata/named_param/sqlite/go/query.sql.go
+++ b/internal/endtoend/testdata/named_param/sqlite/go/query.sql.go
@@ -27,9 +27,6 @@ func (q *Queries) AtParams(ctx context.Context, slug string) ([]string, error) {
 		}
 		items = append(items, name)
 	}
-	if err := rows.Close(); err != nil {
-		return nil, err
-	}
 	if err := rows.Err(); err != nil {
 		return nil, err
 	}
@@ -53,9 +50,6 @@ func (q *Queries) FuncParams(ctx context.Context, slug string) ([]string, error)
 			return nil, err
 		}
 		items = append(items, name)
-	}
-	if err := rows.Close(); err != nil {
-		return nil, err
 	}
 	if err := rows.Err(); err != nil {
 		return nil, err

--- a/internal/endtoend/testdata/named_param/stdlib/go/query.sql.go
+++ b/internal/endtoend/testdata/named_param/stdlib/go/query.sql.go
@@ -32,9 +32,6 @@ func (q *Queries) AtParams(ctx context.Context, arg AtParamsParams) ([]string, e
 		}
 		items = append(items, name)
 	}
-	if err := rows.Close(); err != nil {
-		return nil, err
-	}
 	if err := rows.Err(); err != nil {
 		return nil, err
 	}
@@ -63,9 +60,6 @@ func (q *Queries) FuncParams(ctx context.Context, arg FuncParamsParams) ([]strin
 			return nil, err
 		}
 		items = append(items, name)
-	}
-	if err := rows.Close(); err != nil {
-		return nil, err
 	}
 	if err := rows.Err(); err != nil {
 		return nil, err

--- a/internal/endtoend/testdata/null_if_type/postgresql/pganalyzer/db/query.sql.go
+++ b/internal/endtoend/testdata/null_if_type/postgresql/pganalyzer/db/query.sql.go
@@ -16,9 +16,9 @@ FROM
   author
 `
 
-func (q *Queries) GetRestrictedId(ctx context.Context, id int64) (int64, error) {
+func (q *Queries) GetRestrictedId(ctx context.Context, id int64) (bool, error) {
 	row := q.db.QueryRowContext(ctx, getRestrictedId, id)
-	var restricted_id int64
+	var restricted_id bool
 	err := row.Scan(&restricted_id)
 	return restricted_id, err
 }

--- a/internal/endtoend/testdata/omit_sqlc_version/db/query.sql.go
+++ b/internal/endtoend/testdata/omit_sqlc_version/db/query.sql.go
@@ -70,9 +70,6 @@ func (q *Queries) ListAuthors(ctx context.Context) ([]Author, error) {
 		}
 		items = append(items, i)
 	}
-	if err := rows.Close(); err != nil {
-		return nil, err
-	}
 	if err := rows.Err(); err != nil {
 		return nil, err
 	}

--- a/internal/endtoend/testdata/omit_unused_structs/postgresql/stdlib/go/query.sql.go
+++ b/internal/endtoend/testdata/omit_unused_structs/postgresql/stdlib/go/query.sql.go
@@ -66,9 +66,6 @@ func (q *Queries) query_return_full_table(ctx context.Context) ([]QueryReturnFul
 		}
 		items = append(items, i)
 	}
-	if err := rows.Close(); err != nil {
-		return nil, err
-	}
 	if err := rows.Err(); err != nil {
 		return nil, err
 	}

--- a/internal/endtoend/testdata/order_by_binds/mysql/go/query.sql.go
+++ b/internal/endtoend/testdata/order_by_binds/mysql/go/query.sql.go
@@ -34,9 +34,6 @@ func (q *Queries) ListAuthorsColumnSort(ctx context.Context, arg ListAuthorsColu
 		}
 		items = append(items, i)
 	}
-	if err := rows.Close(); err != nil {
-		return nil, err
-	}
 	if err := rows.Err(); err != nil {
 		return nil, err
 	}
@@ -61,9 +58,6 @@ func (q *Queries) ListAuthorsColumnSortFnWtihArg(ctx context.Context, modArg int
 			return nil, err
 		}
 		items = append(items, i)
-	}
-	if err := rows.Close(); err != nil {
-		return nil, err
 	}
 	if err := rows.Err(); err != nil {
 		return nil, err
@@ -90,9 +84,6 @@ func (q *Queries) ListAuthorsNameSort(ctx context.Context, minID int64) ([]Autho
 			return nil, err
 		}
 		items = append(items, i)
-	}
-	if err := rows.Close(); err != nil {
-		return nil, err
 	}
 	if err := rows.Err(); err != nil {
 		return nil, err

--- a/internal/endtoend/testdata/order_by_binds/pganalyze/go/query.sql.go
+++ b/internal/endtoend/testdata/order_by_binds/pganalyze/go/query.sql.go
@@ -7,7 +7,6 @@ package querytest
 
 import (
 	"context"
-	"database/sql"
 )
 
 const listAuthorsColumnSort = `-- name: ListAuthorsColumnSort :many
@@ -18,7 +17,7 @@ ORDER   BY CASE WHEN $2 = 'name' THEN name END
 
 type ListAuthorsColumnSortParams struct {
 	MinID      int64
-	SortColumn sql.NullString
+	SortColumn interface{}
 }
 
 func (q *Queries) ListAuthorsColumnSort(ctx context.Context, arg ListAuthorsColumnSortParams) ([]Author, error) {
@@ -34,9 +33,6 @@ func (q *Queries) ListAuthorsColumnSort(ctx context.Context, arg ListAuthorsColu
 			return nil, err
 		}
 		items = append(items, i)
-	}
-	if err := rows.Close(); err != nil {
-		return nil, err
 	}
 	if err := rows.Err(); err != nil {
 		return nil, err
@@ -63,9 +59,6 @@ func (q *Queries) ListAuthorsNameSort(ctx context.Context, minID int64) ([]Autho
 			return nil, err
 		}
 		items = append(items, i)
-	}
-	if err := rows.Close(); err != nil {
-		return nil, err
 	}
 	if err := rows.Err(); err != nil {
 		return nil, err

--- a/internal/endtoend/testdata/order_by_binds/postgresql/go/query.sql.go
+++ b/internal/endtoend/testdata/order_by_binds/postgresql/go/query.sql.go
@@ -34,9 +34,6 @@ func (q *Queries) ListAuthorsColumnSort(ctx context.Context, arg ListAuthorsColu
 		}
 		items = append(items, i)
 	}
-	if err := rows.Close(); err != nil {
-		return nil, err
-	}
 	if err := rows.Err(); err != nil {
 		return nil, err
 	}
@@ -61,9 +58,6 @@ func (q *Queries) ListAuthorsColumnSortFnWtihArg(ctx context.Context, mod int64)
 			return nil, err
 		}
 		items = append(items, i)
-	}
-	if err := rows.Close(); err != nil {
-		return nil, err
 	}
 	if err := rows.Err(); err != nil {
 		return nil, err
@@ -90,9 +84,6 @@ func (q *Queries) ListAuthorsNameSort(ctx context.Context, minID int64) ([]Autho
 			return nil, err
 		}
 		items = append(items, i)
-	}
-	if err := rows.Close(); err != nil {
-		return nil, err
 	}
 	if err := rows.Err(); err != nil {
 		return nil, err

--- a/internal/endtoend/testdata/order_by_union/mysql/go/query.sql.go
+++ b/internal/endtoend/testdata/order_by_union/mysql/go/query.sql.go
@@ -30,9 +30,6 @@ func (q *Queries) ListAuthorsUnion(ctx context.Context) ([]string, error) {
 		}
 		items = append(items, foo)
 	}
-	if err := rows.Close(); err != nil {
-		return nil, err
-	}
 	if err := rows.Err(); err != nil {
 		return nil, err
 	}

--- a/internal/endtoend/testdata/order_by_union/postgresql/go/query.sql.go
+++ b/internal/endtoend/testdata/order_by_union/postgresql/go/query.sql.go
@@ -30,9 +30,6 @@ func (q *Queries) ListAuthorsUnion(ctx context.Context) ([]string, error) {
 		}
 		items = append(items, foo)
 	}
-	if err := rows.Close(); err != nil {
-		return nil, err
-	}
 	if err := rows.Err(); err != nil {
 		return nil, err
 	}

--- a/internal/endtoend/testdata/output_file_names/stdlib/go/query.sql.go
+++ b/internal/endtoend/testdata/output_file_names/stdlib/go/query.sql.go
@@ -27,9 +27,6 @@ func (q *Queries) User(ctx context.Context) ([]int64, error) {
 		}
 		items = append(items, id)
 	}
-	if err := rows.Close(); err != nil {
-		return nil, err
-	}
 	if err := rows.Err(); err != nil {
 		return nil, err
 	}

--- a/internal/endtoend/testdata/output_files_suffix/stdlib/go/query.sql_gen.go
+++ b/internal/endtoend/testdata/output_files_suffix/stdlib/go/query.sql_gen.go
@@ -27,9 +27,6 @@ func (q *Queries) User(ctx context.Context) ([]int64, error) {
 		}
 		items = append(items, id)
 	}
-	if err := rows.Close(); err != nil {
-		return nil, err
-	}
 	if err := rows.Err(); err != nil {
 		return nil, err
 	}

--- a/internal/endtoend/testdata/overrides_go_types/mysql/go/query.sql.go
+++ b/internal/endtoend/testdata/overrides_go_types/mysql/go/query.sql.go
@@ -40,9 +40,6 @@ func (q *Queries) TestIN(ctx context.Context, paramname []pkg.CustomType) ([]Foo
 		}
 		items = append(items, i)
 	}
-	if err := rows.Close(); err != nil {
-		return nil, err
-	}
 	if err := rows.Err(); err != nil {
 		return nil, err
 	}

--- a/internal/endtoend/testdata/overrides_go_types/postgresql/stdlib/go/query.sql.go
+++ b/internal/endtoend/testdata/overrides_go_types/postgresql/stdlib/go/query.sql.go
@@ -36,9 +36,6 @@ func (q *Queries) LoadFoo(ctx context.Context, id uuid.UUID) ([]Foo, error) {
 		}
 		items = append(items, i)
 	}
-	if err := rows.Close(); err != nil {
-		return nil, err
-	}
 	if err := rows.Err(); err != nil {
 		return nil, err
 	}

--- a/internal/endtoend/testdata/overrides_nullable/postgresql/stdlib/go/query.sql.go
+++ b/internal/endtoend/testdata/overrides_nullable/postgresql/stdlib/go/query.sql.go
@@ -27,9 +27,6 @@ func (q *Queries) ListFoo(ctx context.Context) ([]Foo, error) {
 		}
 		items = append(items, i)
 	}
-	if err := rows.Close(); err != nil {
-		return nil, err
-	}
 	if err := rows.Err(); err != nil {
 		return nil, err
 	}

--- a/internal/endtoend/testdata/overrides_unsigned/mysql/go/query.sql.go
+++ b/internal/endtoend/testdata/overrides_unsigned/mysql/go/query.sql.go
@@ -81,9 +81,6 @@ func (q *Queries) ListAuthors(ctx context.Context) ([]Author, error) {
 		}
 		items = append(items, i)
 	}
-	if err := rows.Close(); err != nil {
-		return nil, err
-	}
 	if err := rows.Err(); err != nil {
 		return nil, err
 	}

--- a/internal/endtoend/testdata/params_duplicate/mysql/go/query.sql.go
+++ b/internal/endtoend/testdata/params_duplicate/mysql/go/query.sql.go
@@ -33,9 +33,6 @@ func (q *Queries) SelectUserByID(ctx context.Context, arg SelectUserByIDParams) 
 		}
 		items = append(items, first_name)
 	}
-	if err := rows.Close(); err != nil {
-		return nil, err
-	}
 	if err := rows.Err(); err != nil {
 		return nil, err
 	}
@@ -67,9 +64,6 @@ func (q *Queries) SelectUserByName(ctx context.Context, arg SelectUserByNamePara
 		}
 		items = append(items, first_name)
 	}
-	if err := rows.Close(); err != nil {
-		return nil, err
-	}
 	if err := rows.Err(); err != nil {
 		return nil, err
 	}
@@ -99,9 +93,6 @@ func (q *Queries) SelectUserQuestion(ctx context.Context, arg SelectUserQuestion
 			return nil, err
 		}
 		items = append(items, first_name)
-	}
-	if err := rows.Close(); err != nil {
-		return nil, err
 	}
 	if err := rows.Err(); err != nil {
 		return nil, err

--- a/internal/endtoend/testdata/params_duplicate/postgresql/go/query.sql.go
+++ b/internal/endtoend/testdata/params_duplicate/postgresql/go/query.sql.go
@@ -29,9 +29,6 @@ func (q *Queries) SelectUserByID(ctx context.Context, id int32) ([]sql.NullStrin
 		}
 		items = append(items, first_name)
 	}
-	if err := rows.Close(); err != nil {
-		return nil, err
-	}
 	if err := rows.Err(); err != nil {
 		return nil, err
 	}
@@ -59,9 +56,6 @@ func (q *Queries) SelectUserByName(ctx context.Context, name sql.NullString) ([]
 		}
 		items = append(items, first_name)
 	}
-	if err := rows.Close(); err != nil {
-		return nil, err
-	}
 	if err := rows.Err(); err != nil {
 		return nil, err
 	}
@@ -86,9 +80,6 @@ func (q *Queries) SelectUserQuestion(ctx context.Context, id int32) ([]sql.NullS
 			return nil, err
 		}
 		items = append(items, first_name)
-	}
-	if err := rows.Close(); err != nil {
-		return nil, err
 	}
 	if err := rows.Err(); err != nil {
 		return nil, err

--- a/internal/endtoend/testdata/params_in_nested_func/mysql/db/query.sql.go
+++ b/internal/endtoend/testdata/params_in_nested_func/mysql/db/query.sql.go
@@ -45,9 +45,6 @@ func (q *Queries) GetGroups(ctx context.Context, arg GetGroupsParams) ([]GetGrou
 		}
 		items = append(items, i)
 	}
-	if err := rows.Close(); err != nil {
-		return nil, err
-	}
 	if err := rows.Err(); err != nil {
 		return nil, err
 	}

--- a/internal/endtoend/testdata/params_in_nested_func/postgresql/db/query.sql.go
+++ b/internal/endtoend/testdata/params_in_nested_func/postgresql/db/query.sql.go
@@ -45,9 +45,6 @@ func (q *Queries) GetGroups(ctx context.Context, arg GetGroupsParams) ([]GetGrou
 		}
 		items = append(items, i)
 	}
-	if err := rows.Close(); err != nil {
-		return nil, err
-	}
 	if err := rows.Err(); err != nil {
 		return nil, err
 	}

--- a/internal/endtoend/testdata/params_location/mysql/go/query.sql.go
+++ b/internal/endtoend/testdata/params_location/mysql/go/query.sql.go
@@ -64,9 +64,6 @@ func (q *Queries) LimitSQLCArg(ctx context.Context, limit int32) ([]LimitSQLCArg
 		}
 		items = append(items, i)
 	}
-	if err := rows.Close(); err != nil {
-		return nil, err
-	}
 	if err := rows.Err(); err != nil {
 		return nil, err
 	}
@@ -103,9 +100,6 @@ func (q *Queries) ListUserOrders(ctx context.Context, minPrice string) ([]ListUs
 			return nil, err
 		}
 		items = append(items, i)
-	}
-	if err := rows.Close(); err != nil {
-		return nil, err
 	}
 	if err := rows.Err(); err != nil {
 		return nil, err
@@ -145,9 +139,6 @@ func (q *Queries) ListUserParenExpr(ctx context.Context, arg ListUserParenExprPa
 		}
 		items = append(items, i)
 	}
-	if err := rows.Close(); err != nil {
-		return nil, err
-	}
 	if err := rows.Err(); err != nil {
 		return nil, err
 	}
@@ -182,9 +173,6 @@ func (q *Queries) ListUsersByFamily(ctx context.Context, arg ListUsersByFamilyPa
 		}
 		items = append(items, i)
 	}
-	if err := rows.Close(); err != nil {
-		return nil, err
-	}
 	if err := rows.Err(); err != nil {
 		return nil, err
 	}
@@ -215,9 +203,6 @@ func (q *Queries) ListUsersByID(ctx context.Context, id int32) ([]ListUsersByIDR
 		}
 		items = append(items, i)
 	}
-	if err := rows.Close(); err != nil {
-		return nil, err
-	}
 	if err := rows.Err(); err != nil {
 		return nil, err
 	}
@@ -246,9 +231,6 @@ func (q *Queries) ListUsersWithLimit(ctx context.Context, limit int32) ([]ListUs
 			return nil, err
 		}
 		items = append(items, i)
-	}
-	if err := rows.Close(); err != nil {
-		return nil, err
 	}
 	if err := rows.Err(); err != nil {
 		return nil, err

--- a/internal/endtoend/testdata/params_location/postgresql/stdlib/go/query.sql.go
+++ b/internal/endtoend/testdata/params_location/postgresql/stdlib/go/query.sql.go
@@ -64,9 +64,6 @@ func (q *Queries) LimitSQLCArg(ctx context.Context, limit int32) ([]LimitSQLCArg
 		}
 		items = append(items, i)
 	}
-	if err := rows.Close(); err != nil {
-		return nil, err
-	}
 	if err := rows.Err(); err != nil {
 		return nil, err
 	}
@@ -103,9 +100,6 @@ func (q *Queries) ListUserOrders(ctx context.Context, minPrice string) ([]ListUs
 			return nil, err
 		}
 		items = append(items, i)
-	}
-	if err := rows.Close(); err != nil {
-		return nil, err
 	}
 	if err := rows.Err(); err != nil {
 		return nil, err
@@ -145,9 +139,6 @@ func (q *Queries) ListUserParenExpr(ctx context.Context, arg ListUserParenExprPa
 		}
 		items = append(items, i)
 	}
-	if err := rows.Close(); err != nil {
-		return nil, err
-	}
 	if err := rows.Err(); err != nil {
 		return nil, err
 	}
@@ -182,9 +173,6 @@ func (q *Queries) ListUsersByFamily(ctx context.Context, arg ListUsersByFamilyPa
 		}
 		items = append(items, i)
 	}
-	if err := rows.Close(); err != nil {
-		return nil, err
-	}
 	if err := rows.Err(); err != nil {
 		return nil, err
 	}
@@ -215,9 +203,6 @@ func (q *Queries) ListUsersByID(ctx context.Context, id int32) ([]ListUsersByIDR
 		}
 		items = append(items, i)
 	}
-	if err := rows.Close(); err != nil {
-		return nil, err
-	}
 	if err := rows.Err(); err != nil {
 		return nil, err
 	}
@@ -246,9 +231,6 @@ func (q *Queries) ListUsersWithLimit(ctx context.Context, limit int32) ([]ListUs
 			return nil, err
 		}
 		items = append(items, i)
-	}
-	if err := rows.Close(); err != nil {
-		return nil, err
 	}
 	if err := rows.Err(); err != nil {
 		return nil, err

--- a/internal/endtoend/testdata/params_placeholder_in_left_expr/mysql/go/query.sql.go
+++ b/internal/endtoend/testdata/params_placeholder_in_left_expr/mysql/go/query.sql.go
@@ -28,9 +28,6 @@ func (q *Queries) FindByID(ctx context.Context, id int32) ([]User, error) {
 		}
 		items = append(items, i)
 	}
-	if err := rows.Close(); err != nil {
-		return nil, err
-	}
 	if err := rows.Err(); err != nil {
 		return nil, err
 	}
@@ -59,9 +56,6 @@ func (q *Queries) FindByIDAndName(ctx context.Context, arg FindByIDAndNameParams
 			return nil, err
 		}
 		items = append(items, i)
-	}
-	if err := rows.Close(); err != nil {
-		return nil, err
 	}
 	if err := rows.Err(); err != nil {
 		return nil, err

--- a/internal/endtoend/testdata/params_placeholder_in_left_expr/postgresql/go/query.sql.go
+++ b/internal/endtoend/testdata/params_placeholder_in_left_expr/postgresql/go/query.sql.go
@@ -27,9 +27,6 @@ func (q *Queries) FindByID(ctx context.Context, id int32) ([]User, error) {
 		}
 		items = append(items, i)
 	}
-	if err := rows.Close(); err != nil {
-		return nil, err
-	}
 	if err := rows.Err(); err != nil {
 		return nil, err
 	}
@@ -53,9 +50,6 @@ func (q *Queries) FindByIDAndName(ctx context.Context, id int32) ([]User, error)
 			return nil, err
 		}
 		items = append(items, i)
-	}
-	if err := rows.Close(); err != nil {
-		return nil, err
 	}
 	if err := rows.Err(); err != nil {
 		return nil, err

--- a/internal/endtoend/testdata/params_two/mysql/go/query.sql.go
+++ b/internal/endtoend/testdata/params_two/mysql/go/query.sql.go
@@ -34,9 +34,6 @@ func (q *Queries) FooByAandB(ctx context.Context, arg FooByAandBParams) ([]Foo, 
 		}
 		items = append(items, i)
 	}
-	if err := rows.Close(); err != nil {
-		return nil, err
-	}
 	if err := rows.Err(); err != nil {
 		return nil, err
 	}

--- a/internal/endtoend/testdata/params_two/postgresql/stdlib/go/query.sql.go
+++ b/internal/endtoend/testdata/params_two/postgresql/stdlib/go/query.sql.go
@@ -34,9 +34,6 @@ func (q *Queries) FooByAandB(ctx context.Context, arg FooByAandBParams) ([]Foo, 
 		}
 		items = append(items, i)
 	}
-	if err := rows.Close(); err != nil {
-		return nil, err
-	}
 	if err := rows.Err(); err != nil {
 		return nil, err
 	}

--- a/internal/endtoend/testdata/pattern_in_expr/mysql/go/query.sql.go
+++ b/internal/endtoend/testdata/pattern_in_expr/mysql/go/query.sql.go
@@ -28,9 +28,6 @@ func (q *Queries) FooByBarB(ctx context.Context, b sql.NullString) ([]Foo, error
 		}
 		items = append(items, i)
 	}
-	if err := rows.Close(); err != nil {
-		return nil, err
-	}
 	if err := rows.Err(); err != nil {
 		return nil, err
 	}
@@ -59,9 +56,6 @@ func (q *Queries) FooByList(ctx context.Context, arg FooByListParams) ([]Foo, er
 			return nil, err
 		}
 		items = append(items, i)
-	}
-	if err := rows.Close(); err != nil {
-		return nil, err
 	}
 	if err := rows.Err(); err != nil {
 		return nil, err
@@ -92,9 +86,6 @@ func (q *Queries) FooByNotList(ctx context.Context, arg FooByNotListParams) ([]F
 		}
 		items = append(items, i)
 	}
-	if err := rows.Close(); err != nil {
-		return nil, err
-	}
 	if err := rows.Err(); err != nil {
 		return nil, err
 	}
@@ -118,9 +109,6 @@ func (q *Queries) FooByParamList(ctx context.Context, a sql.NullString) ([]Foo, 
 			return nil, err
 		}
 		items = append(items, i)
-	}
-	if err := rows.Close(); err != nil {
-		return nil, err
 	}
 	if err := rows.Err(); err != nil {
 		return nil, err

--- a/internal/endtoend/testdata/pattern_matching/mysql/go/query.sql.go
+++ b/internal/endtoend/testdata/pattern_matching/mysql/go/query.sql.go
@@ -28,9 +28,6 @@ func (q *Queries) PetsByName(ctx context.Context, name sql.NullString) ([]sql.Nu
 		}
 		items = append(items, name)
 	}
-	if err := rows.Close(); err != nil {
-		return nil, err
-	}
 	if err := rows.Err(); err != nil {
 		return nil, err
 	}

--- a/internal/endtoend/testdata/pattern_matching/postgresql/go/query.sql.go
+++ b/internal/endtoend/testdata/pattern_matching/postgresql/go/query.sql.go
@@ -28,9 +28,6 @@ func (q *Queries) PetsByName(ctx context.Context, name sql.NullString) ([]sql.Nu
 		}
 		items = append(items, name)
 	}
-	if err := rows.Close(); err != nil {
-		return nil, err
-	}
 	if err := rows.Err(); err != nil {
 		return nil, err
 	}

--- a/internal/endtoend/testdata/pg_advisory_xact_lock/postgresql/stdlib/go/query.sql.go
+++ b/internal/endtoend/testdata/pg_advisory_xact_lock/postgresql/stdlib/go/query.sql.go
@@ -47,9 +47,6 @@ func (q *Queries) AdvisoryUnlock(ctx context.Context, pgAdvisoryUnlock int64) ([
 		}
 		items = append(items, pg_advisory_unlock)
 	}
-	if err := rows.Close(); err != nil {
-		return nil, err
-	}
 	if err := rows.Err(); err != nil {
 		return nil, err
 	}

--- a/internal/endtoend/testdata/pg_dump/db/query.sql.go
+++ b/internal/endtoend/testdata/pg_dump/db/query.sql.go
@@ -72,9 +72,6 @@ func (q *Queries) ListAuthors(ctx context.Context) ([]Author, error) {
 		}
 		items = append(items, i)
 	}
-	if err := rows.Close(); err != nil {
-		return nil, err
-	}
 	if err := rows.Err(); err != nil {
 		return nil, err
 	}

--- a/internal/endtoend/testdata/pg_ext_ltree/postgresql/stdlib/go/query.sql.go
+++ b/internal/endtoend/testdata/pg_ext_ltree/postgresql/stdlib/go/query.sql.go
@@ -27,9 +27,6 @@ func (q *Queries) ListFoo(ctx context.Context) ([]Foo, error) {
 		}
 		items = append(items, i)
 	}
-	if err := rows.Close(); err != nil {
-		return nil, err
-	}
 	if err := rows.Err(); err != nil {
 		return nil, err
 	}

--- a/internal/endtoend/testdata/pg_generate_series/postgresql/stdlib/go/query.sql.go
+++ b/internal/endtoend/testdata/pg_generate_series/postgresql/stdlib/go/query.sql.go
@@ -33,9 +33,6 @@ func (q *Queries) GenerateSeries(ctx context.Context, arg GenerateSeriesParams) 
 		}
 		items = append(items, generate_series)
 	}
-	if err := rows.Close(); err != nil {
-		return nil, err
-	}
 	if err := rows.Err(); err != nil {
 		return nil, err
 	}

--- a/internal/endtoend/testdata/pg_timezone_names/go_stdlib/query.sql.go
+++ b/internal/endtoend/testdata/pg_timezone_names/go_stdlib/query.sql.go
@@ -33,9 +33,6 @@ func (q *Queries) GetColumns(ctx context.Context) ([]GetColumnsRow, error) {
 		}
 		items = append(items, i)
 	}
-	if err := rows.Close(); err != nil {
-		return nil, err
-	}
 	if err := rows.Err(); err != nil {
 		return nil, err
 	}
@@ -59,9 +56,6 @@ func (q *Queries) GetTables(ctx context.Context) ([]string, error) {
 			return nil, err
 		}
 		items = append(items, table_name)
-	}
-	if err := rows.Close(); err != nil {
-		return nil, err
 	}
 	if err := rows.Err(); err != nil {
 		return nil, err
@@ -98,9 +92,6 @@ func (q *Queries) GetTimezones(ctx context.Context) ([]GetTimezonesRow, error) {
 			return nil, err
 		}
 		items = append(items, i)
-	}
-	if err := rows.Close(); err != nil {
-		return nil, err
 	}
 	if err := rows.Err(); err != nil {
 		return nil, err

--- a/internal/endtoend/testdata/pg_user_table/postgresql/stdlib/go/query.sql.go
+++ b/internal/endtoend/testdata/pg_user_table/postgresql/stdlib/go/query.sql.go
@@ -27,9 +27,6 @@ func (q *Queries) User(ctx context.Context) ([]int64, error) {
 		}
 		items = append(items, id)
 	}
-	if err := rows.Close(); err != nil {
-		return nil, err
-	}
 	if err := rows.Err(); err != nil {
 		return nil, err
 	}

--- a/internal/endtoend/testdata/prepared_queries/mysql/go/query.sql.go
+++ b/internal/endtoend/testdata/prepared_queries/mysql/go/query.sql.go
@@ -94,9 +94,6 @@ func (q *Queries) ListUsers(ctx context.Context) ([]ListUsersRow, error) {
 		}
 		items = append(items, i)
 	}
-	if err := rows.Close(); err != nil {
-		return nil, err
-	}
 	if err := rows.Err(); err != nil {
 		return nil, err
 	}

--- a/internal/endtoend/testdata/prepared_queries/postgresql/stdlib/go/query.sql.go
+++ b/internal/endtoend/testdata/prepared_queries/postgresql/stdlib/go/query.sql.go
@@ -94,9 +94,6 @@ func (q *Queries) ListUsers(ctx context.Context) ([]ListUsersRow, error) {
 		}
 		items = append(items, i)
 	}
-	if err := rows.Close(); err != nil {
-		return nil, err
-	}
 	if err := rows.Err(); err != nil {
 		return nil, err
 	}

--- a/internal/endtoend/testdata/query_parameter_limit_to_two/postgresql/go/query.sql.go
+++ b/internal/endtoend/testdata/query_parameter_limit_to_two/postgresql/go/query.sql.go
@@ -154,9 +154,6 @@ func (q *Queries) ListAuthors(ctx context.Context) ([]Author, error) {
 		}
 		items = append(items, i)
 	}
-	if err := rows.Close(); err != nil {
-		return nil, err
-	}
 	if err := rows.Err(); err != nil {
 		return nil, err
 	}

--- a/internal/endtoend/testdata/query_parameter_limit_to_zero/postgresql/go/query.sql.go
+++ b/internal/endtoend/testdata/query_parameter_limit_to_zero/postgresql/go/query.sql.go
@@ -97,9 +97,6 @@ func (q *Queries) ListAuthors(ctx context.Context) ([]Author, error) {
 		}
 		items = append(items, i)
 	}
-	if err := rows.Close(); err != nil {
-		return nil, err
-	}
 	if err := rows.Err(); err != nil {
 		return nil, err
 	}

--- a/internal/endtoend/testdata/quoted_colname/sqlite/go/query.sql.go
+++ b/internal/endtoend/testdata/quoted_colname/sqlite/go/query.sql.go
@@ -27,9 +27,6 @@ func (q *Queries) TestList(ctx context.Context) ([]string, error) {
 		}
 		items = append(items, id)
 	}
-	if err := rows.Close(); err != nil {
-		return nil, err
-	}
 	if err := rows.Err(); err != nil {
 		return nil, err
 	}

--- a/internal/endtoend/testdata/quoted_tablename/sqlite/go/query.sql.go
+++ b/internal/endtoend/testdata/quoted_tablename/sqlite/go/query.sql.go
@@ -27,9 +27,6 @@ func (q *Queries) TestList(ctx context.Context) ([]string, error) {
 		}
 		items = append(items, id)
 	}
-	if err := rows.Close(); err != nil {
-		return nil, err
-	}
 	if err := rows.Err(); err != nil {
 		return nil, err
 	}

--- a/internal/endtoend/testdata/rename/v1/stdlib/go/query.sql.go
+++ b/internal/endtoend/testdata/rename/v1/stdlib/go/query.sql.go
@@ -27,9 +27,6 @@ func (q *Queries) ListBar(ctx context.Context) ([]BarNew, error) {
 		}
 		items = append(items, i)
 	}
-	if err := rows.Close(); err != nil {
-		return nil, err
-	}
 	if err := rows.Err(); err != nil {
 		return nil, err
 	}
@@ -65,9 +62,6 @@ func (q *Queries) ListFoo(ctx context.Context, arg ListFooParams) ([]ListFooRow,
 			return nil, err
 		}
 		items = append(items, i)
-	}
-	if err := rows.Close(); err != nil {
-		return nil, err
 	}
 	if err := rows.Err(); err != nil {
 		return nil, err

--- a/internal/endtoend/testdata/rename/v2/stdlib/go/query.sql.go
+++ b/internal/endtoend/testdata/rename/v2/stdlib/go/query.sql.go
@@ -27,9 +27,6 @@ func (q *Queries) ListBar(ctx context.Context) ([]BarNew, error) {
 		}
 		items = append(items, i)
 	}
-	if err := rows.Close(); err != nil {
-		return nil, err
-	}
 	if err := rows.Err(); err != nil {
 		return nil, err
 	}
@@ -65,9 +62,6 @@ func (q *Queries) ListFoo(ctx context.Context, arg ListFooParams) ([]ListFooRow,
 			return nil, err
 		}
 		items = append(items, i)
-	}
-	if err := rows.Close(); err != nil {
-		return nil, err
 	}
 	if err := rows.Err(); err != nil {
 		return nil, err

--- a/internal/endtoend/testdata/schema_scoped_enum/stdlib/go/query.sql.go
+++ b/internal/endtoend/testdata/schema_scoped_enum/stdlib/go/query.sql.go
@@ -27,9 +27,6 @@ func (q *Queries) ListUsersByRole(ctx context.Context, role NullFooTypeUserRole)
 		}
 		items = append(items, role)
 	}
-	if err := rows.Close(); err != nil {
-		return nil, err
-	}
 	if err := rows.Err(); err != nil {
 		return nil, err
 	}

--- a/internal/endtoend/testdata/schema_scoped_filter/mysql/go/query.sql.go
+++ b/internal/endtoend/testdata/schema_scoped_filter/mysql/go/query.sql.go
@@ -27,9 +27,6 @@ func (q *Queries) SchemaScopedFilter(ctx context.Context, id uint64) ([]uint64, 
 		}
 		items = append(items, id)
 	}
-	if err := rows.Close(); err != nil {
-		return nil, err
-	}
 	if err := rows.Err(); err != nil {
 		return nil, err
 	}

--- a/internal/endtoend/testdata/schema_scoped_filter/postgresql/stdlib/go/query.sql.go
+++ b/internal/endtoend/testdata/schema_scoped_filter/postgresql/stdlib/go/query.sql.go
@@ -27,9 +27,6 @@ func (q *Queries) SchemaScopedFilter(ctx context.Context, id int32) ([]int32, er
 		}
 		items = append(items, id)
 	}
-	if err := rows.Close(); err != nil {
-		return nil, err
-	}
 	if err := rows.Err(); err != nil {
 		return nil, err
 	}

--- a/internal/endtoend/testdata/schema_scoped_list/mysql/go/query.sql.go
+++ b/internal/endtoend/testdata/schema_scoped_list/mysql/go/query.sql.go
@@ -27,9 +27,6 @@ func (q *Queries) SchemaScopedColList(ctx context.Context) ([]uint64, error) {
 		}
 		items = append(items, id)
 	}
-	if err := rows.Close(); err != nil {
-		return nil, err
-	}
 	if err := rows.Err(); err != nil {
 		return nil, err
 	}
@@ -53,9 +50,6 @@ func (q *Queries) SchemaScopedList(ctx context.Context) ([]uint64, error) {
 			return nil, err
 		}
 		items = append(items, id)
-	}
-	if err := rows.Close(); err != nil {
-		return nil, err
 	}
 	if err := rows.Err(); err != nil {
 		return nil, err

--- a/internal/endtoend/testdata/schema_scoped_list/postgresql/stdlib/go/query.sql.go
+++ b/internal/endtoend/testdata/schema_scoped_list/postgresql/stdlib/go/query.sql.go
@@ -27,9 +27,6 @@ func (q *Queries) SchemaScopedColList(ctx context.Context) ([]int32, error) {
 		}
 		items = append(items, id)
 	}
-	if err := rows.Close(); err != nil {
-		return nil, err
-	}
 	if err := rows.Err(); err != nil {
 		return nil, err
 	}
@@ -53,9 +50,6 @@ func (q *Queries) SchemaScopedList(ctx context.Context) ([]int32, error) {
 			return nil, err
 		}
 		items = append(items, id)
-	}
-	if err := rows.Close(); err != nil {
-		return nil, err
 	}
 	if err := rows.Err(); err != nil {
 		return nil, err

--- a/internal/endtoend/testdata/select_column_cast/mysql/go/query.sql.go
+++ b/internal/endtoend/testdata/select_column_cast/mysql/go/query.sql.go
@@ -27,9 +27,6 @@ func (q *Queries) SelectColumnCast(ctx context.Context) ([]int64, error) {
 		}
 		items = append(items, bar)
 	}
-	if err := rows.Close(); err != nil {
-		return nil, err
-	}
 	if err := rows.Err(); err != nil {
 		return nil, err
 	}

--- a/internal/endtoend/testdata/select_column_cast/postgresql/stdlib/go/query.sql.go
+++ b/internal/endtoend/testdata/select_column_cast/postgresql/stdlib/go/query.sql.go
@@ -27,9 +27,6 @@ func (q *Queries) SelectColumnCast(ctx context.Context) ([]int32, error) {
 		}
 		items = append(items, bar)
 	}
-	if err := rows.Close(); err != nil {
-		return nil, err
-	}
 	if err := rows.Err(); err != nil {
 		return nil, err
 	}

--- a/internal/endtoend/testdata/select_column_cast/sqlite/go/query.sql.go
+++ b/internal/endtoend/testdata/select_column_cast/sqlite/go/query.sql.go
@@ -27,9 +27,6 @@ func (q *Queries) SelectColumnCast(ctx context.Context) ([][]byte, error) {
 		}
 		items = append(items, bar)
 	}
-	if err := rows.Close(); err != nil {
-		return nil, err
-	}
 	if err := rows.Err(); err != nil {
 		return nil, err
 	}

--- a/internal/endtoend/testdata/select_cte/sqlite/go/query.sql.go
+++ b/internal/endtoend/testdata/select_cte/sqlite/go/query.sql.go
@@ -30,9 +30,6 @@ func (q *Queries) ListAuthors(ctx context.Context) ([]int64, error) {
 		}
 		items = append(items, n)
 	}
-	if err := rows.Close(); err != nil {
-		return nil, err
-	}
 	if err := rows.Err(); err != nil {
 		return nil, err
 	}

--- a/internal/endtoend/testdata/select_distinct/stdlib/go/query.sql.go
+++ b/internal/endtoend/testdata/select_distinct/stdlib/go/query.sql.go
@@ -28,9 +28,6 @@ func (q *Queries) GetBars(ctx context.Context) ([]Bar, error) {
 		}
 		items = append(items, i)
 	}
-	if err := rows.Close(); err != nil {
-		return nil, err
-	}
 	if err := rows.Err(); err != nil {
 		return nil, err
 	}

--- a/internal/endtoend/testdata/select_empty_column_list/postgresql/stdlib/go/query.sql.go
+++ b/internal/endtoend/testdata/select_empty_column_list/postgresql/stdlib/go/query.sql.go
@@ -30,9 +30,6 @@ func (q *Queries) GetBars(ctx context.Context) ([]GetBarsRow, error) {
 		}
 		items = append(items, i)
 	}
-	if err := rows.Close(); err != nil {
-		return nil, err
-	}
 	if err := rows.Err(); err != nil {
 		return nil, err
 	}

--- a/internal/endtoend/testdata/select_limit/mysql/go/query.sql.go
+++ b/internal/endtoend/testdata/select_limit/mysql/go/query.sql.go
@@ -29,9 +29,6 @@ func (q *Queries) FooLimit(ctx context.Context, limit int32) ([]sql.NullString, 
 		}
 		items = append(items, a)
 	}
-	if err := rows.Close(); err != nil {
-		return nil, err
-	}
 	if err := rows.Err(); err != nil {
 		return nil, err
 	}
@@ -61,9 +58,6 @@ func (q *Queries) FooLimitOffset(ctx context.Context, arg FooLimitOffsetParams) 
 			return nil, err
 		}
 		items = append(items, a)
-	}
-	if err := rows.Close(); err != nil {
-		return nil, err
 	}
 	if err := rows.Err(); err != nil {
 		return nil, err

--- a/internal/endtoend/testdata/select_limit/postgresql/stdlib/go/query.sql.go
+++ b/internal/endtoend/testdata/select_limit/postgresql/stdlib/go/query.sql.go
@@ -29,9 +29,6 @@ func (q *Queries) FooLimit(ctx context.Context, limit int32) ([]sql.NullString, 
 		}
 		items = append(items, a)
 	}
-	if err := rows.Close(); err != nil {
-		return nil, err
-	}
 	if err := rows.Err(); err != nil {
 		return nil, err
 	}
@@ -61,9 +58,6 @@ func (q *Queries) FooLimitOffset(ctx context.Context, arg FooLimitOffsetParams) 
 			return nil, err
 		}
 		items = append(items, a)
-	}
-	if err := rows.Close(); err != nil {
-		return nil, err
 	}
 	if err := rows.Err(); err != nil {
 		return nil, err

--- a/internal/endtoend/testdata/select_limit/sqlite/go/query.sql.go
+++ b/internal/endtoend/testdata/select_limit/sqlite/go/query.sql.go
@@ -29,9 +29,6 @@ func (q *Queries) FooLimit(ctx context.Context, limit int64) ([]sql.NullString, 
 		}
 		items = append(items, a)
 	}
-	if err := rows.Close(); err != nil {
-		return nil, err
-	}
 	if err := rows.Err(); err != nil {
 		return nil, err
 	}
@@ -61,9 +58,6 @@ func (q *Queries) FooLimitOffset(ctx context.Context, arg FooLimitOffsetParams) 
 			return nil, err
 		}
 		items = append(items, a)
-	}
-	if err := rows.Close(); err != nil {
-		return nil, err
 	}
 	if err := rows.Err(); err != nil {
 		return nil, err

--- a/internal/endtoend/testdata/select_nested_count/mysql/go/query.sql.go
+++ b/internal/endtoend/testdata/select_nested_count/mysql/go/query.sql.go
@@ -44,9 +44,6 @@ func (q *Queries) GetAuthorsWithBooksCount(ctx context.Context) ([]GetAuthorsWit
 		}
 		items = append(items, i)
 	}
-	if err := rows.Close(); err != nil {
-		return nil, err
-	}
 	if err := rows.Err(); err != nil {
 		return nil, err
 	}

--- a/internal/endtoend/testdata/select_nested_count/postgresql/go/query.sql.go
+++ b/internal/endtoend/testdata/select_nested_count/postgresql/go/query.sql.go
@@ -44,9 +44,6 @@ func (q *Queries) GetAuthorsWithBooksCount(ctx context.Context) ([]GetAuthorsWit
 		}
 		items = append(items, i)
 	}
-	if err := rows.Close(); err != nil {
-		return nil, err
-	}
 	if err := rows.Err(); err != nil {
 		return nil, err
 	}

--- a/internal/endtoend/testdata/select_nested_count/sqlite/go/query.sql.go
+++ b/internal/endtoend/testdata/select_nested_count/sqlite/go/query.sql.go
@@ -44,9 +44,6 @@ func (q *Queries) GetAuthorsWithBooksCount(ctx context.Context) ([]GetAuthorsWit
 		}
 		items = append(items, i)
 	}
-	if err := rows.Close(); err != nil {
-		return nil, err
-	}
 	if err := rows.Err(); err != nil {
 		return nil, err
 	}

--- a/internal/endtoend/testdata/select_star/mysql/go/query.sql.go
+++ b/internal/endtoend/testdata/select_star/mysql/go/query.sql.go
@@ -32,9 +32,6 @@ func (q *Queries) GetAll(ctx context.Context) ([]User, error) {
 		}
 		items = append(items, i)
 	}
-	if err := rows.Close(); err != nil {
-		return nil, err
-	}
 	if err := rows.Err(); err != nil {
 		return nil, err
 	}
@@ -58,9 +55,6 @@ func (q *Queries) GetIDAll(ctx context.Context) ([]int32, error) {
 			return nil, err
 		}
 		items = append(items, id)
-	}
-	if err := rows.Close(); err != nil {
-		return nil, err
 	}
 	if err := rows.Err(); err != nil {
 		return nil, err

--- a/internal/endtoend/testdata/select_star/postgresql/stdlib/go/query.sql.go
+++ b/internal/endtoend/testdata/select_star/postgresql/stdlib/go/query.sql.go
@@ -32,9 +32,6 @@ func (q *Queries) GetAll(ctx context.Context) ([]User, error) {
 		}
 		items = append(items, i)
 	}
-	if err := rows.Close(); err != nil {
-		return nil, err
-	}
 	if err := rows.Err(); err != nil {
 		return nil, err
 	}
@@ -58,9 +55,6 @@ func (q *Queries) GetIDAll(ctx context.Context) ([]int32, error) {
 			return nil, err
 		}
 		items = append(items, id)
-	}
-	if err := rows.Close(); err != nil {
-		return nil, err
 	}
 	if err := rows.Err(); err != nil {
 		return nil, err

--- a/internal/endtoend/testdata/select_star/sqlite/go/query.sql.go
+++ b/internal/endtoend/testdata/select_star/sqlite/go/query.sql.go
@@ -32,9 +32,6 @@ func (q *Queries) GetAll(ctx context.Context) ([]User, error) {
 		}
 		items = append(items, i)
 	}
-	if err := rows.Close(); err != nil {
-		return nil, err
-	}
 	if err := rows.Err(); err != nil {
 		return nil, err
 	}
@@ -58,9 +55,6 @@ func (q *Queries) GetIDAll(ctx context.Context) ([]int64, error) {
 			return nil, err
 		}
 		items = append(items, id)
-	}
-	if err := rows.Close(); err != nil {
-		return nil, err
 	}
 	if err := rows.Err(); err != nil {
 		return nil, err

--- a/internal/endtoend/testdata/select_star_quoted/mysql/go/query.sql.go
+++ b/internal/endtoend/testdata/select_star_quoted/mysql/go/query.sql.go
@@ -28,9 +28,6 @@ func (q *Queries) GetAll(ctx context.Context) ([]sql.NullString, error) {
 		}
 		items = append(items, camelcase)
 	}
-	if err := rows.Close(); err != nil {
-		return nil, err
-	}
 	if err := rows.Err(); err != nil {
 		return nil, err
 	}

--- a/internal/endtoend/testdata/select_star_quoted/postgresql/stdlib/go/query.sql.go
+++ b/internal/endtoend/testdata/select_star_quoted/postgresql/stdlib/go/query.sql.go
@@ -28,9 +28,6 @@ func (q *Queries) GetAll(ctx context.Context) ([]sql.NullString, error) {
 		}
 		items = append(items, CamelCase)
 	}
-	if err := rows.Close(); err != nil {
-		return nil, err
-	}
 	if err := rows.Err(); err != nil {
 		return nil, err
 	}

--- a/internal/endtoend/testdata/select_text_array/stdlib/go/query.sql.go
+++ b/internal/endtoend/testdata/select_text_array/stdlib/go/query.sql.go
@@ -29,9 +29,6 @@ func (q *Queries) SelectTextArray(ctx context.Context, dollar_1 []string) ([][]s
 		}
 		items = append(items, column_1)
 	}
-	if err := rows.Close(); err != nil {
-		return nil, err
-	}
 	if err := rows.Err(); err != nil {
 		return nil, err
 	}

--- a/internal/endtoend/testdata/select_union/mysql/go/query.sql.go
+++ b/internal/endtoend/testdata/select_union/mysql/go/query.sql.go
@@ -29,9 +29,6 @@ func (q *Queries) SelectExcept(ctx context.Context) ([]Foo, error) {
 		}
 		items = append(items, i)
 	}
-	if err := rows.Close(); err != nil {
-		return nil, err
-	}
 	if err := rows.Err(); err != nil {
 		return nil, err
 	}
@@ -57,9 +54,6 @@ func (q *Queries) SelectIntersect(ctx context.Context) ([]Foo, error) {
 			return nil, err
 		}
 		items = append(items, i)
-	}
-	if err := rows.Close(); err != nil {
-		return nil, err
 	}
 	if err := rows.Err(); err != nil {
 		return nil, err
@@ -87,9 +81,6 @@ func (q *Queries) SelectUnion(ctx context.Context) ([]Foo, error) {
 		}
 		items = append(items, i)
 	}
-	if err := rows.Close(); err != nil {
-		return nil, err
-	}
 	if err := rows.Err(); err != nil {
 		return nil, err
 	}
@@ -115,9 +106,6 @@ func (q *Queries) SelectUnionOther(ctx context.Context) ([]Foo, error) {
 			return nil, err
 		}
 		items = append(items, i)
-	}
-	if err := rows.Close(); err != nil {
-		return nil, err
 	}
 	if err := rows.Err(); err != nil {
 		return nil, err
@@ -150,9 +138,6 @@ func (q *Queries) SelectUnionWithLimit(ctx context.Context, arg SelectUnionWithL
 			return nil, err
 		}
 		items = append(items, i)
-	}
-	if err := rows.Close(); err != nil {
-		return nil, err
 	}
 	if err := rows.Err(); err != nil {
 		return nil, err

--- a/internal/endtoend/testdata/select_union/postgres/stdlib/go/query.sql.go
+++ b/internal/endtoend/testdata/select_union/postgres/stdlib/go/query.sql.go
@@ -29,9 +29,6 @@ func (q *Queries) SelectExcept(ctx context.Context) ([]Foo, error) {
 		}
 		items = append(items, i)
 	}
-	if err := rows.Close(); err != nil {
-		return nil, err
-	}
 	if err := rows.Err(); err != nil {
 		return nil, err
 	}
@@ -57,9 +54,6 @@ func (q *Queries) SelectIntersect(ctx context.Context) ([]Foo, error) {
 			return nil, err
 		}
 		items = append(items, i)
-	}
-	if err := rows.Close(); err != nil {
-		return nil, err
 	}
 	if err := rows.Err(); err != nil {
 		return nil, err
@@ -87,9 +81,6 @@ func (q *Queries) SelectUnion(ctx context.Context) ([]Foo, error) {
 		}
 		items = append(items, i)
 	}
-	if err := rows.Close(); err != nil {
-		return nil, err
-	}
 	if err := rows.Err(); err != nil {
 		return nil, err
 	}
@@ -115,9 +106,6 @@ func (q *Queries) SelectUnionOther(ctx context.Context) ([]Foo, error) {
 			return nil, err
 		}
 		items = append(items, i)
-	}
-	if err := rows.Close(); err != nil {
-		return nil, err
 	}
 	if err := rows.Err(); err != nil {
 		return nil, err
@@ -150,9 +138,6 @@ func (q *Queries) SelectUnionWithLimit(ctx context.Context, arg SelectUnionWithL
 			return nil, err
 		}
 		items = append(items, i)
-	}
-	if err := rows.Close(); err != nil {
-		return nil, err
 	}
 	if err := rows.Err(); err != nil {
 		return nil, err

--- a/internal/endtoend/testdata/select_union/sqlite/go/query.sql.go
+++ b/internal/endtoend/testdata/select_union/sqlite/go/query.sql.go
@@ -29,9 +29,6 @@ func (q *Queries) SelectExcept(ctx context.Context) ([]Foo, error) {
 		}
 		items = append(items, i)
 	}
-	if err := rows.Close(); err != nil {
-		return nil, err
-	}
 	if err := rows.Err(); err != nil {
 		return nil, err
 	}
@@ -57,9 +54,6 @@ func (q *Queries) SelectIntersect(ctx context.Context) ([]Foo, error) {
 			return nil, err
 		}
 		items = append(items, i)
-	}
-	if err := rows.Close(); err != nil {
-		return nil, err
 	}
 	if err := rows.Err(); err != nil {
 		return nil, err
@@ -87,9 +81,6 @@ func (q *Queries) SelectUnion(ctx context.Context) ([]Foo, error) {
 		}
 		items = append(items, i)
 	}
-	if err := rows.Close(); err != nil {
-		return nil, err
-	}
 	if err := rows.Err(); err != nil {
 		return nil, err
 	}
@@ -115,9 +106,6 @@ func (q *Queries) SelectUnionOther(ctx context.Context) ([]Foo, error) {
 			return nil, err
 		}
 		items = append(items, i)
-	}
-	if err := rows.Close(); err != nil {
-		return nil, err
 	}
 	if err := rows.Err(); err != nil {
 		return nil, err
@@ -150,9 +138,6 @@ func (q *Queries) SelectUnionWithLimit(ctx context.Context, arg SelectUnionWithL
 			return nil, err
 		}
 		items = append(items, i)
-	}
-	if err := rows.Close(); err != nil {
-		return nil, err
 	}
 	if err := rows.Err(); err != nil {
 		return nil, err

--- a/internal/endtoend/testdata/select_union_subquery/mysql/go/query.sql.go
+++ b/internal/endtoend/testdata/select_union_subquery/mysql/go/query.sql.go
@@ -31,9 +31,6 @@ func (q *Queries) TestSubqueryUnion(ctx context.Context) ([]Author, error) {
 		}
 		items = append(items, i)
 	}
-	if err := rows.Close(); err != nil {
-		return nil, err
-	}
 	if err := rows.Err(); err != nil {
 		return nil, err
 	}

--- a/internal/endtoend/testdata/show_warnings/mysql/go/query.sql.go
+++ b/internal/endtoend/testdata/show_warnings/mysql/go/query.sql.go
@@ -33,9 +33,6 @@ func (q *Queries) ShowWarnings(ctx context.Context) ([]ShowWarningsRow, error) {
 		}
 		items = append(items, i)
 	}
-	if err := rows.Close(); err != nil {
-		return nil, err
-	}
 	if err := rows.Err(); err != nil {
 		return nil, err
 	}

--- a/internal/endtoend/testdata/sqlc_arg/mysql/go/query.sql.go
+++ b/internal/endtoend/testdata/sqlc_arg/mysql/go/query.sql.go
@@ -32,9 +32,6 @@ func (q *Queries) Complicated(ctx context.Context, arg ComplicatedParams) ([]str
 		}
 		items = append(items, name)
 	}
-	if err := rows.Close(); err != nil {
-		return nil, err
-	}
 	if err := rows.Err(); err != nil {
 		return nil, err
 	}
@@ -59,9 +56,6 @@ func (q *Queries) FuncParamIdent(ctx context.Context, slug string) ([]string, er
 		}
 		items = append(items, name)
 	}
-	if err := rows.Close(); err != nil {
-		return nil, err
-	}
 	if err := rows.Err(); err != nil {
 		return nil, err
 	}
@@ -85,9 +79,6 @@ func (q *Queries) FuncParamString(ctx context.Context, slug string) ([]string, e
 			return nil, err
 		}
 		items = append(items, name)
-	}
-	if err := rows.Close(); err != nil {
-		return nil, err
 	}
 	if err := rows.Err(); err != nil {
 		return nil, err

--- a/internal/endtoend/testdata/sqlc_arg/postgresql/stdlib/go/query.sql.go
+++ b/internal/endtoend/testdata/sqlc_arg/postgresql/stdlib/go/query.sql.go
@@ -27,9 +27,6 @@ func (q *Queries) FuncParamIdent(ctx context.Context, slug string) ([]string, er
 		}
 		items = append(items, name)
 	}
-	if err := rows.Close(); err != nil {
-		return nil, err
-	}
 	if err := rows.Err(); err != nil {
 		return nil, err
 	}
@@ -53,9 +50,6 @@ func (q *Queries) FuncParamString(ctx context.Context, slug string) ([]string, e
 			return nil, err
 		}
 		items = append(items, name)
-	}
-	if err := rows.Close(); err != nil {
-		return nil, err
 	}
 	if err := rows.Err(); err != nil {
 		return nil, err

--- a/internal/endtoend/testdata/sqlc_arg/sqlite/go/query.sql.go
+++ b/internal/endtoend/testdata/sqlc_arg/sqlite/go/query.sql.go
@@ -27,9 +27,6 @@ func (q *Queries) FuncParamIdent(ctx context.Context, slug string) ([]string, er
 		}
 		items = append(items, name)
 	}
-	if err := rows.Close(); err != nil {
-		return nil, err
-	}
 	if err := rows.Err(); err != nil {
 		return nil, err
 	}
@@ -53,9 +50,6 @@ func (q *Queries) FuncParamString(ctx context.Context, slug string) ([]string, e
 			return nil, err
 		}
 		items = append(items, name)
-	}
-	if err := rows.Close(); err != nil {
-		return nil, err
 	}
 	if err := rows.Err(); err != nil {
 		return nil, err

--- a/internal/endtoend/testdata/sqlc_embed/mysql/go/query.sql.go
+++ b/internal/endtoend/testdata/sqlc_embed/mysql/go/query.sql.go
@@ -141,9 +141,6 @@ func (q *Queries) WithCrossSchema(ctx context.Context) ([]WithCrossSchemaRow, er
 		}
 		items = append(items, i)
 	}
-	if err := rows.Close(); err != nil {
-		return nil, err
-	}
 	if err := rows.Err(); err != nil {
 		return nil, err
 	}
@@ -192,9 +189,6 @@ func (q *Queries) WithSubquery(ctx context.Context) ([]WithSubqueryRow, error) {
 			return nil, err
 		}
 		items = append(items, i)
-	}
-	if err := rows.Close(); err != nil {
-		return nil, err
 	}
 	if err := rows.Err(); err != nil {
 		return nil, err

--- a/internal/endtoend/testdata/sqlc_embed/postgresql/stdlib/go/query.sql.go
+++ b/internal/endtoend/testdata/sqlc_embed/postgresql/stdlib/go/query.sql.go
@@ -144,9 +144,6 @@ func (q *Queries) WithCrossSchema(ctx context.Context) ([]WithCrossSchemaRow, er
 		}
 		items = append(items, i)
 	}
-	if err := rows.Close(); err != nil {
-		return nil, err
-	}
 	if err := rows.Err(); err != nil {
 		return nil, err
 	}
@@ -195,9 +192,6 @@ func (q *Queries) WithSubquery(ctx context.Context) ([]WithSubqueryRow, error) {
 			return nil, err
 		}
 		items = append(items, i)
-	}
-	if err := rows.Close(); err != nil {
-		return nil, err
 	}
 	if err := rows.Err(); err != nil {
 		return nil, err

--- a/internal/endtoend/testdata/sqlc_embed/sqlite/go/query.sql.go
+++ b/internal/endtoend/testdata/sqlc_embed/sqlite/go/query.sql.go
@@ -141,9 +141,6 @@ func (q *Queries) WithCrossSchema(ctx context.Context) ([]WithCrossSchemaRow, er
 		}
 		items = append(items, i)
 	}
-	if err := rows.Close(); err != nil {
-		return nil, err
-	}
 	if err := rows.Err(); err != nil {
 		return nil, err
 	}
@@ -192,9 +189,6 @@ func (q *Queries) WithSubquery(ctx context.Context) ([]WithSubqueryRow, error) {
 			return nil, err
 		}
 		items = append(items, i)
-	}
-	if err := rows.Close(); err != nil {
-		return nil, err
 	}
 	if err := rows.Err(); err != nil {
 		return nil, err

--- a/internal/endtoend/testdata/sqlc_narg/mysql/go/query.sql.go
+++ b/internal/endtoend/testdata/sqlc_narg/mysql/go/query.sql.go
@@ -28,9 +28,6 @@ func (q *Queries) IdentOnNonNullable(ctx context.Context, bar sql.NullString) ([
 		}
 		items = append(items, bar)
 	}
-	if err := rows.Close(); err != nil {
-		return nil, err
-	}
 	if err := rows.Err(); err != nil {
 		return nil, err
 	}
@@ -54,9 +51,6 @@ func (q *Queries) IdentOnNullable(ctx context.Context, maybeBar sql.NullString) 
 			return nil, err
 		}
 		items = append(items, maybe_bar)
-	}
-	if err := rows.Close(); err != nil {
-		return nil, err
 	}
 	if err := rows.Err(); err != nil {
 		return nil, err
@@ -82,9 +76,6 @@ func (q *Queries) StringOnNonNullable(ctx context.Context, bar sql.NullString) (
 		}
 		items = append(items, bar)
 	}
-	if err := rows.Close(); err != nil {
-		return nil, err
-	}
 	if err := rows.Err(); err != nil {
 		return nil, err
 	}
@@ -108,9 +99,6 @@ func (q *Queries) StringOnNullable(ctx context.Context, maybeBar sql.NullString)
 			return nil, err
 		}
 		items = append(items, maybe_bar)
-	}
-	if err := rows.Close(); err != nil {
-		return nil, err
 	}
 	if err := rows.Err(); err != nil {
 		return nil, err

--- a/internal/endtoend/testdata/sqlc_narg/postgresql/stdlib/go/query.sql.go
+++ b/internal/endtoend/testdata/sqlc_narg/postgresql/stdlib/go/query.sql.go
@@ -28,9 +28,6 @@ func (q *Queries) IdentOnNonNullable(ctx context.Context, bar sql.NullString) ([
 		}
 		items = append(items, bar)
 	}
-	if err := rows.Close(); err != nil {
-		return nil, err
-	}
 	if err := rows.Err(); err != nil {
 		return nil, err
 	}
@@ -54,9 +51,6 @@ func (q *Queries) IdentOnNullable(ctx context.Context, maybeBar sql.NullString) 
 			return nil, err
 		}
 		items = append(items, maybe_bar)
-	}
-	if err := rows.Close(); err != nil {
-		return nil, err
 	}
 	if err := rows.Err(); err != nil {
 		return nil, err
@@ -82,9 +76,6 @@ func (q *Queries) StringOnNonNullable(ctx context.Context, bar sql.NullString) (
 		}
 		items = append(items, bar)
 	}
-	if err := rows.Close(); err != nil {
-		return nil, err
-	}
 	if err := rows.Err(); err != nil {
 		return nil, err
 	}
@@ -108,9 +99,6 @@ func (q *Queries) StringOnNullable(ctx context.Context, maybeBar sql.NullString)
 			return nil, err
 		}
 		items = append(items, maybe_bar)
-	}
-	if err := rows.Close(); err != nil {
-		return nil, err
 	}
 	if err := rows.Err(); err != nil {
 		return nil, err

--- a/internal/endtoend/testdata/sqlc_narg/postgresql/stdlib/go_strict/query.sql.go
+++ b/internal/endtoend/testdata/sqlc_narg/postgresql/stdlib/go_strict/query.sql.go
@@ -28,9 +28,6 @@ func (q *Queries) IdentOnNonNullable(ctx context.Context, bar sql.NullString) ([
 		}
 		items = append(items, bar)
 	}
-	if err := rows.Close(); err != nil {
-		return nil, err
-	}
 	if err := rows.Err(); err != nil {
 		return nil, err
 	}
@@ -54,9 +51,6 @@ func (q *Queries) IdentOnNullable(ctx context.Context, maybeBar sql.NullString) 
 			return nil, err
 		}
 		items = append(items, maybe_bar)
-	}
-	if err := rows.Close(); err != nil {
-		return nil, err
 	}
 	if err := rows.Err(); err != nil {
 		return nil, err
@@ -82,9 +76,6 @@ func (q *Queries) StringOnNonNullable(ctx context.Context, bar sql.NullString) (
 		}
 		items = append(items, bar)
 	}
-	if err := rows.Close(); err != nil {
-		return nil, err
-	}
 	if err := rows.Err(); err != nil {
 		return nil, err
 	}
@@ -108,9 +99,6 @@ func (q *Queries) StringOnNullable(ctx context.Context, maybeBar sql.NullString)
 			return nil, err
 		}
 		items = append(items, maybe_bar)
-	}
-	if err := rows.Close(); err != nil {
-		return nil, err
 	}
 	if err := rows.Err(); err != nil {
 		return nil, err

--- a/internal/endtoend/testdata/sqlc_narg/sqlite/go/query.sql.go
+++ b/internal/endtoend/testdata/sqlc_narg/sqlite/go/query.sql.go
@@ -28,9 +28,6 @@ func (q *Queries) IdentOnNonNullable(ctx context.Context, bar sql.NullString) ([
 		}
 		items = append(items, bar)
 	}
-	if err := rows.Close(); err != nil {
-		return nil, err
-	}
 	if err := rows.Err(); err != nil {
 		return nil, err
 	}
@@ -54,9 +51,6 @@ func (q *Queries) IdentOnNullable(ctx context.Context, maybeBar sql.NullString) 
 			return nil, err
 		}
 		items = append(items, maybe_bar)
-	}
-	if err := rows.Close(); err != nil {
-		return nil, err
 	}
 	if err := rows.Err(); err != nil {
 		return nil, err
@@ -82,9 +76,6 @@ func (q *Queries) StringOnNonNullable(ctx context.Context, bar sql.NullString) (
 		}
 		items = append(items, bar)
 	}
-	if err := rows.Close(); err != nil {
-		return nil, err
-	}
 	if err := rows.Err(); err != nil {
 		return nil, err
 	}
@@ -108,9 +99,6 @@ func (q *Queries) StringOnNullable(ctx context.Context, maybeBar sql.NullString)
 			return nil, err
 		}
 		items = append(items, maybe_bar)
-	}
-	if err := rows.Close(); err != nil {
-		return nil, err
 	}
 	if err := rows.Err(); err != nil {
 		return nil, err

--- a/internal/endtoend/testdata/sqlc_slice/mysql/go/query.sql.go
+++ b/internal/endtoend/testdata/sqlc_slice/mysql/go/query.sql.go
@@ -42,9 +42,6 @@ func (q *Queries) FuncNullable(ctx context.Context, favourites []int32) ([]sql.N
 		}
 		items = append(items, bar)
 	}
-	if err := rows.Close(); err != nil {
-		return nil, err
-	}
 	if err := rows.Err(); err != nil {
 		return nil, err
 	}
@@ -79,9 +76,6 @@ func (q *Queries) FuncNullableNot(ctx context.Context, favourites []int32) ([]sq
 			return nil, err
 		}
 		items = append(items, bar)
-	}
-	if err := rows.Close(); err != nil {
-		return nil, err
 	}
 	if err := rows.Err(); err != nil {
 		return nil, err
@@ -125,9 +119,6 @@ func (q *Queries) FuncParamIdent(ctx context.Context, arg FuncParamIdentParams) 
 		}
 		items = append(items, name)
 	}
-	if err := rows.Close(); err != nil {
-		return nil, err
-	}
 	if err := rows.Err(); err != nil {
 		return nil, err
 	}
@@ -162,9 +153,6 @@ func (q *Queries) FuncParamSoloArg(ctx context.Context, favourites []int32) ([]s
 			return nil, err
 		}
 		items = append(items, name)
-	}
-	if err := rows.Close(); err != nil {
-		return nil, err
 	}
 	if err := rows.Err(); err != nil {
 		return nil, err
@@ -207,9 +195,6 @@ func (q *Queries) FuncParamString(ctx context.Context, arg FuncParamStringParams
 			return nil, err
 		}
 		items = append(items, name)
-	}
-	if err := rows.Close(); err != nil {
-		return nil, err
 	}
 	if err := rows.Err(); err != nil {
 		return nil, err
@@ -271,9 +256,6 @@ func (q *Queries) TypedMyStr(ctx context.Context, mystr []mysql.ID) ([]sql.NullS
 			return nil, err
 		}
 		items = append(items, bar)
-	}
-	if err := rows.Close(); err != nil {
-		return nil, err
 	}
 	if err := rows.Err(); err != nil {
 		return nil, err

--- a/internal/endtoend/testdata/sqlc_slice/postgresql/stdlib/go/query.sql.go
+++ b/internal/endtoend/testdata/sqlc_slice/postgresql/stdlib/go/query.sql.go
@@ -46,9 +46,6 @@ func (q *Queries) FuncParamIdent(ctx context.Context, arg FuncParamIdentParams) 
 		}
 		items = append(items, name)
 	}
-	if err := rows.Close(); err != nil {
-		return nil, err
-	}
 	if err := rows.Err(); err != nil {
 		return nil, err
 	}
@@ -90,9 +87,6 @@ func (q *Queries) FuncParamString(ctx context.Context, arg FuncParamStringParams
 			return nil, err
 		}
 		items = append(items, name)
-	}
-	if err := rows.Close(); err != nil {
-		return nil, err
 	}
 	if err := rows.Err(); err != nil {
 		return nil, err

--- a/internal/endtoend/testdata/sqlc_slice/sqlite/go/query.sql.go
+++ b/internal/endtoend/testdata/sqlc_slice/sqlite/go/query.sql.go
@@ -40,9 +40,6 @@ func (q *Queries) FuncNullable(ctx context.Context, favourites []int64) ([]sql.N
 		}
 		items = append(items, bar)
 	}
-	if err := rows.Close(); err != nil {
-		return nil, err
-	}
 	if err := rows.Err(); err != nil {
 		return nil, err
 	}
@@ -77,9 +74,6 @@ func (q *Queries) FuncNullableNot(ctx context.Context, favourites []int64) ([]sq
 			return nil, err
 		}
 		items = append(items, bar)
-	}
-	if err := rows.Close(); err != nil {
-		return nil, err
 	}
 	if err := rows.Err(); err != nil {
 		return nil, err
@@ -123,9 +117,6 @@ func (q *Queries) FuncParamIdent(ctx context.Context, arg FuncParamIdentParams) 
 		}
 		items = append(items, name)
 	}
-	if err := rows.Close(); err != nil {
-		return nil, err
-	}
 	if err := rows.Err(); err != nil {
 		return nil, err
 	}
@@ -160,9 +151,6 @@ func (q *Queries) FuncParamSoloArg(ctx context.Context, favourites []int64) ([]s
 			return nil, err
 		}
 		items = append(items, name)
-	}
-	if err := rows.Close(); err != nil {
-		return nil, err
 	}
 	if err := rows.Err(); err != nil {
 		return nil, err
@@ -205,9 +193,6 @@ func (q *Queries) FuncParamString(ctx context.Context, arg FuncParamStringParams
 			return nil, err
 		}
 		items = append(items, name)
-	}
-	if err := rows.Close(); err != nil {
-		return nil, err
 	}
 	if err := rows.Err(); err != nil {
 		return nil, err

--- a/internal/endtoend/testdata/sqlc_slice_prepared/sqlite/go/query.sql.go
+++ b/internal/endtoend/testdata/sqlc_slice_prepared/sqlite/go/query.sql.go
@@ -46,9 +46,6 @@ func (q *Queries) FuncParamIdent(ctx context.Context, arg FuncParamIdentParams) 
 		}
 		items = append(items, name)
 	}
-	if err := rows.Close(); err != nil {
-		return nil, err
-	}
 	if err := rows.Err(); err != nil {
 		return nil, err
 	}

--- a/internal/endtoend/testdata/sqlite_skip_todo/db/query.sql.go
+++ b/internal/endtoend/testdata/sqlite_skip_todo/db/query.sql.go
@@ -29,9 +29,6 @@ func (q *Queries) GetFoo(ctx context.Context, bar sql.NullString) ([]sql.NullStr
 		}
 		items = append(items, bar)
 	}
-	if err := rows.Close(); err != nil {
-		return nil, err
-	}
 	if err := rows.Err(); err != nil {
 		return nil, err
 	}
@@ -55,9 +52,6 @@ func (q *Queries) ListFoo(ctx context.Context) ([]sql.NullString, error) {
 			return nil, err
 		}
 		items = append(items, bar)
-	}
-	if err := rows.Close(); err != nil {
-		return nil, err
 	}
 	if err := rows.Err(); err != nil {
 		return nil, err

--- a/internal/endtoend/testdata/star_expansion/mysql/go/query.sql.go
+++ b/internal/endtoend/testdata/star_expansion/mysql/go/query.sql.go
@@ -44,9 +44,6 @@ func (q *Queries) StarExpansion(ctx context.Context) ([]StarExpansionRow, error)
 		}
 		items = append(items, i)
 	}
-	if err := rows.Close(); err != nil {
-		return nil, err
-	}
 	if err := rows.Err(); err != nil {
 		return nil, err
 	}
@@ -70,9 +67,6 @@ func (q *Queries) StarQuotedExpansion(ctx context.Context) ([]Foo, error) {
 			return nil, err
 		}
 		items = append(items, i)
-	}
-	if err := rows.Close(); err != nil {
-		return nil, err
 	}
 	if err := rows.Err(); err != nil {
 		return nil, err

--- a/internal/endtoend/testdata/star_expansion/postgresql/stdlib/go/query.sql.go
+++ b/internal/endtoend/testdata/star_expansion/postgresql/stdlib/go/query.sql.go
@@ -44,9 +44,6 @@ func (q *Queries) StarExpansion(ctx context.Context) ([]StarExpansionRow, error)
 		}
 		items = append(items, i)
 	}
-	if err := rows.Close(); err != nil {
-		return nil, err
-	}
 	if err := rows.Err(); err != nil {
 		return nil, err
 	}
@@ -70,9 +67,6 @@ func (q *Queries) StarQuotedExpansion(ctx context.Context) ([]Foo, error) {
 			return nil, err
 		}
 		items = append(items, i)
-	}
-	if err := rows.Close(); err != nil {
-		return nil, err
 	}
 	if err := rows.Err(); err != nil {
 		return nil, err

--- a/internal/endtoend/testdata/star_expansion/sqlite/go/query.sql.go
+++ b/internal/endtoend/testdata/star_expansion/sqlite/go/query.sql.go
@@ -44,9 +44,6 @@ func (q *Queries) StarExpansion(ctx context.Context) ([]StarExpansionRow, error)
 		}
 		items = append(items, i)
 	}
-	if err := rows.Close(); err != nil {
-		return nil, err
-	}
 	if err := rows.Err(); err != nil {
 		return nil, err
 	}
@@ -70,9 +67,6 @@ func (q *Queries) StarQuotedExpansion(ctx context.Context) ([]Foo, error) {
 			return nil, err
 		}
 		items = append(items, i)
-	}
-	if err := rows.Close(); err != nil {
-		return nil, err
 	}
 	if err := rows.Err(); err != nil {
 		return nil, err

--- a/internal/endtoend/testdata/star_expansion_cte/stdlib/go/query.sql.go
+++ b/internal/endtoend/testdata/star_expansion_cte/stdlib/go/query.sql.go
@@ -28,9 +28,6 @@ func (q *Queries) StarExpansionCTE(ctx context.Context) ([]Bar, error) {
 		}
 		items = append(items, i)
 	}
-	if err := rows.Close(); err != nil {
-		return nil, err
-	}
 	if err := rows.Err(); err != nil {
 		return nil, err
 	}
@@ -63,9 +60,6 @@ func (q *Queries) StarExpansionTwoCTE(ctx context.Context) ([]StarExpansionTwoCT
 			return nil, err
 		}
 		items = append(items, i)
-	}
-	if err := rows.Close(); err != nil {
-		return nil, err
 	}
 	if err := rows.Err(); err != nil {
 		return nil, err

--- a/internal/endtoend/testdata/star_expansion_from_cte/stdlib/go/query.sql.go
+++ b/internal/endtoend/testdata/star_expansion_from_cte/stdlib/go/query.sql.go
@@ -33,9 +33,6 @@ func (q *Queries) StarExpansionCTE(ctx context.Context) ([]StarExpansionCTERow, 
 		}
 		items = append(items, i)
 	}
-	if err := rows.Close(); err != nil {
-		return nil, err
-	}
 	if err := rows.Err(); err != nil {
 		return nil, err
 	}

--- a/internal/endtoend/testdata/star_expansion_join/mysql/go/query.sql.go
+++ b/internal/endtoend/testdata/star_expansion_join/mysql/go/query.sql.go
@@ -40,9 +40,6 @@ func (q *Queries) StarExpansionJoin(ctx context.Context) ([]StarExpansionJoinRow
 		}
 		items = append(items, i)
 	}
-	if err := rows.Close(); err != nil {
-		return nil, err
-	}
 	if err := rows.Err(); err != nil {
 		return nil, err
 	}

--- a/internal/endtoend/testdata/star_expansion_join/postgresql/stdlib/go/query.sql.go
+++ b/internal/endtoend/testdata/star_expansion_join/postgresql/stdlib/go/query.sql.go
@@ -40,9 +40,6 @@ func (q *Queries) StarExpansionJoin(ctx context.Context) ([]StarExpansionJoinRow
 		}
 		items = append(items, i)
 	}
-	if err := rows.Close(); err != nil {
-		return nil, err
-	}
 	if err := rows.Err(); err != nil {
 		return nil, err
 	}

--- a/internal/endtoend/testdata/star_expansion_reserved/mysql/go/query.sql.go
+++ b/internal/endtoend/testdata/star_expansion_reserved/mysql/go/query.sql.go
@@ -27,9 +27,6 @@ func (q *Queries) StarExpansionReserved(ctx context.Context) ([]Foo, error) {
 		}
 		items = append(items, i)
 	}
-	if err := rows.Close(); err != nil {
-		return nil, err
-	}
 	if err := rows.Err(); err != nil {
 		return nil, err
 	}

--- a/internal/endtoend/testdata/star_expansion_reserved/postgresql/stdlib/go/query.sql.go
+++ b/internal/endtoend/testdata/star_expansion_reserved/postgresql/stdlib/go/query.sql.go
@@ -27,9 +27,6 @@ func (q *Queries) StarExpansionReserved(ctx context.Context) ([]Foo, error) {
 		}
 		items = append(items, i)
 	}
-	if err := rows.Close(); err != nil {
-		return nil, err
-	}
 	if err := rows.Err(); err != nil {
 		return nil, err
 	}

--- a/internal/endtoend/testdata/star_expansion_subquery/mysql/go/query.sql.go
+++ b/internal/endtoend/testdata/star_expansion_subquery/mysql/go/query.sql.go
@@ -27,9 +27,6 @@ func (q *Queries) StarExpansionSubquery(ctx context.Context) ([]Foo, error) {
 		}
 		items = append(items, i)
 	}
-	if err := rows.Close(); err != nil {
-		return nil, err
-	}
 	if err := rows.Err(); err != nil {
 		return nil, err
 	}

--- a/internal/endtoend/testdata/star_expansion_subquery/postgresql/stdlib/go/query.sql.go
+++ b/internal/endtoend/testdata/star_expansion_subquery/postgresql/stdlib/go/query.sql.go
@@ -27,9 +27,6 @@ func (q *Queries) StarExpansionSubquery(ctx context.Context) ([]Foo, error) {
 		}
 		items = append(items, i)
 	}
-	if err := rows.Close(); err != nil {
-		return nil, err
-	}
 	if err := rows.Err(); err != nil {
 		return nil, err
 	}

--- a/internal/endtoend/testdata/subquery_calculated_column/mysql/go/query.sql.go
+++ b/internal/endtoend/testdata/subquery_calculated_column/mysql/go/query.sql.go
@@ -27,9 +27,6 @@ func (q *Queries) SubqueryCalcColumn(ctx context.Context) ([]int32, error) {
 		}
 		items = append(items, sum)
 	}
-	if err := rows.Close(); err != nil {
-		return nil, err
-	}
 	if err := rows.Err(); err != nil {
 		return nil, err
 	}

--- a/internal/endtoend/testdata/subquery_calculated_column/postgresql/stdlib/go/query.sql.go
+++ b/internal/endtoend/testdata/subquery_calculated_column/postgresql/stdlib/go/query.sql.go
@@ -27,9 +27,6 @@ func (q *Queries) SubqueryCalcColumn(ctx context.Context) ([]int32, error) {
 		}
 		items = append(items, sum)
 	}
-	if err := rows.Close(); err != nil {
-		return nil, err
-	}
 	if err := rows.Err(); err != nil {
 		return nil, err
 	}

--- a/internal/endtoend/testdata/subquery_calculated_column/sqlite/go/query.sql.go
+++ b/internal/endtoend/testdata/subquery_calculated_column/sqlite/go/query.sql.go
@@ -27,9 +27,6 @@ func (q *Queries) SubqueryCalcColumn(ctx context.Context) ([]int64, error) {
 		}
 		items = append(items, sum)
 	}
-	if err := rows.Close(); err != nil {
-		return nil, err
-	}
 	if err := rows.Err(); err != nil {
 		return nil, err
 	}

--- a/internal/endtoend/testdata/sum_type/postgresql/pgx/go/query.sql.go
+++ b/internal/endtoend/testdata/sum_type/postgresql/pgx/go/query.sql.go
@@ -7,17 +7,15 @@ package querytest
 
 import (
 	"context"
-
-	"github.com/jackc/pgx/v5/pgtype"
 )
 
 const sumOrder = `-- name: SumOrder :one
 SELECT SUM(quantity) FROM orders
 `
 
-func (q *Queries) SumOrder(ctx context.Context) (pgtype.Numeric, error) {
+func (q *Queries) SumOrder(ctx context.Context) (int64, error) {
 	row := q.db.QueryRow(ctx, sumOrder)
-	var sum pgtype.Numeric
+	var sum int64
 	err := row.Scan(&sum)
 	return sum, err
 }

--- a/internal/endtoend/testdata/table_function/postgresql/stdlib/go/query.sql.go
+++ b/internal/endtoend/testdata/table_function/postgresql/stdlib/go/query.sql.go
@@ -48,9 +48,6 @@ func (q *Queries) GetTransaction(ctx context.Context, arg GetTransactionParams) 
 		}
 		items = append(items, i)
 	}
-	if err := rows.Close(); err != nil {
-		return nil, err
-	}
 	if err := rows.Err(); err != nil {
 		return nil, err
 	}

--- a/internal/endtoend/testdata/table_function/sqlite/go/query.sql.go
+++ b/internal/endtoend/testdata/table_function/sqlite/go/query.sql.go
@@ -49,9 +49,6 @@ func (q *Queries) GetTransaction(ctx context.Context, arg GetTransactionParams) 
 		}
 		items = append(items, i)
 	}
-	if err := rows.Close(); err != nil {
-		return nil, err
-	}
 	if err := rows.Err(); err != nil {
 		return nil, err
 	}

--- a/internal/endtoend/testdata/types_uuid/postgresql/stdlib/go/query.sql.go
+++ b/internal/endtoend/testdata/types_uuid/postgresql/stdlib/go/query.sql.go
@@ -40,9 +40,6 @@ func (q *Queries) List(ctx context.Context) ([]Foo, error) {
 		}
 		items = append(items, i)
 	}
-	if err := rows.Close(); err != nil {
-		return nil, err
-	}
 	if err := rows.Err(); err != nil {
 		return nil, err
 	}

--- a/internal/endtoend/testdata/unnest/postgresql/stdlib/go/query.sql.go
+++ b/internal/endtoend/testdata/unnest/postgresql/stdlib/go/query.sql.go
@@ -39,9 +39,6 @@ func (q *Queries) CreateMemories(ctx context.Context, vampireID []uuid.UUID) ([]
 		}
 		items = append(items, i)
 	}
-	if err := rows.Close(); err != nil {
-		return nil, err
-	}
 	if err := rows.Err(); err != nil {
 		return nil, err
 	}
@@ -65,9 +62,6 @@ func (q *Queries) GetVampireIDs(ctx context.Context, vampireID []uuid.UUID) ([]u
 			return nil, err
 		}
 		items = append(items, vampires_id)
-	}
-	if err := rows.Close(); err != nil {
-		return nil, err
 	}
 	if err := rows.Err(); err != nil {
 		return nil, err

--- a/internal/endtoend/testdata/unnest_star/postgresql/pgx/go/query.sql.go
+++ b/internal/endtoend/testdata/unnest_star/postgresql/pgx/go/query.sql.go
@@ -7,8 +7,6 @@ package querytest
 
 import (
 	"context"
-
-	"github.com/jackc/pgx/v5/pgtype"
 )
 
 const getPlanItems = `-- name: GetPlanItems :many
@@ -27,8 +25,8 @@ LATERAL (
 
 type GetPlanItemsParams struct {
 	Ids        []int64
-	After      pgtype.Int4
-	LimitCount int64
+	After      interface{}
+	LimitCount int32
 }
 
 type GetPlanItemsRow struct {

--- a/internal/endtoend/testdata/unnest_with_ordinality/postgresql/stdlib/go/query.sql.go
+++ b/internal/endtoend/testdata/unnest_with_ordinality/postgresql/stdlib/go/query.sql.go
@@ -34,9 +34,6 @@ func (q *Queries) GetValues(ctx context.Context) ([]GetValuesRow, error) {
 		}
 		items = append(items, i)
 	}
-	if err := rows.Close(); err != nil {
-		return nil, err
-	}
 	if err := rows.Err(); err != nil {
 		return nil, err
 	}

--- a/internal/endtoend/testdata/update_array_index/postgresql/pgx/go/query.sql.go
+++ b/internal/endtoend/testdata/update_array_index/postgresql/pgx/go/query.sql.go
@@ -17,8 +17,8 @@ RETURNING id, names
 `
 
 type UpdateAuthorParams struct {
-	Names   int32
-	Names_2 string
+	Names   []string
+	Names_2 []string
 	ID      int64
 }
 

--- a/internal/endtoend/testdata/valid_group_by_reference/mysql/go/query.sql.go
+++ b/internal/endtoend/testdata/valid_group_by_reference/mysql/go/query.sql.go
@@ -36,9 +36,6 @@ func (q *Queries) ListAuthors(ctx context.Context) ([]ListAuthorsRow, error) {
 		}
 		items = append(items, i)
 	}
-	if err := rows.Close(); err != nil {
-		return nil, err
-	}
 	if err := rows.Err(); err != nil {
 		return nil, err
 	}
@@ -64,9 +61,6 @@ func (q *Queries) ListAuthorsIdenticalAlias(ctx context.Context) ([]Author, erro
 			return nil, err
 		}
 		items = append(items, i)
-	}
-	if err := rows.Close(); err != nil {
-		return nil, err
 	}
 	if err := rows.Err(); err != nil {
 		return nil, err
@@ -101,9 +95,6 @@ func (q *Queries) ListMetrics(ctx context.Context) ([]ListMetricsRow, error) {
 			return nil, err
 		}
 		items = append(items, i)
-	}
-	if err := rows.Close(); err != nil {
-		return nil, err
 	}
 	if err := rows.Err(); err != nil {
 		return nil, err

--- a/internal/endtoend/testdata/valid_group_by_reference/pganalyzer/go/query.sql.go
+++ b/internal/endtoend/testdata/valid_group_by_reference/pganalyzer/go/query.sql.go
@@ -8,7 +8,6 @@ package querytest
 import (
 	"context"
 	"database/sql"
-	"time"
 )
 
 const listAuthors = `-- name: ListAuthors :many
@@ -29,9 +28,6 @@ func (q *Queries) ListAuthors(ctx context.Context) ([]Author, error) {
 			return nil, err
 		}
 		items = append(items, i)
-	}
-	if err := rows.Close(); err != nil {
-		return nil, err
 	}
 	if err := rows.Err(); err != nil {
 		return nil, err
@@ -58,9 +54,6 @@ func (q *Queries) ListAuthorsIdenticalAlias(ctx context.Context) ([]Author, erro
 		}
 		items = append(items, i)
 	}
-	if err := rows.Close(); err != nil {
-		return nil, err
-	}
 	if err := rows.Err(); err != nil {
 		return nil, err
 	}
@@ -76,7 +69,7 @@ ORDER BY bucket DESC
 `
 
 type ListMetricsRow struct {
-	Bucket   time.Time
+	Bucket   int64
 	CityName sql.NullString
 	Avg      float64
 }
@@ -94,9 +87,6 @@ func (q *Queries) ListMetrics(ctx context.Context) ([]ListMetricsRow, error) {
 			return nil, err
 		}
 		items = append(items, i)
-	}
-	if err := rows.Close(); err != nil {
-		return nil, err
 	}
 	if err := rows.Err(); err != nil {
 		return nil, err

--- a/internal/endtoend/testdata/valid_group_by_reference/postgresql/go/query.sql.go
+++ b/internal/endtoend/testdata/valid_group_by_reference/postgresql/go/query.sql.go
@@ -29,9 +29,6 @@ func (q *Queries) ListAuthors(ctx context.Context) ([]Author, error) {
 		}
 		items = append(items, i)
 	}
-	if err := rows.Close(); err != nil {
-		return nil, err
-	}
 	if err := rows.Err(); err != nil {
 		return nil, err
 	}
@@ -56,9 +53,6 @@ func (q *Queries) ListAuthorsIdenticalAlias(ctx context.Context) ([]Author, erro
 			return nil, err
 		}
 		items = append(items, i)
-	}
-	if err := rows.Close(); err != nil {
-		return nil, err
 	}
 	if err := rows.Err(); err != nil {
 		return nil, err
@@ -93,9 +87,6 @@ func (q *Queries) ListMetrics(ctx context.Context) ([]ListMetricsRow, error) {
 			return nil, err
 		}
 		items = append(items, i)
-	}
-	if err := rows.Close(); err != nil {
-		return nil, err
 	}
 	if err := rows.Err(); err != nil {
 		return nil, err

--- a/internal/endtoend/testdata/virtual_table/sqlite/go/query.sql.go
+++ b/internal/endtoend/testdata/virtual_table/sqlite/go/query.sql.go
@@ -51,9 +51,6 @@ func (q *Queries) SelectAllColsFt(ctx context.Context, b string) ([]string, erro
 		}
 		items = append(items, b)
 	}
-	if err := rows.Close(); err != nil {
-		return nil, err
-	}
 	if err := rows.Err(); err != nil {
 		return nil, err
 	}
@@ -78,9 +75,6 @@ func (q *Queries) SelectAllColsTblFt(ctx context.Context, b string) ([]TblFt, er
 			return nil, err
 		}
 		items = append(items, i)
-	}
-	if err := rows.Close(); err != nil {
-		return nil, err
 	}
 	if err := rows.Err(); err != nil {
 		return nil, err
@@ -113,9 +107,6 @@ func (q *Queries) SelectBm25Func(ctx context.Context, b string) ([]SelectBm25Fun
 		}
 		items = append(items, i)
 	}
-	if err := rows.Close(); err != nil {
-		return nil, err
-	}
 	if err := rows.Err(); err != nil {
 		return nil, err
 	}
@@ -140,9 +131,6 @@ func (q *Queries) SelectHightlighFunc(ctx context.Context, b string) ([]string, 
 			return nil, err
 		}
 		items = append(items, highlight)
-	}
-	if err := rows.Close(); err != nil {
-		return nil, err
 	}
 	if err := rows.Err(); err != nil {
 		return nil, err
@@ -169,9 +157,6 @@ func (q *Queries) SelectOneColFt(ctx context.Context, b string) ([]string, error
 		}
 		items = append(items, b)
 	}
-	if err := rows.Close(); err != nil {
-		return nil, err
-	}
 	if err := rows.Err(); err != nil {
 		return nil, err
 	}
@@ -197,9 +182,6 @@ func (q *Queries) SelectOneColTblFt(ctx context.Context, b string) ([]string, er
 		}
 		items = append(items, c)
 	}
-	if err := rows.Close(); err != nil {
-		return nil, err
-	}
 	if err := rows.Err(); err != nil {
 		return nil, err
 	}
@@ -223,9 +205,6 @@ func (q *Queries) SelectSnippetFunc(ctx context.Context, snippet int64) ([]strin
 			return nil, err
 		}
 		items = append(items, snippet)
-	}
-	if err := rows.Close(); err != nil {
-		return nil, err
 	}
 	if err := rows.Err(); err != nil {
 		return nil, err


### PR DESCRIPTION
## Description

This pull request addresses an issue in the generated query code template [queryCode.tmpl](https://github.com/sqlc-dev/sqlc/blob/main/internal/codegen/golang/templates/stdlib/queryCode.tmpl ) where `rows.Close()` was being called multiple times. This change ensures that `rows.Close()` is only called once using `defer`, which is a best practice for resource management in Go.

## Changes

- Updated the `queryCode.tmpl` template to use `defer rows.Close()` for ensuring the rows are closed properly.
- Removed the redundant `rows.Close()` call after the loop.

## Rationale

Calling `rows.Close()` multiple times is unnecessary and can lead to potential issues. Using `defer` to close the rows ensures that the resource is properly released exactly once, following Go's best practices.
