### PR TITLE
fix(compiler): prevent schema parse failures by ignoring psql meta commands

### DIFF
--- a/internal/endtoend/testdata/pg_dump/schema.sql
+++ b/internal/endtoend/testdata/pg_dump/schema.sql
@@ -5,6 +5,8 @@
 -- Dumped from database version 15.3 (Debian 15.3-1.pgdg120+1)
 -- Dumped by pg_dump version 15.3
 
+\restrict auwherpfqaiuwrhgp
+
 SET statement_timeout = 0;
 SET lock_timeout = 0;
 SET idle_in_transaction_session_timeout = 0;


### PR DESCRIPTION
This is kind of a lazy quick-and-dirty implementation that doesn't attempt to consolidate some duplicate line parsing that we do during migration removal and just sticks a func right in the package that handles file parsing for all engines, even though this line filter only applies to postgresql.

Happy to revise if there's a better place to put this.

Resolves https://github.com/sqlc-dev/sqlc/issues/4065