### PR TITLE
Fix panic for DELETE with JOIN on subquery

### DIFF
--- a/internal/endtoend/testdata/delete_join/mysql/db/query.sql.go
+++ b/internal/endtoend/testdata/delete_join/mysql/db/query.sql.go
@@ -30,6 +30,17 @@ func (q *Queries) DeleteJoin(ctx context.Context, arg DeleteJoinParams) error {
 	return err
 }
 
+const deleteJoinWithSubquery = `-- name: DeleteJoinWithSubquery :exec
+DELETE pt
+FROM primary_table pt
+JOIN (SELECT 1 as id) jt ON pt.id = jt.id
+`
+
+func (q *Queries) DeleteJoinWithSubquery(ctx context.Context) error {
+	_, err := q.db.ExecContext(ctx, deleteJoinWithSubquery)
+	return err
+}
+
 const deleteLeftJoin = `-- name: DeleteLeftJoin :exec
 DELETE jt.*,
 pt.*

--- a/internal/endtoend/testdata/delete_join/mysql/query.sql
+++ b/internal/endtoend/testdata/delete_join/mysql/query.sql
@@ -27,3 +27,8 @@ FROM
 WHERE
         jt.id = ?
         AND pt.user_id = ?;
+
+-- name: DeleteJoinWithSubquery :exec
+DELETE pt
+FROM primary_table pt
+JOIN (SELECT 1 as id) jt ON pt.id = jt.id;

--- a/internal/engine/dolphin/utils.go
+++ b/internal/engine/dolphin/utils.go
@@ -52,6 +52,9 @@ func convertToRangeVarList(list *ast.List, result *ast.List) {
 		if !ok {
 			if list, check := rel.Larg.(*ast.List); check {
 				convertToRangeVarList(list, result)
+			} else if subselect, check := rel.Larg.(*ast.RangeSubselect); check {
+				// Handle subqueries in JOIN clauses
+				result.Items = append(result.Items, subselect)
 			} else {
 				panic("expected range var")
 			}
@@ -64,6 +67,9 @@ func convertToRangeVarList(list *ast.List, result *ast.List) {
 		if !ok {
 			if list, check := rel.Rarg.(*ast.List); check {
 				convertToRangeVarList(list, result)
+			} else if subselect, check := rel.Rarg.(*ast.RangeSubselect); check {
+				// Handle subqueries in JOIN clauses
+				result.Items = append(result.Items, subselect)
 			} else {
 				panic("expected range var")
 			}
@@ -73,6 +79,9 @@ func convertToRangeVarList(list *ast.List, result *ast.List) {
 		}
 
 	case *ast.RangeVar:
+		result.Items = append(result.Items, rel)
+
+	case *ast.RangeSubselect:
 		result.Items = append(result.Items, rel)
 
 	default:


### PR DESCRIPTION
Fixes #3848 

This would create a panic:
```sql
DELETE pt
FROM primary_table pt
JOIN (SELECT 1 as id) jt ON pt.id = jt.id;
```

```
panic: expected range var

github.com/sqlc-dev/sqlc/internal/engine/dolphin.convertToRangeVarList(0x140000669c0?, 0x140008f0390)
```
