### PR TITLE
docs: add link to community python plugin

### DIFF
--- a/docs/reference/language-support.rst
+++ b/docs/reference/language-support.rst
@@ -16,18 +16,18 @@ Community language support
 
 New languages can be added via :doc:`plugins <../guides/plugins>`.
 
-========  =================================  ===============  ===============  ===============
-Language  Plugin                             MySQL            PostgreSQL       SQLite
-========  =================================  ===============  ===============  ===============
-C#        `DaredevilOSS/sqlc-gen-csharp`_    Stable           Stable           Stable
-F#        `kaashyapan/sqlc-gen-fsharp`_      N/A              Beta             Beta
-Java      `tandemdude/sqlc-gen-java`_        Beta             Beta             N/A 
-PHP       `lcarilla/sqlc-plugin-php-dbal`_   Beta             N/A              N/A    
-Ruby      `DaredevilOSS/sqlc-gen-ruby`_      Beta             Beta             Beta           
-Zig       `tinyzimmer/sqlc-gen-zig`_         N/A              Beta             Beta            
-Python    `rayakame/sqlc-gen-better-python`_ N/A              Beta             Beta          
-[Any]     `fdietze/sqlc-gen-from-template`_  Stable           Stable           Stable
-========  =================================  ===============  ===============  ===============
+========  ==================================  ===============  ===============  ===============
+Language  Plugin                              MySQL            PostgreSQL       SQLite
+========  ==================================  ===============  ===============  ===============
+C#        `DaredevilOSS/sqlc-gen-csharp`_     Stable           Stable           Stable
+F#        `kaashyapan/sqlc-gen-fsharp`_       N/A              Beta             Beta
+Java      `tandemdude/sqlc-gen-java`_         Beta             Beta             N/A 
+PHP       `lcarilla/sqlc-plugin-php-dbal`_    Beta             N/A              N/A    
+Ruby      `DaredevilOSS/sqlc-gen-ruby`_       Beta             Beta             Beta           
+Zig       `tinyzimmer/sqlc-gen-zig`_          N/A              Beta             Beta            
+Python    `rayakame/sqlc-gen-better-python`_  N/A              Beta             Beta          
+[Any]     `fdietze/sqlc-gen-from-template`_   Stable           Stable           Stable
+========  ==================================  ===============  ===============  ===============
 
 Community projects
 ******************


### PR DESCRIPTION
I've been working on a plugin to [generate python code](https://github.com/rayakame/sqlc-gen-better-python) because the official plugin had some missing features that I really needed for some of my personal projects (and projects of my friends that love sqlc and want to use it with python).

The plugin I've created takes a different approach then the official one and does not use sqlalchemy, it uses the drivers for the db's directy. 

The plugin has support for `postgresql` and `sqlite` at the moment, `mysql` is planned for the near future.
I've also added support for `msgspec` structs and a lot of other config options.

I really do not want to "compete" with the official sqlc-gen-python plugin - I just want to offer an alternative for those who might need these extra features without adding extra load on the sqlc maintainers.