### PR TITLE
allow renaming function Params structs

### DIFF
--- a/docs/howto/rename.md
+++ b/docs/howto/rename.md
@@ -21,7 +21,7 @@ sql:
   queries: "postgresql/query.sql"
   engine: "postgresql"
   gen:
-    go: 
+    go:
       package: "authors"
       out: "postgresql"
       rename:
@@ -115,6 +115,28 @@ type Publisher struct {
 	Name string
 }
 ```
+
+## Parameter Structure Names
+
+It is possible to rename the arguments a generated function would use.
+For example, if you had a generated function called `FindWriter`
+which used a generated name of `FindWriterParams`, you can choose to rename
+this:
+
+```yaml
+version: "2"
+sql:
+  - engine: postgresql
+    queries: query.sql
+    schema: query.sql
+overrides:
+  go:
+    rename:
+      FindWriterParams: SomeOtherNameParams
+```
+
+The target name must be unique, and even if multiple structures would
+have the same fields, there will be a conflict.
 
 ## Limitations
 

--- a/internal/codegen/golang/result.go
+++ b/internal/codegen/golang/result.go
@@ -376,7 +376,7 @@ func putOutColumns(query *plugin.Query) bool {
 // This is unlikely to happen, so don't fix it yet
 func columnsToStruct(req *plugin.GenerateRequest, options *opts.Options, name string, columns []goColumn, useID bool, models modelTypeSet, qualifier string) (*Struct, error) {
 	gs := Struct{
-		Name: name,
+		Name: CheckRename(name, options),
 	}
 	seen := map[string][]int{}
 	suffixes := map[int]int{}

--- a/internal/codegen/golang/struct.go
+++ b/internal/codegen/golang/struct.go
@@ -20,6 +20,13 @@ type Struct struct {
 	IsModel bool
 }
 
+func CheckRename(name string, options *opts.Options) string {
+	if rename := options.Rename[name]; rename != "" {
+		return rename
+	}
+	return name
+}
+
 func StructName(name string, options *opts.Options) string {
 	if rename := options.Rename[name]; rename != "" {
 		return rename


### PR DESCRIPTION
I have a case where I want to wrap some of the database calls in some internal layers, and would like to have a single params structure that is exposed between my hand-rolled wrapped code and the generated names.

Specifically, I am making a function called `UpsertFooUncached` using code gen and I want a cached version:

```go
func (q *Queries) UpsertFoo(ctx context.Context, args UpsertFooParams) (uuid.UUID, error) {
  // caching would go here
  id, err := q.UpsertFooUncached(ctx, args)
  if err != nil {
    return uuid.Nil, err
  }
  // cache the result
  return id, nil
}
```

In this case, I could use `type UpsertFooParams UpsertFooUncachedParams` but this doesn't work well for users as it doesn't always expand with VSCode, so the internals are a mystery.  I could recreate the structure, but then I need to keep it in sync.  I could embed the Uncached version, but then using it is a pain.

I'd like to rename, and this change seems to do the trick.