### PR TITLE
fix: generate pointer types for nullable enum columns with emit_pointers_for_null_types

### DIFF
--- a/internal/codegen/golang/postgresql_type.go
+++ b/internal/codegen/golang/postgresql_type.go
@@ -576,6 +576,11 @@ func postgresType(req *plugin.GenerateRequest, options *opts.Options, col *plugi
 							return StructName(enum.Name, options)
 						}
 						return StructName(schema.Name+"_"+enum.Name, options)
+					} else if emitPointersForNull {
+						if schema.Name == req.Catalog.DefaultSchema {
+							return "*" + StructName(enum.Name, options)
+						}
+						return "*" + StructName(schema.Name+"_"+enum.Name, options)
 					} else {
 						if schema.Name == req.Catalog.DefaultSchema {
 							return "Null" + StructName(enum.Name, options)


### PR DESCRIPTION
fixes https://github.com/sqlc-dev/sqlc/issues/4052

The generated QueryParams struct for the example from the issue is indeed:

```go
type SearchFoodParams struct {
    Food     string
    FoodType *FoodType
}
```

I wrote a minimal example to verify that this works as intended with sqlc.