### PR TITLE
docs: mention pgxpool in go and pgx guide

### DIFF
--- a/docs/guides/using-go-and-pgx.rst
+++ b/docs/guides/using-go-and-pgx.rst
@@ -109,3 +109,25 @@ pgx types directly.
     
     	fmt.Println(author.Name)
     }
+
+.. note::
+   For production applications, consider using pgxpool for connection pooling:
+
+   .. code-block:: go
+
+       import (
+           "github.com/jackc/pgx/v5/pgxpool"
+           "example.com/sqlc-tutorial/db"
+       )
+
+       func main() {
+           pool, err := pgxpool.New(context.Background(), os.Getenv("DATABASE_URL"))
+           if err != nil {
+               fmt.Fprintf(os.Stderr, "Unable to create connection pool: %v\n", err)
+               os.Exit(1)
+           }
+           defer pool.Close()
+
+           q := db.New(pool)
+           // Use q the same way as with single connections
+       }


### PR DESCRIPTION
Mentioning `pgxpool` to make sure developers consider using a connection pool when using `pgx` and `sqlc`. This can help prevent [bugs](https://github.com/jackc/pgx/issues/2100#issuecomment-2848668548) and will also help answer questions on whether [`sqlc` supports `pgxpool`](https://github.com/sqlc-dev/sqlc/issues/2493).

<img width="728" height="419" alt="image" src="https://github.com/user-attachments/assets/365c87b4-9108-49c3-a4d0-a0b3aa7a77bc" />
