### PR TITLE
enable reading server uri from env var

### DIFF
--- a/internal/config/env.go
+++ b/internal/config/env.go
@@ -13,5 +13,12 @@ func (c *Config) addEnvVars() error {
 	}
 	c.Cloud.AuthToken = authToken
 
+	serverUri := os.Getenv("SQLC_SERVER_URI")
+	if serverUri != "" && len(c.Servers) != 1 {
+		return fmt.Errorf("$SQLC_SERVER_URI may only be used when there is exactly one server in config file")
+	} else if serverUri != "" {
+		c.Servers[0].URI = serverUri
+	}
+
 	return nil
 }


### PR DESCRIPTION
The [managed database](https://docs.sqlc.dev/en/v1.28.0/howto/managed-databases.html#configuring-managed-databases) configuration is a nice feature for further improving the value provided by sqlc. The server connection string however must be specified in `sqlc.yaml`, which limits the flexibility of an sqlc project to adapt to multiple environments.

I have a project which utilizes sqlc in local development. I would like to also utilize sqlc in Continuous Integration of that project. The CI server in question is configured in a way which makes me unable to provide a connection string which can be reused in both local development and CI. 

Many other populate cli tools accepts configuration through environment variables or flags, making them more flexible and therefore easier to integrate into situations like mine. One example being [`atlas migrate lint`](https://atlasgo.io/cli-reference#atlas-migrate-lint) which operates in much the same way as `sqlc verify` and `sqlc vet`, where a database server is used to validate sql.

This PR adds the possibility to configure the server uri through an environment variable if the `sqlc.yaml` contains only one server. 

I am happy to receive feedback or alternative solutions. 


Thanks 🙏 

<details>
<summary>Expand me if you'd like to learn why I am unable to provide a static connection string</summary>

The CI server is configured such that jobs is executed in docker containers. One invocation of my CI pipeline is executed in one such container. The docker socket of the host is mounted into that docker container. My CI pipeline starts by starting a postgres database server in a docker container and mounts the container port 5432 onto port 55432 on the host, such that `sqlc` should be able to connect to `localhost:55432`. The problem is that the host of the container is the CI server and not the container my CI pipeline is executing in. `sqlc` is therefore unable to connect to the database server.
 
</details>