### PR TITLE
Unquote backticks in sqlite identifiers

### DIFF
--- a/internal/engine/sqlite/catalog_test.go
+++ b/internal/engine/sqlite/catalog_test.go
@@ -230,6 +230,23 @@ func TestUpdate(t *testing.T) {
 				},
 			},
 		},
+		{
+			"CREATE TABLE `foo` (`bar` text);",
+			&catalog.Schema{
+				Name: "main",
+				Tables: []*catalog.Table{
+					{
+						Rel: &ast.TableName{Name: "foo"},
+						Columns: []*catalog.Column{
+							{
+								Name: "bar",
+								Type: ast.TypeName{Name: "text"},
+							},
+						},
+					},
+				},
+			},
+		},
 	} {
 		test := tc
 		t.Run(strconv.Itoa(i), func(t *testing.T) {

--- a/internal/engine/sqlite/convert.go
+++ b/internal/engine/sqlite/convert.go
@@ -28,7 +28,7 @@ func todo(funcname string, n node) *ast.TODO {
 }
 
 func identifier(id string) string {
-	if len(id) >= 2 && id[0] == '"' && id[len(id)-1] == '"' {
+	if len(id) >= 2 && (id[0] == '"' && id[len(id)-1] == '"' || id[0] == '`' && id[len(id)-1] == '`') {
 		unquoted, _ := strconv.Unquote(id)
 		return unquoted
 	}


### PR DESCRIPTION
Fixes #3350 #3684 #3800 

In sqlite there is a quirky behavior where backticks are included in table and column names. This causes errors like relation "x" does not exist, even when the column or table is actually present.

The changes in this PR ensure that identifiers no longer include backticks as part of their names.

##  Steps to reproduce the issues this solves
**schema.sql**
```sql
CREATE TABLE `foo` (`bar` text);
```
**queries.sql**
```sql
-- name: GetFoo :many
SELECT bar FROM foo;
```
**sqlc.yaml**
```yaml
version: "2"
sql:
  - engine: "sqlite"
    queries: "queries.sql"
    schema: "schema.sql"
    gen:
      go:
        package: "db"
        out: "db"
```
**output**
```bash
> sqlc generate    
# package db
queries.sql:1:1: relation "foo" does not exist
```
