### PR TITLE
Implement rename_enum option (Fix #2129)

### DIFF
--- a/internal/codegen/golang/enum.go
+++ b/internal/codegen/golang/enum.go
@@ -3,6 +3,8 @@ package golang
 import (
 	"strings"
 	"unicode"
+
+	"github.com/sqlc-dev/sqlc/internal/codegen/golang/opts"
 )
 
 type Constant struct {
@@ -47,9 +49,16 @@ func EnumReplace(value string) string {
 
 // EnumValueName removes all non ident symbols (all but letters, numbers and
 // underscore) and converts snake case ident to camel case.
-func EnumValueName(value string) string {
+func EnumValueName(value string, options *opts.Options) string {
+	if rename := options.RenameEnum[value]; rename != "" {
+		return rename
+	}
 	parts := strings.Split(EnumReplace(value), "_")
 	for i, part := range parts {
+		if _, found := options.InitialismsMap[part]; found {
+			parts[i] = strings.ToUpper(part)
+			continue
+		}
 		parts[i] = titleFirst(part)
 	}
 
@@ -57,6 +66,10 @@ func EnumValueName(value string) string {
 }
 
 func titleFirst(s string) string {
+	if len(s) == 0 {
+		return s
+	}
+
 	r := []rune(s)
 	r[0] = unicode.ToUpper(r[0])
 

--- a/internal/codegen/golang/opts/options.go
+++ b/internal/codegen/golang/opts/options.go
@@ -30,6 +30,7 @@ type Options struct {
 	Out                         string            `json:"out" yaml:"out"`
 	Overrides                   []Override        `json:"overrides,omitempty" yaml:"overrides"`
 	Rename                      map[string]string `json:"rename,omitempty" yaml:"rename"`
+	RenameEnum                  map[string]string `json:"rename_enum,omitempty" yaml:"rename_enum"`
 	SqlPackage                  string            `json:"sql_package" yaml:"sql_package"`
 	SqlDriver                   string            `json:"sql_driver" yaml:"sql_driver"`
 	OutputBatchFileName         string            `json:"output_batch_file_name,omitempty" yaml:"output_batch_file_name"`
@@ -50,8 +51,9 @@ type Options struct {
 }
 
 type GlobalOptions struct {
-	Overrides []Override        `json:"overrides,omitempty" yaml:"overrides"`
-	Rename    map[string]string `json:"rename,omitempty" yaml:"rename"`
+	Overrides  []Override        `json:"overrides,omitempty" yaml:"overrides"`
+	Rename     map[string]string `json:"rename,omitempty" yaml:"rename"`
+	RenameEnum map[string]string `json:"rename_enum,omitempty" yaml:"rename_enum"`
 }
 
 func Parse(req *plugin.GenerateRequest) (*Options, error) {
@@ -71,6 +73,12 @@ func Parse(req *plugin.GenerateRequest) (*Options, error) {
 			options.Rename = map[string]string{}
 		}
 		maps.Copy(options.Rename, global.Rename)
+	}
+	if len(global.RenameEnum) > 0 {
+		if options.RenameEnum == nil {
+			options.RenameEnum = map[string]string{}
+		}
+		maps.Copy(options.RenameEnum, global.RenameEnum)
 	}
 	return options, nil
 }

--- a/internal/codegen/golang/result.go
+++ b/internal/codegen/golang/result.go
@@ -45,7 +45,7 @@ func buildEnums(req *plugin.GenerateRequest, options *opts.Options) []Enum {
 					value = fmt.Sprintf("value_%d", i)
 				}
 				e.Constants = append(e.Constants, Constant{
-					Name:  StructName(enumName+"_"+value, options),
+					Name:  EnumValueName(enumName+"_"+value, options),
 					Value: v,
 					Type:  e.Name,
 				})

--- a/internal/config/v_one.go
+++ b/internal/config/v_one.go
@@ -11,12 +11,13 @@ import (
 )
 
 type V1GenerateSettings struct {
-	Version   string              `json:"version" yaml:"version"`
-	Cloud     Cloud               `json:"cloud" yaml:"cloud"`
-	Packages  []v1PackageSettings `json:"packages" yaml:"packages"`
-	Overrides []golang.Override   `json:"overrides,omitempty" yaml:"overrides,omitempty"`
-	Rename    map[string]string   `json:"rename,omitempty" yaml:"rename,omitempty"`
-	Rules     []Rule              `json:"rules" yaml:"rules"`
+	Version    string              `json:"version" yaml:"version"`
+	Cloud      Cloud               `json:"cloud" yaml:"cloud"`
+	Packages   []v1PackageSettings `json:"packages" yaml:"packages"`
+	Overrides  []golang.Override   `json:"overrides,omitempty" yaml:"overrides,omitempty"`
+	Rename     map[string]string   `json:"rename,omitempty" yaml:"rename,omitempty"`
+	RenameEnum map[string]string   `json:"rename_enum,omitempty" yaml:"rename_enum,omitempty"`
+	Rules      []Rule              `json:"rules" yaml:"rules"`
 }
 
 type v1PackageSettings struct {
@@ -175,10 +176,11 @@ func (c *V1GenerateSettings) Translate() Config {
 		})
 	}
 
-	if len(c.Overrides) > 0 || len(c.Rename) > 0 {
+	if len(c.Overrides) > 0 || len(c.Rename) > 0 || len(c.RenameEnum) > 0 {
 		conf.Overrides.Go = &golang.GlobalOptions{
-			Overrides: c.Overrides,
-			Rename:    c.Rename,
+			Overrides:  c.Overrides,
+			Rename:     c.Rename,
+			RenameEnum: c.RenameEnum,
 		}
 	}
 

--- a/internal/config/v_two.json
+++ b/internal/config/v_two.json
@@ -227,6 +227,14 @@
                                         }
                                     }
                                 },
+                                "rename_enum": {
+                                  "type": "object",
+                                  "patternProperties": {
+                                    ".*": {
+                                      "type": "string"
+                                    }
+                                  }
+                                },
                                 "sql_package": {
                                     "type": "string"
                                 },

--- a/internal/endtoend/testdata/emit_enum_valid_and_values/sqlc.json
+++ b/internal/endtoend/testdata/emit_enum_valid_and_values/sqlc.json
@@ -16,7 +16,9 @@
     "id_old": "IDNew",
     "bar_old": "BarNew",
     "foo_old": "FooNew",
-    "ip_protocol": "IPProtocol",
+    "ip_protocol": "IPProtocol"
+  },
+  "rename_enum": {
     "ip_protocol_tcp": "IPProtocolTCP"
   }
 }

--- a/internal/endtoend/testdata/rename/v1/pgx/v4/sqlc.json
+++ b/internal/endtoend/testdata/rename/v1/pgx/v4/sqlc.json
@@ -14,7 +14,9 @@
     "id_old": "IDNew",
     "bar_old": "BarNew",
     "foo_old": "FooNew",
-    "ip_protocol": "IPProtocol",
+    "ip_protocol": "IPProtocol"
+  },
+  "rename_enum": {
     "ip_protocol_tcp": "IPProtocolTCP"
   }
 }

