### PR TITLE
Add rowid column to FTS5 tables

### DIFF
--- a/internal/endtoend/testdata/virtual_table/sqlite/go/models.go
+++ b/internal/endtoend/testdata/virtual_table/sqlite/go/models.go
@@ -9,7 +9,8 @@ import (
 )
 
 type Ft struct {
-	B string
+	Rowid int64
+	B     string
 }
 
 type Tbl struct {
@@ -21,6 +22,7 @@ type Tbl struct {
 }
 
 type TblFt struct {
-	B string
-	C string
+	Rowid int64
+	B     string
+	C     string
 }

--- a/internal/endtoend/testdata/virtual_table/sqlite/query.sql
+++ b/internal/endtoend/testdata/virtual_table/sqlite/query.sql
@@ -1,3 +1,7 @@
+-- name: SelectRowID :one
+SELECT rowid FROM ft
+LIMIT 1;
+
 -- name: SelectAllColsFt :many
 SELECT b FROM ft
 WHERE b MATCH ?;

--- a/internal/engine/sqlite/convert.go
+++ b/internal/engine/sqlite/convert.go
@@ -146,6 +146,13 @@ func (c *cc) convertCreate_virtual_table_fts5(n *parser.Create_virtual_table_stm
 		IfNotExists: n.EXISTS_() != nil,
 	}
 
+	// All FTS5 virtual tables implicitly contain a 'rowid' column.
+	stmt.Cols = append(stmt.Cols, &ast.ColumnDef{
+		Colname:   "rowid",
+		IsNotNull: true,
+		TypeName:  &ast.TypeName{Name: "integer"},
+	})
+
 	for _, arg := range n.AllModule_argument() {
 		var columnName string
 


### PR DESCRIPTION
Fixes https://github.com/sqlc-dev/sqlc/issues/3901:

> When creating a virtual table like so:
> 
> ```sql
> CREATE VIRTUAL TABLE my_fts USING fts5 (
>     name,
>     description,
>     content = '',
>     contentless_delete = 1,
>     tokenize = 'porter'
> );
> ```
> 
> SQLite automatically adds an extra `rowid` (`int64`) column to all `fts5` virtual tables. However, this is not reflected in the schema. When I add a query like this:
> 
> ```sql
> -- name: InsertMyFTS :exec
> INSERT INTO
>     my_fts (rowid, name, description)
> VALUES
>     (?, ?, ?);
> ```
> 
> and call `sqlc generate`, I get this error:
> 
> ```
> query.sql:12:1: column "rowid" does not exist
> ```