### PR TITLE
SQLite: Fix convertion of `UPDATE` statements table name

### DIFF
--- a/internal/endtoend/testdata/update_set/sqlite/go/query.sql.go
+++ b/internal/endtoend/testdata/update_set/sqlite/go/query.sql.go
@@ -22,3 +22,17 @@ func (q *Queries) UpdateSet(ctx context.Context, arg UpdateSetParams) error {
 	_, err := q.db.ExecContext(ctx, updateSet, arg.Name, arg.Slug)
 	return err
 }
+
+const updateSetQuoted = `-- name: UpdateSetQuoted :exec
+UPDATE "foo" SET "name" = ? WHERE "slug" = ?
+`
+
+type UpdateSetQuotedParams struct {
+	Name string
+	Slug string
+}
+
+func (q *Queries) UpdateSetQuoted(ctx context.Context, arg UpdateSetQuotedParams) error {
+	_, err := q.db.ExecContext(ctx, updateSetQuoted, arg.Name, arg.Slug)
+	return err
+}

--- a/internal/endtoend/testdata/update_set/sqlite/query.sql
+++ b/internal/endtoend/testdata/update_set/sqlite/query.sql
@@ -1,2 +1,5 @@
 /* name: UpdateSet :exec */
 UPDATE foo SET name = ? WHERE slug = ?;
+
+/* name: UpdateSetQuoted :exec */
+UPDATE "foo" SET "name" = ? WHERE "slug" = ?;


### PR DESCRIPTION
Hi! This PR enables support for the following query format (note the double quotes):
```
UPDATE "foo" SET name = ?;
```

It also addresses issues related to schema-qualified table names (e.g., `schema.table`).

As for aliases, I don't believe they're necessary - or even valid - in this context, so we might consider removing that part.