### PR TITLE
chore(engine/dolphin): remove references to deprecated `pcast.ChangeStmt`

### DIFF
--- a/internal/engine/dolphin/convert.go
+++ b/internal/engine/dolphin/convert.go
@@ -727,10 +727,6 @@ func (c *cc) convertCaseExpr(n *pcast.CaseExpr) ast.Node {
 	}
 }
 
-func (c *cc) convertChangeStmt(n *pcast.ChangeStmt) ast.Node {
-	return todo(n)
-}
-
 func (c *cc) convertCleanupTableLockStmt(n *pcast.CleanupTableLockStmt) ast.Node {
 	return todo(n)
 }
@@ -1500,9 +1496,6 @@ func (c *cc) convert(node pcast.Node) ast.Node {
 
 	case *pcast.CaseExpr:
 		return c.convertCaseExpr(n)
-
-	case *pcast.ChangeStmt:
-		return c.convertChangeStmt(n)
 
 	case *pcast.CleanupTableLockStmt:
 		return c.convertCleanupTableLockStmt(n)


### PR DESCRIPTION
`pcast.ChangeStmt` is deprecated, according to https://github.com/pingcap/tidb/issues/62912#issuecomment-3177527279

Resolves https://github.com/sqlc-dev/sqlc/issues/4046
Resolves https://github.com/pingcap/tidb/issues/62912