### PR TITLE
Fix SQLite Update query generation

### DIFF
--- a/internal/engine/sqlite/convert.go
+++ b/internal/engine/sqlite/convert.go
@@ -1035,7 +1035,7 @@ func (c *cc) convertUpdate_stmtContext(n Update_stmt) ast.Node {
 	}
 
 	relations := &ast.List{}
-	tableName := n.Qualified_table_name().GetText()
+	tableName := identifier(n.Qualified_table_name().GetText())
 	rel := ast.RangeVar{
 		Relname:  &tableName,
 		Location: n.GetStart().GetStart(),


### PR DESCRIPTION
# Purpose
Resolve the issue described in #3852 where update statements fail when generating queries. Note that this regression was introduced in 1.28.0 and is currently affecting the current latest release (1.29.0).

# Background
In commit 58b08ae the table names in sqlite queries were normalized (i.e. lower cased). In that commit a number of changes were made in the file `internal/engine/sqlite/convert.go` to lowercase tables names in during query parsing so that the table names would always match the table names pulled from the schema even if the casing is different. The linked issue above exists because the table name in update statements was not included in the linked set of changes last year. In essence, if you used an uppercase table name in your update query (i.e. `UPDATE MY_TABLE ...`) it will not match the parsed table name which is currently being converted to lowercase (i.e. `my_table`).

# Changes
- Call the `identifier()` function in `convertUpdate_stmtContext()` so that tableName is properly cased before it is returned and used. 