### PR TITLE
test(endtoend): Skip process_plugin_sqlc_gen_json

### DIFF
--- a/internal/endtoend/testdata/process_plugin_sqlc_gen_json/exec.json
+++ b/internal/endtoend/testdata/process_plugin_sqlc_gen_json/exec.json
@@ -1,3 +1,4 @@
 {
-  "contexts": ["base"]
+  "contexts": ["base"],
+  "process": "sqlc-gen-json"
 }


### PR DESCRIPTION
If the sqlc-gen-json binary isn't installed, skip the test instead of failing. The goal is that running `go test ./...` should work without running any additional commands.