### PR TITLE
Implement tern template support

### DIFF
--- a/internal/compiler/compile.go
+++ b/internal/compiler/compile.go
@@ -38,6 +38,11 @@ func (c *Compiler) parseCatalog(schemas []string) error {
 			continue
 		}
 		contents := migrations.RemoveRollbackStatements(string(blob))
+		contents, err = migrations.TransformStatements(filepath.Dir(filename), contents)
+		if err != nil {
+			merr.Add(filename, contents, 0, err)
+			continue
+		}
 		c.schema = append(c.schema, contents)
 		stmts, err := c.parser.Parse(strings.NewReader(contents))
 		if err != nil {


### PR DESCRIPTION
`tern` allows sql scripts reference scripts in sub folders with the syntax `{{ template "path/to/script" . }}`.

`sqlc` does not accept this syntax appears within migration scripts, which means you either gives up the nice organizational feature of tern, or gives up sqlc.

By adding a pre-processor func `TransformStatements()` next to `RemoveRollbackStatements()`, this PR allows sqlc to fetch content of script files referenced by tern template syntax and replace the syntax lines with the actual sql file content.

