### PR TITLE
Fix S1001 linter warning: use copy() instead of manual loop

### DIFF
--- a/internal/codegen/golang/result.go
+++ b/internal/codegen/golang/result.go
@@ -141,9 +141,7 @@ func newGoEmbed(embed *plugin.Identifier, structs []Struct, defaultSchema string
 		}
 
 		fields := make([]Field, len(s.Fields))
-		for i, f := range s.Fields {
-			fields[i] = f
-		}
+		copy(fields, s.Fields)
 
 		return &goEmbed{
 			modelType: s.Name,


### PR DESCRIPTION
Replaces a manual slice copy loop with Go's built-in copy() function to fix the staticcheck S1001 linter warning.

Before:
```go
fields := make([]Field, len(s.Fields))
for i, f := range s.Fields {
    fields[i] = f
}
```

After:
```go
fields := make([]Field, len(s.Fields))
copy(fields, s.Fields)
```

Why:
- Idiomatic Go code
- Fixes linter warning: "should use copy(to, from) instead of a loop"
- No functional changes, just optimization