### PR TITLE
fix(pgx): Do not wrap nil error

### DIFF
--- a/internal/codegen/golang/templates/pgx/queryCode.tmpl
+++ b/internal/codegen/golang/templates/pgx/queryCode.tmpl
@@ -89,7 +89,14 @@ func (q *Queries) {{.MethodName}}(ctx context.Context, db DBTX, {{.Arg.Pair}}) e
 func (q *Queries) {{.MethodName}}(ctx context.Context, {{.Arg.Pair}}) error {
 	_, err := q.db.Exec(ctx, {{.ConstantName}}, {{.Arg.Params}})
 {{- end}}
-	return {{if $.WrapErrors}}fmt.Errorf("query {{.MethodName}}: %w", err){{else}}err{{end}}
+	{{- if $.WrapErrors }}
+	if err != nil {
+		return fmt.Errorf("query {{.MethodName}}: %w", err)
+	}
+	return nil
+	{{- else }}
+	return err
+	{{- end }}
 }
 {{end}}
 

--- a/internal/endtoend/testdata/wrap_errors/postgresql/pgx/db/query.sql.go
+++ b/internal/endtoend/testdata/wrap_errors/postgresql/pgx/db/query.sql.go
@@ -44,7 +44,10 @@ WHERE id = $1
 
 func (q *Queries) DeleteAuthorExec(ctx context.Context, id int64) error {
 	_, err := q.db.Exec(ctx, deleteAuthorExec, id)
-	return fmt.Errorf("query DeleteAuthorExec: %w", err)
+	if err != nil {
+		return fmt.Errorf("query DeleteAuthorExec: %w", err)
+	}
+	return nil
 }
 
 const deleteAuthorExecLastID = `-- name: DeleteAuthorExecLastID :execlastid


### PR DESCRIPTION
When wrapping errors, add a nil check before wrapping the error.

Fixes https://github.com/sqlc-dev/sqlc/issues/3912