### PR TITLE
Add  $schema as expected property to config

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -65,6 +65,10 @@ type Config struct {
 	Plugins   []Plugin             `json:"plugins" yaml:"plugins"`
 	Rules     []Rule               `json:"rules" yaml:"rules"`
 	Options   map[string]yaml.Node `json:"options" yaml:"options"`
+
+	// expect `$schema` so that parsing a json file which contains `$schema` will not
+	// cause error
+	Schema string `json:"$schema,omitempty" yaml:"$schema,omitempty"`
 }
 
 type Server struct {


### PR DESCRIPTION
This pr adds `$schema` as expected property to `config` so that parsing the following `json` file will not cause any error

```json
{
  "$schema": "https://www.schemastore.org/sqlc-2.0.json",
  "version": "2",
  "sql": [
    {
      "engine": "sqlite",
      "queries": "./problems/means-to-end/sql/queries.sql",
      "schema": "./problems/means-to-end/sql/schema.sql",
      "gen": {
        "go": {
          "package": "db",
          "out": "./problems/means-to-end/db"
        }
      }
    }
  ]
}
```

# Result

Change when running the `generate` command for the above `config` file 


### Before 

```shell
sqlc generate
error parsing sqlc.json: yaml: unmarshal errors:
  line 2: field $schema not found in type config.Config
  ```
  
  
### After 

```shell
sqlc-dev generate

# exited without any error
```