### PR TITLE
docs: fix parameter syntax inconsistency for MySQL and SQLite

### DIFF
--- a/docs/howto/delete.md
+++ b/docs/howto/delete.md
@@ -5,9 +5,20 @@ CREATE TABLE authors (
   id         SERIAL PRIMARY KEY,
   bio        text   NOT NULL
 );
+```
 
+The parameter syntax varies by database engine:
+
+**PostgreSQL:**
+```sql
 -- name: DeleteAuthor :exec
 DELETE FROM authors WHERE id = $1;
+```
+
+**MySQL and SQLite:**
+```sql
+-- name: DeleteAuthor :exec
+DELETE FROM authors WHERE id = ?;
 ```
 
 ```go

--- a/docs/howto/insert.md
+++ b/docs/howto/insert.md
@@ -5,9 +5,20 @@ CREATE TABLE authors (
   id         SERIAL PRIMARY KEY,
   bio        text   NOT NULL
 );
+```
 
+The parameter syntax varies by database engine:
+
+**PostgreSQL:**
+```sql
 -- name: CreateAuthor :exec
 INSERT INTO authors (bio) VALUES ($1);
+```
+
+**MySQL and SQLite:**
+```sql
+-- name: CreateAuthor :exec
+INSERT INTO authors (bio) VALUES (?);
 ```
 
 ```go
@@ -51,7 +62,10 @@ CREATE TABLE authors (
   name text      NOT NULL,
   bio  text
 );
+```
 
+**PostgreSQL:**
+```sql
 -- name: CreateAuthor :one
 INSERT INTO authors (
   name, bio
@@ -68,6 +82,27 @@ INSERT INTO authors (
 )
 RETURNING id;
 ```
+
+**SQLite (with RETURNING support):**
+```sql
+-- name: CreateAuthor :one
+INSERT INTO authors (
+  name, bio
+) VALUES (
+  ?, ?
+)
+RETURNING *;
+
+-- name: CreateAuthorAndReturnId :one
+INSERT INTO authors (
+  name, bio
+) VALUES (
+  ?, ?
+)
+RETURNING id;
+```
+
+Note: MySQL does not support the `RETURNING` clause. Use `:execresult` instead to get the last insert ID.
 
 ```go
 package db

--- a/docs/howto/select.md
+++ b/docs/howto/select.md
@@ -8,11 +8,26 @@ CREATE TABLE authors (
   bio        text   NOT NULL,
   birth_year int    NOT NULL
 );
+```
 
+The parameter syntax varies by database engine:
 
+**PostgreSQL:**
+```sql
 -- name: GetAuthor :one
 SELECT * FROM authors
 WHERE id = $1;
+
+-- name: ListAuthors :many
+SELECT * FROM authors
+ORDER BY id;
+```
+
+**MySQL and SQLite:**
+```sql
+-- name: GetAuthor :one
+SELECT * FROM authors
+WHERE id = ?;
 
 -- name: ListAuthors :many
 SELECT * FROM authors

--- a/docs/howto/update.md
+++ b/docs/howto/update.md
@@ -12,9 +12,18 @@ CREATE TABLE authors (
 If your query has a single parameter, your Go method will also have a single
 parameter.
 
+The parameter syntax varies by database engine:
+
+**PostgreSQL:**
 ```sql
 -- name: UpdateAuthorBios :exec
 UPDATE authors SET bio = $1;
+```
+
+**MySQL and SQLite:**
+```sql
+-- name: UpdateAuthorBios :exec
+UPDATE authors SET bio = ?;
 ```
 
 ```go
@@ -52,11 +61,21 @@ func (q *Queries) UpdateAuthorBios(ctx context.Context, bio string) error {
 If your query has more than one parameter, your Go method will accept a
 `Params` struct.
 
+**PostgreSQL:**
 ```sql
 -- name: UpdateAuthor :exec
 UPDATE authors SET bio = $2
 WHERE id = $1;
 ```
+
+**MySQL and SQLite:**
+```sql
+-- name: UpdateAuthor :exec
+UPDATE authors SET bio = ?
+WHERE id = ?;
+```
+
+Note: For MySQL and SQLite, parameters are bound in the order they appear in the query, regardless of the order in the function signature.
 
 ```go
 package db


### PR DESCRIPTION
## Summary
This PR fixes parameter syntax inconsistency in the howto documentation where examples only showed PostgreSQL syntax (`$1`, `$2`), causing confusion and errors for MySQL and SQLite users.

## Problem
As reported in #3697, the generic howto documentation files showed only PostgreSQL parameter syntax:
- Used `$1`, `$2` placeholders which only work with PostgreSQL
- Caused **silent failures** in MySQL code generation (functions generated without parameters)
- Caused **syntax errors** in SQLite compilation
- Created confusion for developers using multi-database setups

## Solution
Updated four key documentation files to include database-specific examples:

### Modified Files:
- `docs/howto/update.md`
- `docs/howto/insert.md`  
- `docs/howto/delete.md`
- `docs/howto/select.md`

### Changes Made:
✅ **Added database-specific sections** with clear syntax examples:
- **PostgreSQL**: `$1`, `$2` syntax
- **MySQL and SQLite**: `?` placeholder syntax

✅ **Added explanatory notes** about parameter binding differences

✅ **Maintained existing Go code examples** (they remain database-agnostic)

✅ **Added clarification** about MySQL not supporting `RETURNING` clause

## Example of Changes
**Before:**
```sql
-- name: UpdateAuthor :exec
UPDATE authors SET bio = $2 WHERE id = $1;
```

**After:**
```markdown
**PostgreSQL:**
-- name: UpdateAuthor :exec
UPDATE authors SET bio = $2 WHERE id = $1;

**MySQL and SQLite:**
-- name: UpdateAuthor :exec
UPDATE authors SET bio = ? WHERE id = ?;
```

## Impact
- ✅ Eliminates confusion for MySQL/SQLite users
- ✅ Prevents silent code generation failures  
- ✅ Provides clear guidance for multi-database projects
- ✅ Maintains backward compatibility (PostgreSQL examples preserved)
- ✅ Aligns with existing database-specific tutorial documentation

## Test Plan
- [x] Verified all syntax examples are database-appropriate
- [x] Confirmed tutorials already use correct database-specific syntax
- [x] Ensured documentation structure remains consistent
- [x] Cross-referenced with official database documentation

Fixes #3697

🤖 Generated with [Claude Code](https://claude.ai/code)