### PR TITLE
fix(migrations): case-sensitive migration rollback detection

### DIFF
--- a/internal/migrations/migrations.go
+++ b/internal/migrations/migrations.go
@@ -15,16 +15,17 @@ func RemoveRollbackStatements(contents string) string {
 	s := bufio.NewScanner(strings.NewReader(contents))
 	var lines []string
 	for s.Scan() {
-		if strings.HasPrefix(s.Text(), "-- +goose Down") {
+		statement := strings.ToLower(s.Text())
+		if strings.HasPrefix(statement, "-- +goose down") {
 			break
 		}
-		if strings.HasPrefix(s.Text(), "-- +migrate Down") {
+		if strings.HasPrefix(statement, "-- +migrate down") {
 			break
 		}
-		if strings.HasPrefix(s.Text(), "---- create above / drop below ----") {
+		if strings.HasPrefix(statement, "---- create above / drop below ----") {
 			break
 		}
-		if strings.HasPrefix(s.Text(), "-- migrate:down") {
+		if strings.HasPrefix(statement, "-- migrate:down") {
 			break
 		}
 		lines = append(lines, s.Text())


### PR DESCRIPTION
This PR fixes an issue where SQLC was failing to properly detect and remove rollback statements in migration files due to case sensitivity. Previously, SQLC only recognized uppercase `Down` in rollback statements (e.g., `-- +goose Down`), but migration tools like Goose have updated their [documentation](https://pressly.github.io/goose/documentation/annotations/) to use lowercase `down` (e.g., `-- +goose down`).

The change makes the rollback statement detection case-insensitive by converting the statement to lowercase before checking, ensuring compatibility with:
- Both `-- +goose Down` and `-- +goose down` (Goose migrations)
- Both `-- +migrate Down` and `-- +migrate down` (sql-migrate)
- Case variations in other migration tool formats

This maintains backward compatibility with existing migrations while supporting the current documentation standards of migration tools.

Fixes issue #3444

## Changes
- Modified `RemoveRollbackStatements` to perform case-insensitive comparison by converting statements to lowercase before checking
- Maintains support for all existing migration tool formats:
  - Goose
  - sql-migrate
  - tern
  - dbmate

## Testing
- Verified that both uppercase and lowercase rollback statements are properly detected and removed
- Ensures no breaking changes for existing migration files