### PR TITLE
feat(plugin): add configuration to run go package

### DIFF
--- a/internal/cmd/generate.go
+++ b/internal/cmd/generate.go
@@ -349,6 +349,7 @@ func codegen(ctx context.Context, combo config.CombinedSettings, sql OutputPair,
 		switch {
 		case plug.Process != nil:
 			handler = &process.Runner{
+				GoPkg:  plug.Process.GoPkg,
 				Cmd:    plug.Process.Cmd,
 				Env:    plug.Env,
 				Format: plug.Process.Format,

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -89,6 +89,7 @@ type Plugin struct {
 	Name    string   `json:"name" yaml:"name"`
 	Env     []string `json:"env" yaml:"env"`
 	Process *struct {
+		GoPkg  string `json:"go_package" yaml:"go_package"`
 		Cmd    string `json:"cmd" yaml:"cmd"`
 		Format string `json:"format" yaml:"format"`
 	} `json:"process" yaml:"process"`
@@ -226,7 +227,8 @@ var ErrPluginExists = errors.New("a plugin with that name already exists")
 var ErrPluginNotFound = errors.New("no plugin found")
 var ErrPluginNoType = errors.New("plugin: field `process` or `wasm` required")
 var ErrPluginBothTypes = errors.New("plugin: `process` and `wasm` cannot both be defined")
-var ErrPluginProcessNoCmd = errors.New("plugin: missing process command")
+var ErrPluginProcessTooManyCmd = errors.New("plugin: only one of `cmd` or `go_package` is allowed for process plugin")
+var ErrPluginProcessNoCmd = errors.New("plugin: missing `cmd` or `go_package` for process plugin")
 
 var ErrInvalidDatabase = errors.New("database must be managed or have a non-empty URI")
 var ErrManagedDatabaseNoProject = errors.New(`managed databases require a cloud project

--- a/internal/config/v_two.go
+++ b/internal/config/v_two.go
@@ -48,8 +48,11 @@ func v2ParseConfig(rd io.Reader) (Config, error) {
 		if conf.Plugins[i].Process != nil && conf.Plugins[i].WASM != nil {
 			return conf, ErrPluginBothTypes
 		}
-		if conf.Plugins[i].Process != nil {
-			if conf.Plugins[i].Process.Cmd == "" {
+		if r := conf.Plugins[i].Process; r != nil {
+			switch {
+			case r.Cmd != "" && r.GoPkg != "":
+				return conf, ErrPluginProcessTooManyCmd
+			case r.Cmd == "" && r.GoPkg == "":
 				return conf, ErrPluginProcessNoCmd
 			}
 		}


### PR DESCRIPTION
This PR adds "go_package" field under "plugin.process" for configurations
I'm trying to write plugin for a specific project, so I think it's reasonable to put plugin code alongside the project, and currently we need to install the plugin into $PATH before running sqlc generate, this simplifies the process.
I suspect the "cmd" field checks for existence for some reason, so I didn't add a "args" field which may be more universal but less maintainable. I'm not sure about that.