### PR TITLE
Use MySQL 9 in docker-compose.yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 version: "3.8"
 services:
   mysql:
-    image: "mysql/mysql-server:8.0"
+    image: "mysql:9"
     ports:
       - "3306:3306"
     restart: always


### PR DESCRIPTION
I got an error when execute `make test` in my local env with `make start`.

```
--- FAIL: TestValidSchema (0.19s)
    --- FAIL: TestValidSchema/endtoend-testdata/mysql_vector/mysql/sqlc.json-0 (0.02s)
        ddl_test.go:56: CREATE TABLE foo(
                id INT PRIMARY KEY auto_increment,
                embedding VECTOR(4)
            );: Error 1064 (42000): You have an error in your SQL syntax; check the manual that corresponds to your MySQL server version for the right syntax to use near 'VECTOR(4)
            )' at line 3
```

I am not familiar with MySQL, but from what I've researched, `VECTOR` data type appears to be supported from version 9 [^1].
sqlc's CI workflow uses version 9 too [^2].

[^1]: https://dev.mysql.com/doc/relnotes/mysql/9.0/en/news-9-0-0.html#mysqld-9-0-0-vectors
[^2]: https://github.com/sqlc-dev/sqlc/blob/v1.29.0/.github/workflows/ci.yml#L64