--- a/internal/endtoend/testdata/rename/v1/pgx/v5/sqlc.json
+++ b/internal/endtoend/testdata/rename/v1/pgx/v5/sqlc.json
@@ -14,7 +14,9 @@
     "id_old": "IDNew",
     "bar_old": "BarNew",
     "foo_old": "FooNew",
-    "ip_protocol": "IPProtocol",
+    "ip_protocol": "IPProtocol"
+  },
+  "rename_enum": {
     "ip_protocol_tcp": "IPProtocolTCP"
   }
 }

--- a/internal/endtoend/testdata/rename/v1/stdlib/sqlc.json
+++ b/internal/endtoend/testdata/rename/v1/stdlib/sqlc.json
@@ -12,7 +12,9 @@
     "id_old": "IDNew",
     "bar_old": "BarNew",
     "foo_old": "FooNew",
-    "ip_protocol": "IPProtocol",
+    "ip_protocol": "IPProtocol"
+  },
+  "rename_enum": {
     "ip_protocol_tcp": "IPProtocolTCP"
   }
 }

--- a/internal/endtoend/testdata/rename/v2/pgx/v4/sqlc.json
+++ b/internal/endtoend/testdata/rename/v2/pgx/v4/sqlc.json
@@ -14,7 +14,9 @@
             "id_old": "IDNew",
             "bar_old": "BarNew",
             "foo_old": "FooNew",
-            "ip_protocol": "IPProtocol",
+            "ip_protocol": "IPProtocol"
+          },
+          "rename_enum": {
             "ip_protocol_tcp": "IPProtocolTCP"
           }
         }

--- a/internal/endtoend/testdata/rename/v2/pgx/v5/sqlc.json
+++ b/internal/endtoend/testdata/rename/v2/pgx/v5/sqlc.json
@@ -14,7 +14,9 @@
             "id_old": "IDNew",
             "bar_old": "BarNew",
             "foo_old": "FooNew",
-            "ip_protocol": "IPProtocol",
+            "ip_protocol": "IPProtocol"
+          },
+          "rename_enum": {
             "ip_protocol_tcp": "IPProtocolTCP"
           }
         }

--- a/internal/endtoend/testdata/rename/v2/stdlib/sqlc.json
+++ b/internal/endtoend/testdata/rename/v2/stdlib/sqlc.json
@@ -13,7 +13,9 @@
             "id_old": "IDNew",
             "bar_old": "BarNew",
             "foo_old": "FooNew",
-            "ip_protocol": "IPProtocol",
+            "ip_protocol": "IPProtocol"
+          },
+          "rename_enum": {
             "ip_protocol_tcp": "IPProtocolTCP"
           }
         }


### PR DESCRIPTION
This pull request adds support for renaming Go enum values via a new `rename_enum` option in the configuration. The changes update the code generation logic to use custom names for enum values if specified, and ensure that enum value renaming is handled consistently across global and local options.

Configuration and code generation enhancements:

* Added a new `RenameEnum` field to the `Options` and `GlobalOptions` structs in `internal/codegen/golang/opts/options.go`, allowing users to specify custom names for enum values. [[1]](diffhunk://#diff-3f2d59d9117f5973dcd92df9e8d437b264171a3f4de8cf1256bb2c1b5f4ff033R33) [[2]](diffhunk://#diff-3f2d59d9117f5973dcd92df9e8d437b264171a3f4de8cf1256bb2c1b5f4ff033R56)
* Updated the JSON schema in `internal/config/v_two.json` to support the new `rename_enum` configuration property.
* Modified the `Parse` function in `internal/codegen/golang/opts/options.go` to merge global `RenameEnum` mappings into local options during parsing.

Enum value naming logic improvements:

* Changed the `EnumValueName` function in `internal/codegen/golang/enum.go` to accept options and use the custom name from `RenameEnum` if available, as well as to respect initialisms.
* Updated enum value generation in `internal/codegen/golang/result.go` to use the new `EnumValueName` logic, ensuring renamed values are used in generated code.

These changes closes #2129.