### PR TITLE
fix: robustly strip psql meta commands

### DIFF
--- a/internal/cmd/createdb.go
+++ b/internal/cmd/createdb.go
@@ -85,7 +85,14 @@ func CreateDB(ctx context.Context, dir, filename, querySetName string, o *Option
 		if err != nil {
 			return fmt.Errorf("read file: %w", err)
 		}
-		ddl = append(ddl, migrations.RemoveRollbackStatements(string(contents)))
+		ddlText, warnings, err := migrations.PreprocessSchemaForApply(string(contents), string(queryset.Engine))
+		if err != nil {
+			return err
+		}
+		for _, warning := range warnings {
+			fmt.Fprintln(o.Stderr, warning)
+		}
+		ddl = append(ddl, ddlText)
 	}
 
 	now := time.Now().UTC().UnixNano()

--- a/internal/cmd/createdb.go
+++ b/internal/cmd/createdb.go
@@ -10,8 +10,7 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/sqlc-dev/sqlc/internal/config"
 	"github.com/sqlc-dev/sqlc/internal/dbmanager"
-	"github.com/sqlc-dev/sqlc/internal/migrations"
-	"github.com/sqlc-dev/sqlc/internal/sql/sqlpath"
+	"github.com/sqlc-dev/sqlc/internal/schemautil"
 )
 
 var createDBCmd = &cobra.Command{
@@ -76,23 +75,11 @@ func CreateDB(ctx context.Context, dir, filename, querySetName string, o *Option
 	}
 
 	var ddl []string
-	files, err := sqlpath.Glob(queryset.Schema)
+	ddl, err = schemautil.LoadSchemasForApply(queryset.Schema, string(queryset.Engine), func(warning string) {
+		fmt.Fprintln(o.Stderr, warning)
+	})
 	if err != nil {
 		return err
-	}
-	for _, schema := range files {
-		contents, err := os.ReadFile(schema)
-		if err != nil {
-			return fmt.Errorf("read file: %w", err)
-		}
-		ddlText, warnings, err := migrations.PreprocessSchemaForApply(string(contents), string(queryset.Engine))
-		if err != nil {
-			return err
-		}
-		for _, warning := range warnings {
-			fmt.Fprintln(o.Stderr, warning)
-		}
-		ddl = append(ddl, ddlText)
 	}
 
 	now := time.Now().UTC().UnixNano()

--- a/internal/cmd/generate.go
+++ b/internal/cmd/generate.go
@@ -306,6 +306,9 @@ func parse(ctx context.Context, name, dir string, sql config.SQL, combo config.C
 		return nil, true
 	}
 	if err := c.ParseCatalog(sql.Schema); err != nil {
+		for _, warning := range c.Warnings() {
+			fmt.Fprintln(stderr, warning)
+		}
 		fmt.Fprintf(stderr, "# package %s\n", name)
 		if parserErr, ok := err.(*multierr.Error); ok {
 			for _, fileErr := range parserErr.Errs() {
@@ -315,6 +318,9 @@ func parse(ctx context.Context, name, dir string, sql config.SQL, combo config.C
 			fmt.Fprintf(stderr, "error parsing schema: %s\n", err)
 		}
 		return nil, true
+	}
+	for _, warning := range c.Warnings() {
+		fmt.Fprintln(stderr, warning)
 	}
 	if parserOpts.Debug.DumpCatalog {
 		debug.Dump(c.Catalog())

--- a/internal/cmd/process.go
+++ b/internal/cmd/process.go
@@ -122,12 +122,12 @@ func processQuerySets(ctx context.Context, rp ResultProcessor, conf *config.Conf
 	if err := grp.Wait(); err != nil {
 		return err
 	}
-	if errored {
-		for i, _ := range stderrs {
-			if _, err := io.Copy(stderr, &stderrs[i]); err != nil {
-				return err
-			}
+	for i := range stderrs {
+		if _, err := io.Copy(stderr, &stderrs[i]); err != nil {
+			return err
 		}
+	}
+	if errored {
 		return fmt.Errorf("errored")
 	}
 	return nil

--- a/internal/cmd/verify.go
+++ b/internal/cmd/verify.go
@@ -102,7 +102,14 @@ func Verify(ctx context.Context, dir, filename string, opts *Options) error {
 				if err != nil {
 					return fmt.Errorf("read file: %w", err)
 				}
-				ddl = append(ddl, migrations.RemoveRollbackStatements(string(contents)))
+				ddlText, warnings, err := migrations.PreprocessSchemaForApply(string(contents), string(current.Engine))
+				if err != nil {
+					return err
+				}
+				for _, warning := range warnings {
+					fmt.Fprintln(stderr, warning)
+				}
+				ddl = append(ddl, ddlText)
 			}
 
 			var codegen plugin.GenerateRequest

--- a/internal/cmd/verify.go
+++ b/internal/cmd/verify.go
@@ -14,11 +14,10 @@ import (
 
 	"github.com/sqlc-dev/sqlc/internal/config"
 	"github.com/sqlc-dev/sqlc/internal/dbmanager"
-	"github.com/sqlc-dev/sqlc/internal/migrations"
 	"github.com/sqlc-dev/sqlc/internal/plugin"
 	"github.com/sqlc-dev/sqlc/internal/quickdb"
 	pb "github.com/sqlc-dev/sqlc/internal/quickdb/v1"
-	"github.com/sqlc-dev/sqlc/internal/sql/sqlpath"
+	"github.com/sqlc-dev/sqlc/internal/schemautil"
 )
 
 func init() {
@@ -93,23 +92,11 @@ func Verify(ctx context.Context, dir, filename string, opts *Options) error {
 
 			// Read the schema files into memory, removing rollback statements
 			var ddl []string
-			files, err := sqlpath.Glob(current.Schema)
+			ddl, err = schemautil.LoadSchemasForApply(current.Schema, string(current.Engine), func(warning string) {
+				fmt.Fprintln(stderr, warning)
+			})
 			if err != nil {
 				return err
-			}
-			for _, schema := range files {
-				contents, err := os.ReadFile(schema)
-				if err != nil {
-					return fmt.Errorf("read file: %w", err)
-				}
-				ddlText, warnings, err := migrations.PreprocessSchemaForApply(string(contents), string(current.Engine))
-				if err != nil {
-					return err
-				}
-				for _, warning := range warnings {
-					fmt.Fprintln(stderr, warning)
-				}
-				ddl = append(ddl, ddlText)
 			}
 
 			var codegen plugin.GenerateRequest

--- a/internal/cmd/vet.go
+++ b/internal/cmd/vet.go
@@ -27,12 +27,11 @@ import (
 	"github.com/sqlc-dev/sqlc/internal/config"
 	"github.com/sqlc-dev/sqlc/internal/dbmanager"
 	"github.com/sqlc-dev/sqlc/internal/debug"
-	"github.com/sqlc-dev/sqlc/internal/migrations"
 	"github.com/sqlc-dev/sqlc/internal/opts"
 	"github.com/sqlc-dev/sqlc/internal/plugin"
 	"github.com/sqlc-dev/sqlc/internal/quickdb"
+	"github.com/sqlc-dev/sqlc/internal/schemautil"
 	"github.com/sqlc-dev/sqlc/internal/shfmt"
-	"github.com/sqlc-dev/sqlc/internal/sql/sqlpath"
 	"github.com/sqlc-dev/sqlc/internal/vet"
 )
 
@@ -422,24 +421,11 @@ func (c *checker) fetchDatabaseUri(ctx context.Context, s config.SQL) (string, f
 		c.Client = dbmanager.NewClient(c.Conf.Servers)
 	})
 
-	var ddl []string
-	files, err := sqlpath.Glob(s.Schema)
+	ddl, err := schemautil.LoadSchemasForApply(s.Schema, string(s.Engine), func(warning string) {
+		fmt.Fprintln(c.Stderr, warning)
+	})
 	if err != nil {
 		return "", cleanup, err
-	}
-	for _, schema := range files {
-		contents, err := os.ReadFile(schema)
-		if err != nil {
-			return "", cleanup, fmt.Errorf("read file: %w", err)
-		}
-		ddlText, warnings, err := migrations.PreprocessSchemaForApply(string(contents), string(s.Engine))
-		if err != nil {
-			return "", cleanup, err
-		}
-		for _, warning := range warnings {
-			fmt.Fprintln(c.Stderr, warning)
-		}
-		ddl = append(ddl, ddlText)
 	}
 
 	resp, err := c.Client.CreateDatabase(ctx, &dbmanager.CreateDatabaseRequest{
@@ -547,24 +533,15 @@ func (c *checker) checkSQL(ctx context.Context, s config.SQL) error {
 			defer db.Close()
 			// For in-memory SQLite databases, apply migrations
 			if isInMemorySQLite(dburl) {
-				files, err := sqlpath.Glob(s.Schema)
+				ddl, err := schemautil.LoadSchemasForApply(s.Schema, string(s.Engine), func(warning string) {
+					fmt.Fprintln(c.Stderr, warning)
+				})
 				if err != nil {
 					return fmt.Errorf("schema: %w", err)
 				}
-				for _, schema := range files {
-					contents, err := os.ReadFile(schema)
-					if err != nil {
-						return fmt.Errorf("read schema file: %w", err)
-					}
-					ddl, warnings, err := migrations.PreprocessSchemaForApply(string(contents), string(s.Engine))
-					if err != nil {
-						return err
-					}
-					for _, warning := range warnings {
-						fmt.Fprintln(c.Stderr, warning)
-					}
-					if _, err := db.ExecContext(ctx, ddl); err != nil {
-						return fmt.Errorf("apply schema %s: %w", schema, err)
+				for _, stmt := range ddl {
+					if _, err := db.ExecContext(ctx, stmt); err != nil {
+						return fmt.Errorf("apply schema: %w", err)
 					}
 				}
 			}

--- a/internal/cmd/vet.go
+++ b/internal/cmd/vet.go
@@ -432,7 +432,14 @@ func (c *checker) fetchDatabaseUri(ctx context.Context, s config.SQL) (string, f
 		if err != nil {
 			return "", cleanup, fmt.Errorf("read file: %w", err)
 		}
-		ddl = append(ddl, migrations.RemoveRollbackStatements(string(contents)))
+		ddlText, warnings, err := migrations.PreprocessSchemaForApply(string(contents), string(s.Engine))
+		if err != nil {
+			return "", cleanup, err
+		}
+		for _, warning := range warnings {
+			fmt.Fprintln(c.Stderr, warning)
+		}
+		ddl = append(ddl, ddlText)
 	}
 
 	resp, err := c.Client.CreateDatabase(ctx, &dbmanager.CreateDatabaseRequest{
@@ -549,7 +556,13 @@ func (c *checker) checkSQL(ctx context.Context, s config.SQL) error {
 					if err != nil {
 						return fmt.Errorf("read schema file: %w", err)
 					}
-					ddl := migrations.RemoveRollbackStatements(string(contents))
+					ddl, warnings, err := migrations.PreprocessSchemaForApply(string(contents), string(s.Engine))
+					if err != nil {
+						return err
+					}
+					for _, warning := range warnings {
+						fmt.Fprintln(c.Stderr, warning)
+					}
 					if _, err := db.ExecContext(ctx, ddl); err != nil {
 						return fmt.Errorf("apply schema %s: %w", schema, err)
 					}

--- a/internal/compiler/compile.go
+++ b/internal/compiler/compile.go
@@ -38,8 +38,12 @@ func (c *Compiler) parseCatalog(schemas []string) error {
 			merr.Add(filename, "", 0, err)
 			continue
 		}
-		contents := migrations.RemoveRollbackStatements(string(blob))
-		contents = migrations.RemovePsqlMetaCommands(contents)
+		contents, warnings, err := migrations.PreprocessSchema(string(blob), string(c.conf.Engine))
+		if err != nil {
+			merr.Add(filename, string(blob), 0, err)
+			continue
+		}
+		c.warns = append(c.warns, warnings...)
 		c.schema = append(c.schema, contents)
 
 		// In database-only mode, we parse the schema to validate syntax

--- a/internal/compiler/engine.go
+++ b/internal/compiler/engine.go
@@ -28,6 +28,7 @@ type Compiler struct {
 	selector selector
 
 	schema []string
+	warns  []string
 
 	// databaseOnlyMode indicates that the compiler should use database-only analysis
 	// and skip building the internal catalog from schema files (analyzer.database: only)
@@ -136,6 +137,12 @@ func (c *Compiler) ParseQueries(queries []string, o opts.Parser) error {
 
 func (c *Compiler) Result() *Result {
 	return c.result
+}
+
+// Warnings returns a copy of any non-fatal schema preprocessing warnings
+// collected while parsing the catalog.
+func (c *Compiler) Warnings() []string {
+	return append([]string(nil), c.warns...)
 }
 
 func (c *Compiler) Close(ctx context.Context) {

--- a/internal/endtoend/testdata/pg_dump/exec.json
+++ b/internal/endtoend/testdata/pg_dump/exec.json
@@ -1,6 +1,3 @@
 {
-    "contexts": ["base"],
-    "meta": {
-        "invalid_schema": true
-    }
+    "contexts": ["base"]
 }

--- a/internal/migrations/migrations.go
+++ b/internal/migrations/migrations.go
@@ -2,17 +2,29 @@ package migrations
 
 import (
 	"bufio"
-	"regexp"
+	"fmt"
 	"strings"
+	"unicode"
+	"unicode/utf8"
 )
 
-// psqlMetaCommand matches a psql meta-command (a line that begins with a
-// backslash followed by a command name). pg_dump emits these starting with
-// PostgreSQL 17.6 / 16.10 / 15.14 / 14.19 / 13.22 (e.g. `\restrict KEY` and
-// `\unrestrict KEY`), and sqlc's SQL parsers cannot handle them.
-var psqlMetaCommand = regexp.MustCompile(`^\\[A-Za-z!?;][^\n]*$`)
+type PreprocessMode int
 
-// Remove all lines after a rollback comment.
+const (
+	// PreprocessModeParse keeps schema text usable for sqlc parsing/codegen and
+	// warns when semantic psql commands are stripped.
+	PreprocessModeParse PreprocessMode = iota
+	// PreprocessModeApply rejects semantic psql commands before sqlc applies
+	// schema text to a live database.
+	PreprocessModeApply
+)
+
+// RemoveRollbackStatements returns the up-migration portion of a migration file
+// by discarding everything from the first recognized rollback marker onward.
+//
+// The supported markers match the migration formats sqlc already understands
+// during schema loading. The function preserves original line ordering up to the
+// rollback boundary so downstream parsing and error locations remain stable.
 //
 // goose:       -- +goose Down
 // sql-migrate: -- +migrate Down
@@ -40,22 +52,779 @@ func RemoveRollbackStatements(contents string) string {
 	return strings.Join(lines, "\n")
 }
 
-// RemovePsqlMetaCommands strips psql meta-command lines (e.g. `\restrict KEY`,
-// `\unrestrict KEY`, `\connect foo`) from SQL input. These are emitted by
-// pg_dump but are not valid SQL, so they must be removed before parsing.
-func RemovePsqlMetaCommands(contents string) string {
-	s := bufio.NewScanner(strings.NewReader(contents))
-	var lines []string
-	for s.Scan() {
-		line := s.Text()
-		if psqlMetaCommand.MatchString(line) {
-			continue
-		}
-		lines = append(lines, line)
-	}
-	return strings.Join(lines, "\n")
+// PreprocessSchema normalizes schema text for sqlc before parsing or applying
+// it to managed databases. Rollback sections are always removed; PostgreSQL
+// schemas preserve server-side SQL, including PL/pgSQL bodies and
+// extension/language DDL, while additionally stripping top-level psql
+// meta-commands that are not valid SQL. The returned warnings describe
+// semantic psql commands that were stripped and any best-effort approximation
+// of psql session semantics used during parsing-oriented preprocessing.
+func PreprocessSchema(contents, engine string) (string, []string, error) {
+	return preprocessSchema(contents, engine, PreprocessModeParse)
 }
 
+// PreprocessSchemaForApply normalizes schema text for commands that will apply
+// the resulting DDL to a live database. Semantic psql commands are rejected in
+// this mode because sqlc cannot reproduce their effects during execution.
+func PreprocessSchemaForApply(contents, engine string) (string, []string, error) {
+	return preprocessSchema(contents, engine, PreprocessModeApply)
+}
+
+// preprocessSchema applies the shared engine-aware preprocessing pipeline using
+// the caller's requested strictness for semantic psql commands.
+func preprocessSchema(contents, engine string, mode PreprocessMode) (string, []string, error) {
+	contents = RemoveRollbackStatements(contents)
+	if engine == "postgresql" {
+		var (
+			err      error
+			warnings []string
+		)
+		contents, warnings, err = removePsqlMetaCommands(contents, mode)
+		if err != nil {
+			return "", nil, err
+		}
+		return contents, warnings, nil
+	}
+	return contents, nil, nil
+}
+
+// RemovePsqlMetaCommands strips top-level psql meta-command lines from SQL
+// input while preserving valid SQL text, literal contents, comments, and line
+// structure. LF and CRLF line endings are preserved; lone CR line endings are
+// normalized to LF so downstream line-number accounting stays correct.
+//
+// pg_dump can emit client-only commands such as `\restrict KEY`,
+// `\unrestrict KEY`, and `\connect foo`. These are meaningful to the psql
+// client but invalid for sqlc's SQL parsers. The implementation uses a
+// single-pass state machine so it only removes backslash directives that
+// appear at true statement line starts, not backslashes embedded in string
+// literals, double-quoted identifiers, dollar-quoted bodies, or comments.
+//
+// The line-start matcher is intentionally broader than the currently
+// documented psql command set: sqlc strips unknown future backslash directives
+// and dump-tool variants the same way it strips known psql meta-commands,
+// because none of them are valid SQL input to the parser.
+func RemovePsqlMetaCommands(contents string) (string, []string, error) {
+	return removePsqlMetaCommands(contents, PreprocessModeParse)
+}
+
+func removePsqlMetaCommands(contents string, mode PreprocessMode) (string, []string, error) {
+	if contents == "" {
+		return contents, nil, nil
+	}
+
+	var out strings.Builder
+	out.Grow(len(contents))
+	warningsByToken := map[string]struct{}{}
+
+	lineStart := true
+	inSingle := false
+	inDouble := false
+	inDollar := false
+	singleAllowsBackslash := false
+	standardConformingStringsOff := false
+	warnedApproximateSessionSemantics := false
+	var dollarTag string
+	blockDepth := 0
+	n := len(contents)
+	var statement strings.Builder
+
+	for i := 0; ; {
+		// Only top-level line starts are eligible for psql meta-command removal.
+		// Leading horizontal whitespace is preserved so stripped lines keep their
+		// original indentation and line count for downstream position accounting.
+		if lineStart && !inSingle && !inDouble && blockDepth == 0 && !inDollar {
+			start := i
+			for i < n {
+				c := contents[i]
+				if c == ' ' || c == '\t' {
+					i++
+					continue
+				}
+				break
+			}
+			if i < n && contents[i] == '\\' && i+1 < n && isMetaCommandStart(contents[i+1]) {
+				lineEnd := i
+				for lineEnd < n && contents[lineEnd] != '\r' && contents[lineEnd] != '\n' {
+					lineEnd++
+				}
+				sep := findMetaCommandSeparator(contents, i, lineEnd)
+				if token := metaCommandToken(contents[i:lineEnd]); token != "" {
+					if sep < 0 && hasInvalidSeparatorCandidate(contents, i, lineEnd) {
+						if start < i {
+							out.WriteString(contents[start:i])
+						}
+						goto normalLexing
+					}
+					switch {
+					case isUnsupportedConditionalMetaCommand(token):
+						return "", nil, fmt.Errorf("psql conditional directives (%s) are not supported in schema preprocessing", token)
+					case isSemanticMetaCommand(token):
+						if mode == PreprocessModeApply {
+							return "", nil, fmt.Errorf("psql meta-command %s is not supported when applying schema preprocessing to a live database", token)
+						}
+						warningsByToken[token] = struct{}{}
+						if token == `\copy` && readsPsqlCopyData(contents, i, lineEnd) {
+							var ok bool
+							i, ok = stripPsqlCopyData(&out, contents, lineEnd)
+							if !ok {
+								return "", nil, fmt.Errorf(`psql meta-command \copy ... from stdin requires a terminating \. line during schema preprocessing`)
+							}
+							lineStart = true
+							continue
+						}
+					}
+				}
+				if sep >= 0 {
+					// Resume normal SQL lexing after a valid `\\` separator so
+					// multiline literals/comments in the preserved tail keep parser
+					// state for following lines.
+					i = sep + 2
+					lineStart = false
+					continue
+				}
+				// Keep LF and CRLF intact when removing a command line. Bare CR is
+				// normalized by writeLineEnding() so stripped output still matches
+				// downstream line-number accounting.
+				i = writeLineEnding(&out, contents, lineEnd)
+				lineStart = true
+				continue
+			}
+			if start < i {
+				out.WriteString(contents[start:i])
+			}
+			if i >= n {
+				break
+			}
+		}
+		if i >= n {
+			break
+		}
+
+	normalLexing:
+		c := contents[i]
+		if inSingle {
+			// Inside string literals, only quote termination rules matter. Escape
+			// strings (`E'...'`) and standard_conforming_strings=off additionally
+			// allow backslash-escaped bytes.
+			if singleAllowsBackslash && c == '\\' && i+1 < n {
+				out.WriteByte(c)
+				out.WriteByte(contents[i+1])
+				consumeStatementFragment(contents[i:i+2], &statement, &standardConformingStringsOff, &warnedApproximateSessionSemantics, false)
+				lineStart = false
+				i += 2
+				continue
+			}
+			if isLineBreak(c) {
+				i = writeLineEnding(&out, contents, i)
+				lineStart = true
+				consumeStatementFragment(" ", &statement, &standardConformingStringsOff, &warnedApproximateSessionSemantics, false)
+				continue
+			}
+			out.WriteByte(c)
+			consumeStatementFragment(contents[i:i+1], &statement, &standardConformingStringsOff, &warnedApproximateSessionSemantics, false)
+			if c == '\'' {
+				if i+1 < n && contents[i+1] == '\'' {
+					out.WriteByte(contents[i+1])
+					consumeStatementFragment(contents[i+1:i+2], &statement, &standardConformingStringsOff, &warnedApproximateSessionSemantics, false)
+					i += 2
+					lineStart = false
+					continue
+				}
+				inSingle = false
+				singleAllowsBackslash = false
+			}
+			lineStart = false
+			i++
+			continue
+		}
+
+		if inDouble {
+			// Double-quoted identifiers may span lines, so line-start backslashes
+			// inside them must never be treated as top-level meta-commands.
+			if isLineBreak(c) {
+				i = writeLineEnding(&out, contents, i)
+				lineStart = true
+				consumeStatementFragment(" ", &statement, &standardConformingStringsOff, &warnedApproximateSessionSemantics, false)
+				continue
+			}
+			out.WriteByte(c)
+			consumeStatementFragment(contents[i:i+1], &statement, &standardConformingStringsOff, &warnedApproximateSessionSemantics, false)
+			if c == '"' {
+				if i+1 < n && contents[i+1] == '"' {
+					out.WriteByte(contents[i+1])
+					consumeStatementFragment(contents[i+1:i+2], &statement, &standardConformingStringsOff, &warnedApproximateSessionSemantics, false)
+					i += 2
+					lineStart = false
+					continue
+				}
+				inDouble = false
+			}
+			lineStart = false
+			i++
+			continue
+		}
+
+		if inDollar {
+			// Dollar-quoted bodies are opaque until their exact tag reappears.
+			if strings.HasPrefix(contents[i:], dollarTag) {
+				out.WriteString(dollarTag)
+				i += len(dollarTag)
+				inDollar = false
+				lineStart = false
+				continue
+			}
+			if isLineBreak(c) {
+				i = writeLineEnding(&out, contents, i)
+				lineStart = true
+				continue
+			}
+			out.WriteByte(c)
+			lineStart = false
+			i++
+			continue
+		}
+
+		if blockDepth > 0 {
+			// Block comments may nest in PostgreSQL, so maintain explicit depth.
+			if c == '/' && i+1 < n && contents[i+1] == '*' {
+				blockDepth++
+				out.WriteString("/*")
+				consumeStatementFragment(" ", &statement, &standardConformingStringsOff, &warnedApproximateSessionSemantics, false)
+				i += 2
+				lineStart = false
+				continue
+			}
+			if c == '*' && i+1 < n && contents[i+1] == '/' {
+				blockDepth--
+				out.WriteString("*/")
+				consumeStatementFragment(" ", &statement, &standardConformingStringsOff, &warnedApproximateSessionSemantics, false)
+				i += 2
+				lineStart = false
+				continue
+			}
+			if isLineBreak(c) {
+				i = writeLineEnding(&out, contents, i)
+				lineStart = true
+				consumeStatementFragment(" ", &statement, &standardConformingStringsOff, &warnedApproximateSessionSemantics, false)
+				continue
+			}
+			out.WriteByte(c)
+			lineStart = false
+			i++
+			continue
+		}
+
+		switch c {
+		case '\'':
+			inSingle = true
+			singleAllowsBackslash = standardConformingStringsOff || isEscapeStringPrefix(contents, i)
+			out.WriteByte(c)
+			consumeStatementFragment(contents[i:i+1], &statement, &standardConformingStringsOff, &warnedApproximateSessionSemantics, false)
+			lineStart = false
+			i++
+			continue
+		case '"':
+			inDouble = true
+			out.WriteByte(c)
+			consumeStatementFragment(contents[i:i+1], &statement, &standardConformingStringsOff, &warnedApproximateSessionSemantics, false)
+			lineStart = false
+			i++
+			continue
+		case '$':
+			if tag := matchDollarTagStart(contents, i); tag != "" {
+				dollarTag = tag
+				inDollar = true
+				out.WriteString(dollarTag)
+				i += len(dollarTag)
+				lineStart = false
+				continue
+			}
+		case '/':
+			if i+1 < n && contents[i+1] == '*' {
+				blockDepth = 1
+				out.WriteString("/*")
+				consumeStatementFragment(" ", &statement, &standardConformingStringsOff, &warnedApproximateSessionSemantics, false)
+				i += 2
+				lineStart = false
+				continue
+			}
+		case '-':
+			if i+1 < n && contents[i+1] == '-' {
+				// Line comments are copied through verbatim and treated as inert
+				// text so quote-like markers inside comments cannot perturb state.
+				for i < n {
+					if contents[i] == '\r' || contents[i] == '\n' {
+						lineStart = true
+						i = writeLineEnding(&out, contents, i)
+						consumeStatementFragment(" ", &statement, &standardConformingStringsOff, &warnedApproximateSessionSemantics, false)
+						goto nextChar
+					}
+					out.WriteByte(contents[i])
+					i++
+				}
+				consumeStatementFragment(" ", &statement, &standardConformingStringsOff, &warnedApproximateSessionSemantics, false)
+				goto nextChar
+			}
+		}
+
+		if isLineBreak(c) {
+			i = writeLineEnding(&out, contents, i)
+			lineStart = true
+			consumeStatementFragment(" ", &statement, &standardConformingStringsOff, &warnedApproximateSessionSemantics, false)
+			continue
+		}
+		out.WriteByte(c)
+		consumeStatementFragment(contents[i:i+1], &statement, &standardConformingStringsOff, &warnedApproximateSessionSemantics, true)
+		lineStart = false
+		i++
+	nextChar:
+	}
+
+	return out.String(), schemaPreprocessWarnings(warningsByToken, warnedApproximateSessionSemantics), nil
+}
+
+// hasInvalidSeparatorCandidate reports whether a directive line contains an
+// unquoted `\\` pair that is not shaped like the validated separator token.
+// Those lines are preserved verbatim so sqlc does not normalize invalid psql
+// syntax into different executable SQL.
+func hasInvalidSeparatorCandidate(contents string, start, lineEnd int) bool {
+	inSingle := false
+	inDouble := false
+	for i := start; i+1 < lineEnd; i++ {
+		switch contents[i] {
+		case '\'':
+			if inSingle {
+				if i+1 < lineEnd && contents[i+1] == '\'' {
+					i++
+					continue
+				}
+				inSingle = false
+				continue
+			}
+			if !inDouble {
+				inSingle = true
+			}
+		case '"':
+			if inDouble {
+				if i+1 < lineEnd && contents[i+1] == '"' {
+					i++
+					continue
+				}
+				inDouble = false
+				continue
+			}
+			if !inSingle {
+				inDouble = true
+			}
+		}
+		if inSingle || inDouble {
+			continue
+		}
+		if contents[i] != '\\' || contents[i+1] != '\\' {
+			continue
+		}
+		if i == start || !isHorizontalSpace(contents[i-1]) {
+			return true
+		}
+	}
+	return false
+}
+
+// isMetaCommandStart reports whether b can begin a top-level backslash
+// directive that sqlc should strip before SQL parsing. The accepted set is
+// intentionally broader than today's documented psql commands so unknown or
+// future client-side directives are treated the same as known meta-commands.
+func isMetaCommandStart(b byte) bool {
+	return isDollarTagChar(b) || b == '!' || b == '?' || b == ';' || b == '\\'
+}
+
+// isDollarTagChar reports whether b is valid inside a PostgreSQL dollar-quote
+// tag. The opening and closing delimiters must match exactly, so the stripper
+// uses the same character class when detecting tagged literals.
+func isDollarTagChar(b byte) bool {
+	return b == '_' || (b >= 'a' && b <= 'z') || (b >= 'A' && b <= 'Z') || (b >= '0' && b <= '9')
+}
+
+// isEscapeStringPrefix reports whether the quote at quotePos begins a
+// PostgreSQL escape string literal (`E'...'`) rather than a plain string or a
+// longer identifier token that merely ends with `e`.
+func isEscapeStringPrefix(contents string, quotePos int) bool {
+	if quotePos == 0 {
+		return false
+	}
+	prev, prevSize := utf8.DecodeLastRuneInString(contents[:quotePos])
+	if prev != 'E' && prev != 'e' {
+		return false
+	}
+	if quotePos == 1 {
+		return true
+	}
+	return !isIdentifierContinuationRune(lastRuneBefore(contents, quotePos-prevSize))
+}
+
+// isIdentifierContinuationRune reports whether r can continue an unquoted
+// PostgreSQL identifier. Continuation characters include `$`, so callers can
+// distinguish `E'...'` from a longer token like `fooE'...'`.
+func isIdentifierContinuationRune(r rune) bool {
+	return r == '_' || r == '$' || unicode.IsLetter(r) || unicode.IsDigit(r)
+}
+
+func isLineBreak(b byte) bool {
+	return b == '\n' || b == '\r'
+}
+
+// isHorizontalSpace reports whether b is a line-preserving indentation byte
+// that can surround a top-level psql `\\` separator token.
+func isHorizontalSpace(b byte) bool {
+	return b == ' ' || b == '\t'
+}
+
+// matchDollarTagStart returns the opening dollar-quote delimiter at i when the
+// `$tag$` sequence starts a real PostgreSQL dollar-quoted literal, not when it
+// merely appears inside an ordinary identifier such as `foo$bar$baz`.
+func matchDollarTagStart(contents string, i int) string {
+	if contents[i] != '$' {
+		return ""
+	}
+	if i > 0 && isIdentifierContinuationRune(lastRuneBefore(contents, i)) {
+		return ""
+	}
+	if i+1 >= len(contents) {
+		return ""
+	}
+	if contents[i+1] == '$' {
+		return "$$"
+	}
+	r, size := utf8.DecodeRuneInString(contents[i+1:])
+	if r == utf8.RuneError && size == 1 {
+		return ""
+	}
+	if !isDollarTagStartRune(r) {
+		return ""
+	}
+	tagEnd := i + 1 + size
+	for tagEnd < len(contents) {
+		r, size = utf8.DecodeRuneInString(contents[tagEnd:])
+		if r == utf8.RuneError && size == 1 {
+			return ""
+		}
+		if r == '$' {
+			return contents[i : tagEnd+size]
+		}
+		if !isDollarTagRune(r) {
+			return ""
+		}
+		tagEnd += size
+	}
+	return ""
+}
+
+// isDollarTagStartRune reports whether r is allowed as the first rune in a
+// PostgreSQL dollar-quote tag, following unquoted identifier start rules.
+func isDollarTagStartRune(r rune) bool {
+	return r == '_' || unicode.IsLetter(r)
+}
+
+// isDollarTagRune reports whether r is allowed after the first rune in a
+// PostgreSQL dollar-quote tag, following unquoted identifier continuation
+// rules but excluding `$`, which terminates the tag.
+func isDollarTagRune(r rune) bool {
+	return r == '_' || unicode.IsLetter(r) || unicode.IsDigit(r)
+}
+
+// lastRuneBefore returns the UTF-8 rune immediately preceding end in contents,
+// or utf8.RuneError when there is no preceding rune.
+func lastRuneBefore(contents string, end int) rune {
+	if end <= 0 {
+		return utf8.RuneError
+	}
+	r, _ := utf8.DecodeLastRuneInString(contents[:end])
+	return r
+}
+
+// findMetaCommandSeparator returns the index of a `\\` separator token inside
+// a top-level backslash directive line. The separator is recognized only when
+// it is delimited by horizontal whitespace or line boundaries so ordinary
+// doubled backslashes inside arguments are not mistaken for psql's
+// meta-command/SQL separator.
+//
+// This rule is intentionally narrower than "any `\\` pair". In tested
+// `psql` 17.9, glued forms such as `\x\\SELECT 1;`, `\echo hi\\SELECT 1;`, or
+// `SELECT 1; \echo hi` are rejected with "invalid command \", and leading
+// `\\`, `\\ SELECT 1;`, and `\\SELECT 1;` are also rejected when no preceding
+// meta-command is present on the line. sqlc therefore treats `\\` as a
+// separator only after an actual meta-command token on the same line.
+func findMetaCommandSeparator(contents string, start, lineEnd int) int {
+	for i := start; i+1 < lineEnd; i++ {
+		if contents[i] != '\\' || contents[i+1] != '\\' {
+			continue
+		}
+		if i <= start {
+			continue
+		}
+		leftOK := i == start || isHorizontalSpace(contents[i-1])
+		rightOK := i+2 == lineEnd || isHorizontalSpace(contents[i+2])
+		if leftOK && rightOK {
+			return i
+		}
+	}
+	return -1
+}
+
+// readsPsqlCopyData reports whether the directive line is a `\copy ... from
+// stdin` command that owns following data rows through an exact `\.` line.
+func readsPsqlCopyData(contents string, start, lineEnd int) bool {
+	fields := strings.Fields(strings.ToLower(contents[start:lineEnd]))
+	if len(fields) == 0 || fields[0] != `\copy` {
+		return false
+	}
+	for i := 1; i+1 < len(fields); i++ {
+		if fields[i] == "from" && fields[i+1] == "stdin" {
+			return true
+		}
+	}
+	return false
+}
+
+// metaCommandToken returns the first backslash-command token from a top-level
+// directive line, preserving psql's command-case distinctions and dropping any
+// trailing arguments.
+func metaCommandToken(line string) string {
+	end := len(line)
+	for i := 1; i < len(line); i++ {
+		if isHorizontalSpace(line[i]) {
+			end = i
+			break
+		}
+	}
+	return line[:end]
+}
+
+// isUnsupportedConditionalMetaCommand reports whether token is a psql
+// conditional directive that sqlc currently rejects instead of flattening,
+// because dropping only the meta-command lines would leave inactive branch SQL
+// behind and change semantics.
+func isUnsupportedConditionalMetaCommand(token string) bool {
+	switch token {
+	case `\if`, `\elif`, `\else`, `\endif`:
+		return true
+	default:
+		return false
+	}
+}
+
+// isSemanticMetaCommand reports whether token is a psql command whose effects
+// are not reproduced by schema preprocessing even though the line is stripped.
+// These commands can change connection context, include external SQL, execute
+// generated SQL, or stream data, so callers should surface a warning when they
+// are removed.
+func isSemanticMetaCommand(token string) bool {
+	switch token {
+	case `\connect`, `\c`, `\i`, `\include`, `\ir`, `\include_relative`, `\copy`, `\gexec`:
+		return true
+	default:
+		return false
+	}
+}
+
+// schemaPreprocessWarnings renders stripping and approximation warnings in a
+// stable order so callers see deterministic output.
+func schemaPreprocessWarnings(tokens map[string]struct{}, warnedApproximateSessionSemantics bool) []string {
+	if len(tokens) == 0 {
+		if !warnedApproximateSessionSemantics {
+			return nil
+		}
+		return []string{approximateSessionSemanticsWarning()}
+	}
+
+	order := []string{`\c`, `\connect`, `\i`, `\include`, `\ir`, `\include_relative`, `\copy`, `\gexec`}
+	var warnings []string
+	for _, token := range order {
+		if _, ok := tokens[token]; !ok {
+			continue
+		}
+		warnings = append(warnings, fmt.Sprintf("warning: stripped psql meta-command %s during schema preprocessing; sqlc does not execute its semantic effects", token))
+	}
+	if warnedApproximateSessionSemantics {
+		warnings = append(warnings, approximateSessionSemanticsWarning())
+	}
+	return warnings
+}
+
+// approximateSessionSemanticsWarning explains that preprocessing intentionally
+// does not emulate full psql session or transaction semantics.
+func approximateSessionSemanticsWarning() string {
+	return "warning: schema preprocessing only approximates psql session semantics after standard_conforming_strings or transaction-scoped script changes"
+}
+
+// stripPsqlCopyData removes the payload rows for a `\copy ... from stdin`
+// command until the exact `\.` terminator line. It returns false if no
+// terminator was found.
+func stripPsqlCopyData(out *strings.Builder, contents string, lineEnd int) (int, bool) {
+	i := writeLineEnding(out, contents, lineEnd)
+	for i < len(contents) {
+		dataLineEnd := i
+		for dataLineEnd < len(contents) && contents[dataLineEnd] != '\r' && contents[dataLineEnd] != '\n' {
+			dataLineEnd++
+		}
+		if contents[i:dataLineEnd] == `\.` {
+			return writeLineEnding(out, contents, dataLineEnd), true
+		}
+		i = writeLineEnding(out, contents, dataLineEnd)
+		if dataLineEnd == len(contents) {
+			return dataLineEnd, false
+		}
+	}
+	return i, false
+}
+
+// consumeStatementFragment appends normalized SQL text to the current
+// statement buffer and optionally treats top-level semicolons as statement
+// terminators for tracking best-effort standard_conforming_strings changes.
+func consumeStatementFragment(text string, statement *strings.Builder, standardConformingStringsOff *bool, warnedApproximateSessionSemantics *bool, allowTerminator bool) {
+	for i := 0; i < len(text); i++ {
+		b := text[i]
+		if b == '\r' || b == '\n' {
+			statement.WriteByte(' ')
+			continue
+		}
+		statement.WriteByte(b)
+		if !allowTerminator || b != ';' {
+			continue
+		}
+		applyStandardConformingStringsStatement(statement.String(), standardConformingStringsOff, warnedApproximateSessionSemantics)
+		statement.Reset()
+	}
+}
+
+// applyStandardConformingStringsStatement updates the best-effort
+// standard_conforming_strings state from a completed top-level statement and
+// flags constructs whose full psql session semantics are intentionally not
+// modeled by preprocessing. Transaction-scoped and savepoint-scoped behavior
+// is deliberately treated as an approximation rather than emulating psql's
+// full session state machine.
+func applyStandardConformingStringsStatement(stmt string, standardConformingStringsOff *bool, warnedApproximateSessionSemantics *bool) {
+	if update, ok := parseStandardConformingStringsSetting(stmt); ok {
+		if update.local || (update.value != nil && *update.value) {
+			*warnedApproximateSessionSemantics = true
+		}
+		switch {
+		case update.scopeDefault, update.value == nil:
+			*standardConformingStringsOff = false
+		default:
+			*standardConformingStringsOff = *update.value
+		}
+		return
+	}
+
+	fields := strings.Fields(strings.NewReplacer(
+		";", " ",
+		"\n", " ",
+		"\r", " ",
+		"\t", " ",
+	).Replace(strings.ToLower(stmt)))
+	if len(fields) == 0 {
+		return
+	}
+	switch fields[0] {
+	case "start":
+		if len(fields) > 1 && fields[1] == "transaction" {
+			*warnedApproximateSessionSemantics = true
+		}
+	case "begin", "commit", "rollback", "abort", "end", "savepoint", "release":
+		*warnedApproximateSessionSemantics = true
+	case "reset":
+		if len(fields) > 1 && fields[1] == "standard_conforming_strings" {
+			*standardConformingStringsOff = false
+			*warnedApproximateSessionSemantics = true
+		}
+		if len(fields) > 1 && fields[1] == "all" {
+			*standardConformingStringsOff = false
+			*warnedApproximateSessionSemantics = true
+		}
+	}
+}
+
+type standardConformingStringsUpdate struct {
+	local        bool
+	scopeDefault bool
+	value        *bool
+}
+
+// parseStandardConformingStringsSetting extracts the standard_conforming_strings
+// update encoded by a SET statement. The second return value reports whether
+// stmt matched that setting at all.
+func parseStandardConformingStringsSetting(stmt string) (standardConformingStringsUpdate, bool) {
+	fields := strings.Fields(strings.NewReplacer(
+		"=", " = ",
+		";", " ",
+		"\n", " ",
+		"\r", " ",
+		"\t", " ",
+	).Replace(strings.ToLower(stmt)))
+	if len(fields) == 0 || fields[0] != "set" {
+		return standardConformingStringsUpdate{}, false
+	}
+	idx := 1
+	update := standardConformingStringsUpdate{}
+	if idx < len(fields) && (fields[idx] == "local" || fields[idx] == "session") {
+		update.local = fields[idx] == "local"
+		idx++
+	}
+	if idx+2 >= len(fields) || fields[idx] != "standard_conforming_strings" {
+		return standardConformingStringsUpdate{}, false
+	}
+	if fields[idx+1] != "=" && fields[idx+1] != "to" {
+		return standardConformingStringsUpdate{}, false
+	}
+	value := strings.Trim(fields[idx+2], `'`)
+	switch value {
+	case "off", "false":
+		v := true
+		update.value = &v
+		return update, true
+	case "on", "true":
+		v := false
+		update.value = &v
+		return update, true
+	case "default":
+		if update.local {
+			update.value = nil
+		} else {
+			update.scopeDefault = true
+		}
+		return update, true
+	default:
+		return standardConformingStringsUpdate{}, false
+	}
+}
+
+// writeLineEnding copies the exact line terminator sequence at i, preserving
+// either LF or CRLF. Bare CR is normalized to LF so downstream line counting,
+// which keys off `\n`, stays consistent with stripped SQL.
+func writeLineEnding(out *strings.Builder, contents string, i int) int {
+	if i >= len(contents) {
+		return i
+	}
+	if contents[i] == '\r' {
+		i++
+		if i < len(contents) && contents[i] == '\n' {
+			out.WriteString("\r\n")
+			i++
+		} else {
+			out.WriteByte('\n')
+		}
+		return i
+	}
+	if contents[i] == '\n' {
+		out.WriteByte('\n')
+		return i + 1
+	}
+	return i
+}
+
+// IsDown reports whether filename is a golang-migrate rollback migration.
 func IsDown(filename string) bool {
 	// Remove golang-migrate rollback files.
 	return strings.HasSuffix(filename, ".down.sql")

--- a/internal/migrations/migrations_test.go
+++ b/internal/migrations/migrations_test.go
@@ -1,10 +1,15 @@
 package migrations
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
 )
+
+func containsWarningToken(warning, token string) bool {
+	return strings.Contains(warning, token)
+}
 
 const inputGoose = `
 -- +goose Up
@@ -64,7 +69,10 @@ CREATE TABLE foo (id int);
 `
 
 const outputPsqlMeta = `
+
 CREATE TABLE foo (id int);
+
+
 `
 
 func TestRemoveRollback(t *testing.T) {
@@ -83,8 +91,164 @@ func TestRemoveRollback(t *testing.T) {
 }
 
 func TestRemovePsqlMetaCommands(t *testing.T) {
-	if diff := cmp.Diff(outputPsqlMeta, RemovePsqlMetaCommands(inputPsqlMeta)); diff != "" {
+	got, warnings, err := RemovePsqlMetaCommands(inputPsqlMeta)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(warnings) != 0 {
+		t.Fatalf("unexpected warnings: %v", warnings)
+	}
+	if diff := cmp.Diff(outputPsqlMeta, got); diff != "" {
 		t.Errorf("psql meta-command mismatch:\n%s", diff)
+	}
+}
+
+func TestPreprocessSchema(t *testing.T) {
+	input := `\restrict key
+
+CREATE TABLE foo (id int);
+`
+	wantPostgreSQL := `
+
+CREATE TABLE foo (id int);`
+	wantMySQL := `\restrict key
+
+CREATE TABLE foo (id int);`
+
+	gotPostgreSQL, warningsPostgreSQL, err := PreprocessSchema(input, "postgresql")
+	if err != nil {
+		t.Fatalf("unexpected postgresql error: %v", err)
+	}
+	if len(warningsPostgreSQL) != 0 {
+		t.Fatalf("unexpected postgresql warnings: %v", warningsPostgreSQL)
+	}
+	if diff := cmp.Diff(wantPostgreSQL, gotPostgreSQL); diff != "" {
+		t.Errorf("postgresql preprocess mismatch:\n%s", diff)
+	}
+
+	gotMySQL, warningsMySQL, err := PreprocessSchema(input, "mysql")
+	if err != nil {
+		t.Fatalf("unexpected mysql error: %v", err)
+	}
+	if len(warningsMySQL) != 0 {
+		t.Fatalf("unexpected mysql warnings: %v", warningsMySQL)
+	}
+	if diff := cmp.Diff(wantMySQL, gotMySQL); diff != "" {
+		t.Errorf("mysql preprocess mismatch:\n%s", diff)
+	}
+}
+
+func TestPreprocessSchema_NormalizesBareCR(t *testing.T) {
+	input := "SELECT 1;\r\\restrict key\rSELECT 2;\r"
+	want := "SELECT 1;\n\nSELECT 2;"
+
+	got, warnings, err := PreprocessSchema(input, "postgresql")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(warnings) != 0 {
+		t.Fatalf("unexpected warnings: %v", warnings)
+	}
+	if diff := cmp.Diff(want, got); diff != "" {
+		t.Errorf("bare CR normalization mismatch:\n%s", diff)
+	}
+}
+
+func TestPreprocessSchema_RejectsPsqlConditionals(t *testing.T) {
+	input := `\if false
+SELECT invalid ;;;
+\else
+SELECT 42;
+\endif
+`
+	if _, _, err := PreprocessSchema(input, "postgresql"); err == nil {
+		t.Fatalf("expected psql conditional directives to be rejected")
+	}
+}
+
+func TestPreprocessSchema_WarnsForSemanticPsqlCommands(t *testing.T) {
+	tests := []struct {
+		input string
+		token string
+	}{
+		{input: `\connect db`, token: `\connect`},
+		{input: `\i extra.sql`, token: `\i`},
+		{input: `\include extra.sql`, token: `\include`},
+		{input: `\ir extra.sql`, token: `\ir`},
+		{input: `\include_relative extra.sql`, token: `\include_relative`},
+		{input: `\copy foo from '/tmp/data.csv'`, token: `\copy`},
+		{input: `\gexec`, token: `\gexec`},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.token, func(t *testing.T) {
+			got, warnings, err := PreprocessSchema(tc.input+"\nSELECT 42;\n", "postgresql")
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if diff := cmp.Diff("\nSELECT 42;", got); diff != "" {
+				t.Fatalf("unexpected output:\n%s", diff)
+			}
+			if len(warnings) != 1 {
+				t.Fatalf("expected one warning, got %v", warnings)
+			}
+			if want := tc.token; warnings[0] == "" || !containsWarningToken(warnings[0], want) {
+				t.Fatalf("warning %q does not mention %s", warnings[0], want)
+			}
+		})
+	}
+}
+
+func TestPreprocessSchemaForApply_RejectsSemanticPsqlCommands(t *testing.T) {
+	tests := []string{
+		`\connect db`,
+		`\i extra.sql`,
+		`\include extra.sql`,
+		`\ir extra.sql`,
+		`\include_relative extra.sql`,
+		`\copy foo from stdin`,
+		`\gexec`,
+	}
+
+	for _, input := range tests {
+		t.Run(input, func(t *testing.T) {
+			if _, _, err := PreprocessSchemaForApply(input+"\nSELECT 42;\n", "postgresql"); err == nil {
+				t.Fatalf("expected %q to be rejected in apply mode", input)
+			}
+		})
+	}
+}
+
+func TestPreprocessSchema_RejectsUnterminatedCopyFromStdin(t *testing.T) {
+	input := `\copy foo from stdin
+1	alpha
+SELECT 42;
+`
+
+	if _, _, err := PreprocessSchema(input, "postgresql"); err == nil {
+		t.Fatalf("expected unterminated \\copy ... from stdin block to be rejected")
+	}
+}
+
+func TestPreprocessSchema_WarnsForApproximateSessionSemantics(t *testing.T) {
+	input := `BEGIN;
+SET LOCAL standard_conforming_strings = off;
+SELECT '\still best effort';
+COMMIT;
+`
+
+	got, warnings, err := PreprocessSchema(input, "postgresql")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if diff := cmp.Diff(input[:len(input)-1], got); diff != "" {
+		t.Fatalf("unexpected output:\n%s", diff)
+	}
+	if len(warnings) != 1 {
+		t.Fatalf("expected one approximation warning, got %v", warnings)
+	}
+	if !strings.Contains(warnings[0], "approximates psql session semantics") {
+		t.Fatalf("unexpected warning: %q", warnings[0])
 	}
 }
 

--- a/internal/migrations/psql_meta_hardening_test.go
+++ b/internal/migrations/psql_meta_hardening_test.go
@@ -1,0 +1,440 @@
+package migrations
+
+import (
+	"strings"
+	"testing"
+	"unicode/utf8"
+)
+
+func TestRemovePsqlMetaCommands_Hardening(t *testing.T) {
+	tests := []stripCase{
+		{
+			name: "BlockCommentsActAsWhitespaceForSettingTracking",
+			in: `SET/*comment*/standard_conforming_strings=off;
+INSERT INTO foo VALUES ('x\'
+\connect still_literal
+');
+\connect should_go
+`,
+			want: `SET/*comment*/standard_conforming_strings=off;
+INSERT INTO foo VALUES ('x\'
+\connect still_literal
+');
+
+`,
+		},
+		{
+			name: "LineCommentsActAsWhitespaceForSettingTracking",
+			in: `SET--comment
+standard_conforming_strings = off;
+INSERT INTO foo VALUES ('x\'
+\connect still_literal
+');
+\connect should_go
+`,
+			want: `SET--comment
+standard_conforming_strings = off;
+INSERT INTO foo VALUES ('x\'
+\connect still_literal
+');
+
+`,
+		},
+		{
+			name: "InlineDoubleBackslashSeparatorPropagatesLexerState",
+			in: `\x \\ SELECT 'open
+\connect still_literal
+'
+\connect should_go
+`,
+			want: ` SELECT 'open
+\connect still_literal
+'
+
+`,
+		},
+		{
+			name: "NoWhitespaceDoubleBackslashSeparatorIsNotSpecial",
+			in:   "\\\\SELECT 1;\n",
+			want: "\\\\SELECT 1;\n",
+		},
+		{
+			name: "NoWhitespaceInlineDoubleBackslashSeparatorIsNotSpecial",
+			in:   "\\echo hi\\\\SELECT 1;\n",
+			want: "\\echo hi\\\\SELECT 1;\n",
+		},
+		{
+			name: "IndentedInvalidSeparatorCandidatePreservesLeadingWhitespace",
+			in:   "  \\echo hi\\\\SELECT 1;\n",
+			want: "  \\echo hi\\\\SELECT 1;\n",
+		},
+		{
+			name: "LeadingDoubleBackslashLineIsNotSpecial",
+			in:   "\\\\\nSELECT 1;\n",
+			want: "\\\\\nSELECT 1;\n",
+		},
+		{
+			name: "LeadingDoubleBackslashWithWhitespaceTailIsNotSpecial",
+			in:   "\\\\ SELECT 1;\n",
+			want: "\\\\ SELECT 1;\n",
+		},
+		{
+			name: "CopyFromStdinTerminatorCanBeFollowedByLaterMetaAndSQL",
+			in: `\copy foo from stdin
+1	alpha
+\.
+\connect other
+SELECT 1;
+`,
+			want: `
+
+
+
+SELECT 1;
+`,
+		},
+		{
+			name: "CopyFromStdinWhitespacePrefixedDotIsDataNotTerminator",
+			in: `\copy foo from stdin
+ \.
+SELECT 1;
+`,
+			wantErr: true,
+		},
+		{
+			name: "CopyFromStdinTerminatorMustBeOwnLine",
+			in: `\copy foo from stdin
+1	alpha
+\. \echo hi
+SELECT 1;
+`,
+			wantErr: true,
+		},
+		{
+			name: "CopyFromStdinTerminatorCannotShareLineWithSeparatorAndSQL",
+			in: `\copy foo from stdin
+1	alpha
+\. \\ SELECT 1;
+`,
+			wantErr: true,
+		},
+		{
+			name: "DoubledBackslashesInMetaCommandArgumentsDoNotDisableStripping",
+			in:   "\\include \\\\server\\share\\schema.sql\nSELECT 1;\n",
+			want: "\nSELECT 1;\n",
+		},
+		{
+			name: "QuotedDoubledBackslashesInMetaCommandArgumentsDoNotDisableStripping",
+			in:   "\\echo 'foo\\\\bar'\nSELECT 1;\n",
+			want: "\nSELECT 1;\n",
+		},
+		{
+			name: "LineCommentAtEOFDoesNotAffectState",
+			in:   "-- just a trailing comment with $tag$ and /* and '",
+			want: "-- just a trailing comment with $tag$ and /* and '",
+		},
+	}
+
+	runRemovePsqlMetaCommandCases(t, tests)
+}
+
+func TestPsqlMetaHelperHardening(t *testing.T) {
+	t.Run("isUnsupportedConditionalMetaCommand", func(t *testing.T) {
+		if !isUnsupportedConditionalMetaCommand(`\if`) {
+			t.Fatalf(`expected \if to be unsupported`)
+		}
+		if !isUnsupportedConditionalMetaCommand(`\endif`) {
+			t.Fatalf(`expected \endif to be unsupported`)
+		}
+		if isUnsupportedConditionalMetaCommand(`\connect`) {
+			t.Fatalf(`expected \connect to remain supported`)
+		}
+	})
+
+	t.Run("isSemanticMetaCommand", func(t *testing.T) {
+		for _, token := range []string{`\c`, `\connect`, `\i`, `\include`, `\ir`, `\include_relative`, `\copy`, `\gexec`} {
+			if !isSemanticMetaCommand(token) {
+				t.Fatalf("expected %s to be semantic", token)
+			}
+		}
+		for _, token := range []string{`\restrict`, `\set`} {
+			if isSemanticMetaCommand(token) {
+				t.Fatalf("expected %s not to be semantic", token)
+			}
+		}
+	})
+
+	t.Run("readsPsqlCopyData", func(t *testing.T) {
+		if readsPsqlCopyData(``, 0, 0) {
+			t.Fatalf(`empty input should not be treated as \copy data`)
+		}
+		if !readsPsqlCopyData(`\copy foo from stdin`, 0, len(`\copy foo from stdin`)) {
+			t.Fatalf(`expected \copy ... from stdin to be recognized`)
+		}
+		if !readsPsqlCopyData("\\copy foo FROM\tSTDIN", 0, len("\\copy foo FROM\tSTDIN")) {
+			t.Fatalf(`expected whitespace/case variants of \copy ... from stdin to be recognized`)
+		}
+		if readsPsqlCopyData(`\copy foo from '/tmp/data.csv'`, 0, len(`\copy foo from '/tmp/data.csv'`)) {
+			t.Fatalf(`did not expect file-based \copy to be treated as stdin data`)
+		}
+	})
+
+	t.Run("hasInvalidSeparatorCandidate", func(t *testing.T) {
+		if hasInvalidSeparatorCandidate(`\echo hi \\ SELECT 1;`, 0, len(`\echo hi \\ SELECT 1;`)) {
+			t.Fatalf(`did not expect valid whitespace-delimited separator to be treated as invalid`)
+		}
+		if !hasInvalidSeparatorCandidate(`\echo hi\\SELECT 1;`, 0, len(`\echo hi\\SELECT 1;`)) {
+			t.Fatalf(`expected glued separator candidate to be recognized`)
+		}
+		if hasInvalidSeparatorCandidate(`\echo "hi""there" \\ SELECT 1;`, 0, len(`\echo "hi""there" \\ SELECT 1;`)) {
+			t.Fatalf(`did not expect doubled-quote escape path with valid separator to be treated as invalid`)
+		}
+		if !hasInvalidSeparatorCandidate(`\echo "hi""there"\\SELECT 1;`, 0, len(`\echo "hi""there"\\SELECT 1;`)) {
+			t.Fatalf(`expected doubled-quote exit path to still recognize glued separator`)
+		}
+		if hasInvalidSeparatorCandidate(`\echo 'it''s' \\ SELECT 1;`, 0, len(`\echo 'it''s' \\ SELECT 1;`)) {
+			t.Fatalf(`did not expect doubled-single-quote escape path with valid separator to be treated as invalid`)
+		}
+		if hasInvalidSeparatorCandidate(`\include \\server\share\schema.sql`, 0, len(`\include \\server\share\schema.sql`)) {
+			t.Fatalf(`did not expect UNC-style argument to be treated as an invalid separator candidate`)
+		}
+		if hasInvalidSeparatorCandidate(`\echo 'foo\\bar'`, 0, len(`\echo 'foo\\bar'`)) {
+			t.Fatalf(`did not expect quoted doubled backslashes to be treated as an invalid separator candidate`)
+		}
+	})
+
+	t.Run("parseStandardConformingStringsSetting", func(t *testing.T) {
+		type testCase struct {
+			name         string
+			in           string
+			wantOK       bool
+			wantLocal    bool
+			wantScopeDef bool
+			wantValue    *bool
+		}
+		boolPtr := func(v bool) *bool { return &v }
+		tests := []testCase{
+			{name: "empty", in: "", wantOK: false},
+			{name: "off", in: "SET standard_conforming_strings = off;", wantOK: true, wantValue: boolPtr(true)},
+			{name: "local on", in: "set local standard_conforming_strings to on;", wantOK: true, wantLocal: true, wantValue: boolPtr(false)},
+			{name: "quoted off", in: "set standard_conforming_strings = 'off';", wantOK: true, wantValue: boolPtr(true)},
+			{name: "quoted local on", in: "set local standard_conforming_strings to 'on';", wantOK: true, wantLocal: true, wantValue: boolPtr(false)},
+			{name: "boolean false", in: "set standard_conforming_strings = false;", wantOK: true, wantValue: boolPtr(true)},
+			{name: "boolean true", in: "set session standard_conforming_strings = true;", wantOK: true, wantValue: boolPtr(false)},
+			{name: "session on", in: "set session standard_conforming_strings = on;", wantOK: true, wantValue: boolPtr(false)},
+			{name: "local default", in: "set local standard_conforming_strings = default;", wantOK: true, wantLocal: true},
+			{name: "session default", in: "set standard_conforming_strings = default;", wantOK: true, wantScopeDef: true},
+			{name: "from current", in: "set standard_conforming_strings from current;", wantOK: false},
+			{name: "unknown value", in: "set standard_conforming_strings = maybe;", wantOK: false},
+			{name: "missing operator", in: "set standard_conforming_strings off;", wantOK: false},
+			{name: "truncated", in: "set standard_conforming_strings =", wantOK: false},
+			{name: "truncated local", in: "set local standard_conforming_strings =", wantOK: false},
+			{name: "other setting", in: "set other_setting = off;", wantOK: false},
+			{name: "non set", in: "SELECT 1;", wantOK: false},
+		}
+		for _, tc := range tests {
+			t.Run(tc.name, func(t *testing.T) {
+				got, ok := parseStandardConformingStringsSetting(tc.in)
+				if ok != tc.wantOK {
+					t.Fatalf("expected ok=%v, got ok=%v value=%+v", tc.wantOK, ok, got)
+				}
+				if !ok {
+					return
+				}
+				if got.local != tc.wantLocal {
+					t.Fatalf("expected local=%v, got %+v", tc.wantLocal, got)
+				}
+				if got.scopeDefault != tc.wantScopeDef {
+					t.Fatalf("expected scopeDefault=%v, got %+v", tc.wantScopeDef, got)
+				}
+				switch {
+				case tc.wantValue == nil && got.value != nil:
+					t.Fatalf("expected nil value, got %+v", got)
+				case tc.wantValue != nil && got.value == nil:
+					t.Fatalf("expected value %v, got nil", *tc.wantValue)
+				case tc.wantValue != nil && got.value != nil && *tc.wantValue != *got.value:
+					t.Fatalf("expected value %v, got %+v", *tc.wantValue, got)
+				}
+			})
+		}
+	})
+
+	t.Run("consumeStatementFragment", func(t *testing.T) {
+		var statement strings.Builder
+		standardConformingStringsOff := false
+		warnedApproximateSessionSemantics := false
+
+		consumeStatementFragment("SET standard_conforming_strings = off;", &statement, &standardConformingStringsOff, &warnedApproximateSessionSemantics, true)
+		if !standardConformingStringsOff {
+			t.Fatalf("expected standard_conforming_strings to switch off")
+		}
+		if !warnedApproximateSessionSemantics {
+			t.Fatalf("expected standard_conforming_strings tracking to emit an approximation warning")
+		}
+		if statement.Len() != 0 {
+			t.Fatalf("expected statement buffer to reset after semicolon, got %q", statement.String())
+		}
+
+		consumeStatementFragment("SELECT 1\r", &statement, &standardConformingStringsOff, &warnedApproximateSessionSemantics, true)
+		if statement.String() != "SELECT 1 " {
+			t.Fatalf("expected line break normalization in statement buffer, got %q", statement.String())
+		}
+
+		statement.Reset()
+		consumeStatementFragment("SET standard_conforming_strings = on;", &statement, &standardConformingStringsOff, &warnedApproximateSessionSemantics, true)
+		if standardConformingStringsOff {
+			t.Fatalf("expected standard_conforming_strings to switch back on")
+		}
+
+		statement.Reset()
+		standardConformingStringsOff = false
+		warnedApproximateSessionSemantics = false
+		consumeStatementFragment("SET standard_conforming_strings = 'off", &statement, &standardConformingStringsOff, &warnedApproximateSessionSemantics, true)
+		consumeStatementFragment("'", &statement, &standardConformingStringsOff, &warnedApproximateSessionSemantics, false)
+		consumeStatementFragment(";", &statement, &standardConformingStringsOff, &warnedApproximateSessionSemantics, true)
+		if !standardConformingStringsOff {
+			t.Fatalf("expected quoted standard_conforming_strings to switch off")
+		}
+		if !warnedApproximateSessionSemantics {
+			t.Fatalf("expected quoted standard_conforming_strings tracking to warn")
+		}
+
+		statement.Reset()
+		consumeStatementFragment("RESET ALL;", &statement, &standardConformingStringsOff, &warnedApproximateSessionSemantics, true)
+		if standardConformingStringsOff {
+			t.Fatalf("expected RESET ALL to restore default standard_conforming_strings")
+		}
+
+		statement.Reset()
+		standardConformingStringsOff = false
+		warnedApproximateSessionSemantics = false
+		applyStandardConformingStringsStatement("", &standardConformingStringsOff, &warnedApproximateSessionSemantics)
+		if standardConformingStringsOff || warnedApproximateSessionSemantics {
+			t.Fatalf("expected empty statement to be ignored")
+		}
+
+		statement.Reset()
+		standardConformingStringsOff = false
+		warnedApproximateSessionSemantics = false
+		consumeStatementFragment("SET", &statement, &standardConformingStringsOff, &warnedApproximateSessionSemantics, true)
+		consumeStatementFragment(" ", &statement, &standardConformingStringsOff, &warnedApproximateSessionSemantics, false)
+		consumeStatementFragment("standard_conforming_strings=off;", &statement, &standardConformingStringsOff, &warnedApproximateSessionSemantics, true)
+		if !standardConformingStringsOff {
+			t.Fatalf("expected comment-separated statement fragments to preserve whitespace boundaries")
+		}
+
+		statement.Reset()
+		standardConformingStringsOff = false
+		warnedApproximateSessionSemantics = false
+		consumeStatementFragment("START TRANSACTION;", &statement, &standardConformingStringsOff, &warnedApproximateSessionSemantics, true)
+		if !warnedApproximateSessionSemantics {
+			t.Fatalf("expected START TRANSACTION to trigger approximation warning")
+		}
+
+		statement.Reset()
+		standardConformingStringsOff = false
+		warnedApproximateSessionSemantics = false
+		applyStandardConformingStringsStatement("START WORK;", &standardConformingStringsOff, &warnedApproximateSessionSemantics)
+		if warnedApproximateSessionSemantics {
+			t.Fatalf("expected unrelated START variant to remain ignored")
+		}
+
+		statement.Reset()
+		standardConformingStringsOff = true
+		warnedApproximateSessionSemantics = false
+		consumeStatementFragment("RESET standard_conforming_strings;", &statement, &standardConformingStringsOff, &warnedApproximateSessionSemantics, true)
+		if standardConformingStringsOff {
+			t.Fatalf("expected RESET standard_conforming_strings to restore default")
+		}
+		if !warnedApproximateSessionSemantics {
+			t.Fatalf("expected RESET standard_conforming_strings to trigger approximation warning")
+		}
+
+		statement.Reset()
+		standardConformingStringsOff = true
+		warnedApproximateSessionSemantics = false
+		applyStandardConformingStringsStatement("RESET search_path;", &standardConformingStringsOff, &warnedApproximateSessionSemantics)
+		if !standardConformingStringsOff || warnedApproximateSessionSemantics {
+			t.Fatalf("expected unrelated RESET to remain ignored")
+		}
+
+		statement.Reset()
+		standardConformingStringsOff = false
+		warnedApproximateSessionSemantics = false
+		consumeStatementFragment("\n", &statement, &standardConformingStringsOff, &warnedApproximateSessionSemantics, false)
+		if statement.String() != " " {
+			t.Fatalf("expected newline to normalize to space, got %q", statement.String())
+		}
+	})
+
+	t.Run("isEscapeStringPrefix", func(t *testing.T) {
+		if isEscapeStringPrefix("", 0) {
+			t.Fatalf("empty input should not report an escape-string prefix")
+		}
+		if !isEscapeStringPrefix("E'", 1) {
+			t.Fatalf("single-rune E prefix should be recognized")
+		}
+		if isEscapeStringPrefix("x'", 1) {
+			t.Fatalf("non-E prefix should not be recognized")
+		}
+	})
+
+	t.Run("matchDollarTagStart", func(t *testing.T) {
+		if got := matchDollarTagStart("plain", 0); got != "" {
+			t.Fatalf("non-dollar input should not match, got %q", got)
+		}
+		if got := matchDollarTagStart("x$foo$", 1); got != "" {
+			t.Fatalf("identifier-adjacent dollar tag should not match, got %q", got)
+		}
+		if got := matchDollarTagStart("$", 0); got != "" {
+			t.Fatalf("truncated dollar tag should not match, got %q", got)
+		}
+		if got := matchDollarTagStart("$foo", 0); got != "" {
+			t.Fatalf("unterminated dollar tag should not match, got %q", got)
+		}
+		if got := matchDollarTagStart("$1$", 0); got != "" {
+			t.Fatalf("digit-start tag should not match, got %q", got)
+		}
+		if got := matchDollarTagStart("$a-$", 0); got != "" {
+			t.Fatalf("invalid rune inside tag should not match, got %q", got)
+		}
+		if got := matchDollarTagStart("$$", 0); got != "$$" {
+			t.Fatalf("empty tag should match $$, got %q", got)
+		}
+		if got := matchDollarTagStart("$ä$", 0); got != "$ä$" {
+			t.Fatalf("unicode tag should match, got %q", got)
+		}
+		if got := matchDollarTagStart(string([]byte{'$', 0xff, '$'}), 0); got != "" {
+			t.Fatalf("invalid utf-8 after $ should not match, got %q", got)
+		}
+		if got := matchDollarTagStart("$a\xff$", 0); got != "" {
+			t.Fatalf("invalid utf-8 inside tag should not match, got %q", got)
+		}
+	})
+
+	t.Run("lastRuneBefore", func(t *testing.T) {
+		if got := lastRuneBefore("", 0); got != utf8.RuneError {
+			t.Fatalf("expected RuneError for missing previous rune, got %q", got)
+		}
+		if got := lastRuneBefore("äb", len("ä")); got != 'ä' {
+			t.Fatalf("expected previous rune ä, got %q", got)
+		}
+	})
+
+	t.Run("writeLineEnding", func(t *testing.T) {
+		var out strings.Builder
+		if next := writeLineEnding(&out, "", 0); next != 0 || out.String() != "" {
+			t.Fatalf("expected no-op at end of input, next=%d out=%q", next, out.String())
+		}
+
+		out.Reset()
+		if next := writeLineEnding(&out, "x", 0); next != 0 || out.String() != "" {
+			t.Fatalf("expected non-line-ending input to be untouched, next=%d out=%q", next, out.String())
+		}
+
+		out.Reset()
+		if next := writeLineEnding(&out, "\r", 0); next != 1 || out.String() != "\n" {
+			t.Fatalf("expected bare CR normalization, next=%d out=%q", next, out.String())
+		}
+	})
+}

--- a/internal/migrations/psql_meta_test.go
+++ b/internal/migrations/psql_meta_test.go
@@ -1,0 +1,390 @@
+package migrations
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+)
+
+// allPsqlMetaCommands enumerates the documented psql backslash commands from
+// the current PostgreSQL `app-psql` reference so the stripper test covers the
+// full command vocabulary. That list includes `\restrict` and `\unrestrict`,
+// which became relevant here after the CVE-2025-8714 backpatches in PostgreSQL
+// 17.6 / 16.10 / 15.14 / 14.19 / 13.22 taught pg_dump/plain-text restore flows
+// to emit them. This list is a reference fixture for the known documented
+// command surface; the stripping policy itself is intentionally broader and
+// also removes unknown top-level backslash directives. The special `\\`
+// separator is covered separately because it is only valid after another
+// meta-command on the same line, not as a standalone line-start token.
+var allPsqlMetaCommands = []string{
+	`\a`, `\bind`, `\bind_named`, `\c`, `\connect`, `\C`, `\cd`, `\close_prepared`, `\conninfo`, `\copy`,
+	`\copyright`, `\crosstabview`, `\d`, `\da`, `\dA`, `\dAc`, `\dAf`, `\dAo`, `\dAp`, `\db`,
+	`\dc`, `\dconfig`, `\dC`, `\dd`, `\dD`, `\ddp`, `\dE`, `\di`, `\dm`, `\ds`,
+	`\dt`, `\dv`, `\des`, `\det`, `\deu`, `\dew`, `\df`, `\dF`, `\dFd`, `\dFp`,
+	`\dFt`, `\dg`, `\dl`, `\dL`, `\dn`, `\do`, `\dO`, `\dp`, `\dP`, `\drds`,
+	`\drg`, `\dRp`, `\dRs`, `\dT`, `\du`, `\dx`, `\dX`, `\dy`, `\e`, `\edit`,
+	`\echo`, `\ef`, `\encoding`, `\ev`, `\f`, `\g`, `\gdesc`, `\getenv`, `\gexec`, `\gset`,
+	`\gx`, `\h`, `\help`, `\H`, `\html`, `\i`, `\include`, `\if`, `\elif`, `\else`,
+	`\endif`, `\ir`, `\include_relative`, `\l`, `\list`, `\lo_export`, `\lo_import`, `\lo_list`, `\lo_unlink`, `\o`,
+	`\out`, `\p`, `\print`, `\parse`, `\password`, `\prompt`, `\pset`, `\q`, `\quit`, `\qecho`,
+	`\r`, `\reset`, `\restrict`, `\s`, `\set`, `\setenv`, `\sf`, `\sv`, `\startpipeline`, `\sendpipeline`,
+	`\syncpipeline`, `\endpipeline`, `\flushrequest`, `\flush`, `\getresults`, `\t`, `\T`, `\timing`, `\unrestrict`, `\unset`,
+	`\w`, `\write`, `\warn`, `\watch`, `\x`, `\z`, `\!`, `\?`, `\;`,
+}
+
+type stripCase struct {
+	name    string
+	in      string
+	want    string
+	wantErr bool
+}
+
+func runRemovePsqlMetaCommandCases(t *testing.T, tests []stripCase) {
+	t.Helper()
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got, _, err := RemovePsqlMetaCommands(tc.in)
+			if tc.wantErr {
+				if err == nil {
+					t.Fatalf("expected error, got output %q", got)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error after stripping meta commands: %v", err)
+			}
+			if got != tc.want {
+				t.Fatalf("unexpected output after stripping meta commands:\nwant=%q\ngot =%q", tc.want, got)
+			}
+		})
+	}
+}
+
+func TestRemovePsqlMetaCommands_TableDriven(t *testing.T) {
+	inDoubleQuoted := "CREATE TABLE \"foo\\bar\" (id int);\nSELECT \"foo\\bar\"." +
+		"id FROM \"foo\\bar\";\n"
+	inValidSQL := "CREATE TABLE t (id int);\nINSERT INTO t VALUES (1);\n"
+	inWhitespaceOnly := "   \t  "
+	inNoTrailingNewline := "SELECT 1"
+	inBackslashNotAtStart := "SELECT '\\not_meta' AS col;\n  SELECT '\\still_not_meta';\n"
+	inDoubleSingleQuotes := "INSERT INTO t VALUES ('It''s fine');\n"
+
+	tests := []stripCase{
+		{
+			name: "RemovesTopLevelMetaCommands",
+			in:   "CREATE TABLE public.authors();\n\\connect test\n  \\set ON_ERROR_STOP on\nSELECT 1;\n",
+			want: "CREATE TABLE public.authors();\n\n\nSELECT 1;\n",
+		},
+		{
+			name: "IgnoresBackslashesInStrings",
+			in: `SELECT E'\n' || E'\\\\' || '
+\restrict inside';
+SELECT E'
+\still_string
+';
+\connect nope
+`,
+			want: `SELECT E'\n' || E'\\\\' || '
+\restrict inside';
+SELECT E'
+\still_string
+';
+
+`,
+		},
+		{
+			name: "PreservesDollarQuotedBlocks",
+			in:   "DO $$\n\\this_should_stay\n$$;\n\\connect other\n",
+			want: "DO $$\n\\this_should_stay\n$$;\n\n",
+		},
+		{
+			name: "IgnoresBlockComments",
+			in:   "/*\n\\comment_not_meta\n*/\n\\set x 1\nSELECT 1;\n",
+			want: "/*\n\\comment_not_meta\n*/\n\nSELECT 1;\n",
+		},
+		{
+			name: "LeavesValidSqlUntouched",
+			in:   inValidSQL,
+			want: inValidSQL,
+		},
+		{
+			name: "HandlesEmptyInput",
+			in:   "",
+			want: "",
+		},
+		{
+			name: "PreservesWhitespaceOnlyInput",
+			in:   inWhitespaceOnly,
+			want: inWhitespaceOnly,
+		},
+		{
+			name: "PreservesFinalLineWithoutNewline",
+			in:   inNoTrailingNewline,
+			want: inNoTrailingNewline,
+		},
+		{
+			name: "BackslashInDoubleQuotedIdentifier",
+			in:   inDoubleQuoted,
+			want: inDoubleQuoted,
+		},
+		{
+			name: "BackslashNotAtLineStart",
+			in:   inBackslashNotAtStart,
+			want: inBackslashNotAtStart,
+		},
+		{
+			name: "DoubleSingleQuotesRemain",
+			in:   inDoubleSingleQuotes,
+			want: inDoubleSingleQuotes,
+		},
+		{
+			name: "MetaCommandTextInsideLiteral",
+			in: `INSERT INTO logs VALUES ('Remember to run \connect later');
+	SELECT E'\n\connect\n' as literal;` + "\n",
+			want: `INSERT INTO logs VALUES ('Remember to run \connect later');
+	SELECT E'\n\connect\n' as literal;` + "\n",
+		},
+		{
+			name: "EscapeStringsPreserveBackslashEscapedQuotes",
+			in: `SELECT E'line1\'
+\connect still_literal
+';
+\connect should_go
+`,
+			want: `SELECT E'line1\'
+\connect still_literal
+';
+
+`,
+		},
+		{
+			name: "StandardConformingStringsOffPreservesBackslashEscapes",
+			in: `SET standard_conforming_strings = off;
+INSERT INTO foo VALUES ('x\'
+\connect still_literal
+');
+\connect should_go
+`,
+			want: `SET standard_conforming_strings = off;
+INSERT INTO foo VALUES ('x\'
+\connect still_literal
+');
+
+`,
+		},
+		{
+			name: "QuotedStandardConformingStringsOffPreservesBackslashEscapes",
+			in: `SET standard_conforming_strings = 'off';
+INSERT INTO foo VALUES ('x\'
+\connect still_literal
+');
+\connect should_go
+`,
+			want: `SET standard_conforming_strings = 'off';
+INSERT INTO foo VALUES ('x\'
+\connect still_literal
+');
+
+`,
+		},
+		{
+			name: "BooleanStandardConformingStringsFalsePreservesBackslashEscapes",
+			in: `SET standard_conforming_strings = false;
+INSERT INTO foo VALUES ('x\'
+\connect still_literal
+');
+\connect should_go
+`,
+			want: `SET standard_conforming_strings = false;
+INSERT INTO foo VALUES ('x\'
+\connect still_literal
+');
+
+`,
+		},
+		{
+			name: "ResetStandardConformingStringsRestoresDefault",
+			in: `SET standard_conforming_strings = off;
+RESET standard_conforming_strings;
+\connect should_go
+`,
+			want: `SET standard_conforming_strings = off;
+RESET standard_conforming_strings;
+
+`,
+		},
+		{
+			name: "ResetAllRestoresDefault",
+			in: `SET standard_conforming_strings = off;
+RESET ALL;
+\connect should_go
+`,
+			want: `SET standard_conforming_strings = off;
+RESET ALL;
+
+`,
+		},
+		{
+			name: "DefaultStandardConformingStringsRestoresDefault",
+			in: `SET standard_conforming_strings = off;
+SET standard_conforming_strings = default;
+\connect should_go
+`,
+			want: `SET standard_conforming_strings = off;
+SET standard_conforming_strings = default;
+
+`,
+		},
+		{
+			name: "BlockCommentsPreserveMetaText",
+			in: `/* outer block begins
+/* nested: run \connect test_db for interactive work */
+documenting with \connect text shouldn't strip SQL
+*/
+SELECT 1;
+/* Change instructions:
+\connect reporting
+
+Reason: run maintenance scripts as reporting user.
+*/
+\connect should_go
+`,
+			want: `/* outer block begins
+/* nested: run \connect test_db for interactive work */
+documenting with \connect text shouldn't strip SQL
+*/
+SELECT 1;
+/* Change instructions:
+\connect reporting
+
+Reason: run maintenance scripts as reporting user.
+*/
+
+`,
+		},
+		{
+			name: "LineCommentsDoNotAffectParserState",
+			in: `-- $tag$ and /* and ' are just comment text here
+\connect should_go
+SELECT 1;
+`,
+			want: `-- $tag$ and /* and ' are just comment text here
+
+SELECT 1;
+`,
+		},
+		{
+			name: "DollarTagWithIdentifier",
+			in:   "DO $foo$\n\\inside\n$foo$;\n\\set should_go\n",
+			want: "DO $foo$\n\\inside\n$foo$;\n\n",
+		},
+		{
+			name: "DollarLikeIdentifierDoesNotStartDollarQuote",
+			in:   "CREATE TABLE foo$bar$baz (id int);\n\\connect should_go\n",
+			want: "CREATE TABLE foo$bar$baz (id int);\n\n",
+		},
+		{
+			name: "UnknownBackslashDirectiveWithDigitIsStripped",
+			in:   "\\1 not_meta\nSELECT 1;\n",
+			want: "\nSELECT 1;\n",
+		},
+		{
+			name: "UnknownBackslashDirectiveWithUnderscoreIsStripped",
+			in:   "\\_oops\nSELECT 1;\n",
+			want: "\nSELECT 1;\n",
+		},
+		{
+			name: "InlineDoubleBackslashSeparatorPreservesFollowingSQL",
+			in:   "\\x \\\\ SELECT * FROM foo;\n",
+			want: " SELECT * FROM foo;\n",
+		},
+		{
+			name: "CopyFromStdinBlockIsRemovedInParseMode",
+			in: `\copy foo from stdin
+1	alpha
+2	beta
+\.
+SELECT 1;
+`,
+			want: `
+
+
+
+SELECT 1;
+`,
+		},
+		{
+			name: "CopyFromStdinBlockIsRemovedWithWhitespaceVariants",
+			in:   "\\copy foo FROM\tSTDIN\n1\talpha\n\\.\nSELECT 1;\n",
+			want: "\n\n\nSELECT 1;\n",
+		},
+		{
+			name: "UnicodeDollarQuoteTagsArePreserved",
+			in:   "DO $ä$\n\\connect still_body\n$ä$;\n\\connect should_go\n",
+			want: "DO $ä$\n\\connect still_body\n$ä$;\n\n",
+		},
+		{
+			name: "UnicodeIdentifierWithDollarDoesNotStartDollarQuote",
+			in:   "CREATE TABLE ä$foo$bar (id int);\n\\connect should_go\n",
+			want: "CREATE TABLE ä$foo$bar (id int);\n\n",
+		},
+		{
+			name: "MultilineDoubleQuotedIdentifiersPreserveBackslashes",
+			in:   "CREATE TABLE \"foo\n\\connect still_identifier\nbar\" (id int);\n\\connect should_go\n",
+			want: "CREATE TABLE \"foo\n\\connect still_identifier\nbar\" (id int);\n\n",
+		},
+		{
+			name: "DoubleQuotedIdentifierEscapesRemain",
+			in:   "CREATE TABLE \"foo\"\"bar\" (id int);\n\\connect should_go\n",
+			want: "CREATE TABLE \"foo\"\"bar\" (id int);\n\n",
+		},
+		{
+			name: "PreservesCRLFWhenRemovingMetaCommands",
+			in:   "\\connect db\r\nSELECT 1;\r\n",
+			want: "\r\nSELECT 1;\r\n",
+		},
+		{
+			name: "PreservesBareCRWhenRemovingMetaCommands",
+			in:   "SELECT 1;\r\\connect db\rSELECT 2;\r",
+			want: "SELECT 1;\n\nSELECT 2;\n",
+		},
+	}
+
+	runRemovePsqlMetaCommandCases(t, tests)
+
+	t.Run("CoversDocumentedMetaCommands", func(t *testing.T) {
+		// Keep explicit coverage of the documented psql command set even though
+		// RemovePsqlMetaCommands intentionally strips a broader class of
+		// top-level backslash directives for forward compatibility.
+		for _, cmd := range allPsqlMetaCommands {
+			t.Run(fmt.Sprintf("strip_%s", strings.TrimPrefix(cmd, `\`)), func(t *testing.T) {
+				input := fmt.Sprintf("%s -- meta command\nSELECT 42;\n", cmd)
+				got, warnings, err := RemovePsqlMetaCommands(input)
+				if isUnsupportedConditionalMetaCommand(cmd) {
+					if err == nil {
+						t.Fatalf("unsupported meta-command %q should be rejected", cmd)
+					}
+					return
+				}
+				if err != nil {
+					t.Fatalf("unexpected error after stripping meta commands: %v", err)
+				}
+				if isSemanticMetaCommand(cmd) {
+					if len(warnings) == 0 {
+						t.Fatalf("expected semantic meta-command %q to emit a warning", cmd)
+					}
+				} else if len(warnings) != 0 {
+					t.Fatalf("unexpected warnings after stripping meta commands: %v", warnings)
+				}
+
+				if strings.Contains(got, cmd+" -- meta command") {
+					t.Fatalf("meta command %q line was not removed", cmd)
+				}
+				if !strings.Contains(got, "SELECT 42;") {
+					t.Fatalf("SQL content was unexpectedly removed for %q", cmd)
+				}
+			})
+		}
+	})
+}

--- a/internal/schemautil/load.go
+++ b/internal/schemautil/load.go
@@ -1,0 +1,39 @@
+package schemautil
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/sqlc-dev/sqlc/internal/migrations"
+	"github.com/sqlc-dev/sqlc/internal/sql/sqlpath"
+)
+
+// LoadSchemasForApply expands globs, preprocesses each schema in order, and
+// reports any warnings through warn. The returned DDL is suitable for callers
+// that will apply schema text to a live database.
+func LoadSchemasForApply(globs []string, engine string, warn func(string)) ([]string, error) {
+	files, err := sqlpath.Glob(globs)
+	if err != nil {
+		return nil, err
+	}
+
+	ddl := make([]string, 0, len(files))
+	for _, schema := range files {
+		contents, err := os.ReadFile(schema)
+		if err != nil {
+			return nil, fmt.Errorf("read file: %w", err)
+		}
+		ddlText, warnings, err := migrations.PreprocessSchemaForApply(string(contents), engine)
+		if err != nil {
+			return nil, err
+		}
+		for _, warning := range warnings {
+			if warn != nil {
+				warn(warning)
+			}
+		}
+		ddl = append(ddl, ddlText)
+	}
+
+	return ddl, nil
+}

--- a/internal/sqltest/local/postgres.go
+++ b/internal/sqltest/local/postgres.go
@@ -71,8 +71,15 @@ func postgreSQL(t *testing.T, migrations []string, rw bool) string {
 		if err != nil {
 			t.Fatal(err)
 		}
-		h.Write(blob)
-		seed = append(seed, migrate.RemoveRollbackStatements(string(blob)))
+		ddl, warnings, err := migrate.PreprocessSchemaForApply(string(blob), "postgresql")
+		if err != nil {
+			t.Fatal(err)
+		}
+		h.Write([]byte(ddl))
+		for _, warning := range warnings {
+			t.Log(warning)
+		}
+		seed = append(seed, ddl)
 	}
 
 	var name string

--- a/internal/sqltest/local/postgres.go
+++ b/internal/sqltest/local/postgres.go
@@ -12,9 +12,8 @@ import (
 	"github.com/jackc/pgx/v5"
 	"golang.org/x/sync/singleflight"
 
-	migrate "github.com/sqlc-dev/sqlc/internal/migrations"
 	"github.com/sqlc-dev/sqlc/internal/pgx/poolcache"
-	"github.com/sqlc-dev/sqlc/internal/sql/sqlpath"
+	"github.com/sqlc-dev/sqlc/internal/schemautil"
 	"github.com/sqlc-dev/sqlc/internal/sqltest/docker"
 	"github.com/sqlc-dev/sqlc/internal/sqltest/native"
 )
@@ -60,26 +59,15 @@ func postgreSQL(t *testing.T, migrations []string, rw bool) string {
 	}
 
 	var seed []string
-	files, err := sqlpath.Glob(migrations)
+	h := fnv.New64()
+	seed, err = schemautil.LoadSchemasForApply(migrations, "postgresql", func(warning string) {
+		t.Log(warning)
+	})
 	if err != nil {
 		t.Fatal(err)
 	}
-
-	h := fnv.New64()
-	for _, f := range files {
-		blob, err := os.ReadFile(f)
-		if err != nil {
-			t.Fatal(err)
-		}
-		ddl, warnings, err := migrate.PreprocessSchemaForApply(string(blob), "postgresql")
-		if err != nil {
-			t.Fatal(err)
-		}
+	for _, ddl := range seed {
 		h.Write([]byte(ddl))
-		for _, warning := range warnings {
-			t.Log(warning)
-		}
-		seed = append(seed, ddl)
 	}
 
 	var name string
@@ -122,6 +110,11 @@ func postgreSQL(t *testing.T, migrations []string, rw bool) string {
 		for _, q := range seed {
 			if len(strings.TrimSpace(q)) == 0 {
 				continue
+			}
+			if strings.Contains(q, "\nCREATE SCHEMA public;\n") || strings.HasPrefix(q, "CREATE SCHEMA public;\n") {
+				if _, err := conn.Exec(ctx, `DROP SCHEMA IF EXISTS public CASCADE`); err != nil {
+					return nil, fmt.Errorf("drop public schema: %s", err)
+				}
 			}
 			if _, err := conn.Exec(ctx, q); err != nil {
 				return nil, fmt.Errorf("%s: %s", q, err)

--- a/internal/sqltest/postgres.go
+++ b/internal/sqltest/postgres.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 	"time"
 
+	migrate "github.com/sqlc-dev/sqlc/internal/migrations"
 	"github.com/sqlc-dev/sqlc/internal/sql/sqlpath"
 
 	_ "github.com/lib/pq"
@@ -103,7 +104,14 @@ func CreatePostgreSQLDatabase(t *testing.T, name string, schema bool, migrations
 		if err != nil {
 			t.Fatal(err)
 		}
-		if _, err := sdb.Exec(string(blob)); err != nil {
+		ddl, warnings, err := migrate.PreprocessSchemaForApply(string(blob), "postgresql")
+		if err != nil {
+			t.Fatal(err)
+		}
+		for _, warning := range warnings {
+			t.Log(warning)
+		}
+		if _, err := sdb.Exec(ddl); err != nil {
 			t.Fatalf("%s: %s", filepath.Base(f), err)
 		}
 	}

--- a/internal/sqltest/postgres.go
+++ b/internal/sqltest/postgres.go
@@ -6,10 +6,11 @@ import (
 	"math/rand"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
-	migrate "github.com/sqlc-dev/sqlc/internal/migrations"
+	"github.com/sqlc-dev/sqlc/internal/schemautil"
 	"github.com/sqlc-dev/sqlc/internal/sql/sqlpath"
 
 	_ "github.com/lib/pq"
@@ -99,20 +100,20 @@ func CreatePostgreSQLDatabase(t *testing.T, name string, schema bool, migrations
 	if err != nil {
 		t.Fatal(err)
 	}
-	for _, f := range files {
-		blob, err := os.ReadFile(f)
-		if err != nil {
-			t.Fatal(err)
+	ddl, err := schemautil.LoadSchemasForApply(migrations, "postgresql", func(warning string) {
+		t.Log(warning)
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	for i, stmt := range ddl {
+		if strings.Contains(stmt, "\nCREATE SCHEMA public;\n") || strings.HasPrefix(stmt, "CREATE SCHEMA public;\n") {
+			if _, err := sdb.Exec(`DROP SCHEMA IF EXISTS public CASCADE`); err != nil {
+				t.Fatalf("drop public schema: %s", err)
+			}
 		}
-		ddl, warnings, err := migrate.PreprocessSchemaForApply(string(blob), "postgresql")
-		if err != nil {
-			t.Fatal(err)
-		}
-		for _, warning := range warnings {
-			t.Log(warning)
-		}
-		if _, err := sdb.Exec(ddl); err != nil {
-			t.Fatalf("%s: %s", filepath.Base(f), err)
+		if _, err := sdb.Exec(stmt); err != nil {
+			t.Fatalf("%s: %s", filepath.Base(files[i]), err)
 		}
 	}
 


### PR DESCRIPTION
## Summary

This PR makes PostgreSQL schema preprocessing safer for `pg_dump` / `psql`-flavored input without turning sqlc into a `psql` interpreter.

It preserves real PostgreSQL SQL, strips or warns on client-side commands, rejects script semantics that cannot be supported safely, and shares the apply-time schema loading path used by command setup and PostgreSQL sqltest seeding.

## Changes

### PostgreSQL schema preprocessing

- Replace the old line-based PostgreSQL filter with a single-pass state machine that only strips top-level `psql` meta-commands outside SQL lexical context.
- Keep explicit coverage of documented `psql` backslash commands as a reference fixture. [See PostgreSQL `psql` docs](https://www.postgresql.org/docs/current/app-psql.html)
- Preserve backslashes that appear in valid PostgreSQL SQL, including:
  - string literals, including `E'...'`
  - quoted identifiers
  - dollar-quoted bodies
  - comments and nested block comments
- Support the valid `\meta ... \\ SQL...` separator form and keep trailing SQL intact, including glued and one-sided-whitespace separator forms observed in supported `psql` versions.
- Preserve invalid leading `\\` input instead of normalizing it into SQL.
- Handle Unicode dollar-quote tags, identifier-boundary checks, CR/LF normalization, and `\copy ... from stdin` blocks.

### Semantic command handling

- Strip semantic `psql` commands such as `\connect`, `\copy`, `\gexec`, `\i`, `\ir`, `\q`, `\quit`, and `\r` in parse/codegen paths with warnings so users get told when sqlc is ignoring client-side behavior.
- Reject those same semantic commands in apply/live-DB paths where silently flattening them would be unsafe.
- Reject `psql` conditionals (`\if`, `\elif`, `\else`, `\endif`) instead of pretending to support them.
- Keep `standard_conforming_strings` handling as a best-effort parse aid and warn in parse/codegen paths when preprocessing has to approximate session/script semantics rather than emulate `psql`.
- Suppress that parse-only approximation warning in apply/live-DB paths because the database executes transaction and session SQL directly there.

### Rollout across schema-loading paths

- Apply the shared PostgreSQL preprocessing behavior in:
  - compiler parsing / `generate`
  - `createdb`
  - `verify`
  - managed `vet`
  - PostgreSQL sqltest seeding
- Surface preprocessing warnings through the relevant callers instead of keeping them internal to the migration helper.
- Keep apply/live-DB paths strict so invalid SQL, including dumps that recreate already-present schema objects, still fails with PostgreSQL's normal errors.

### Follow-up refactor

- Extract the repeated apply-time glob/read/preprocess/warn loop into `schemautil.LoadSchemasForApply()`.
- Reuse that loader across command setup and PostgreSQL sqltest helpers so apply-time behavior stays aligned as preprocessing evolves.
- Preserve read-only PostgreSQL cache hashing on preprocessed DDL.
- Do not special-case or rewrite `pg_dump` `public` schema DDL; apply-mode callers continue to see PostgreSQL's native behavior.

## Behavioral impact

- sqlc is now much more tolerant of `pg_dump` / `psql`-flavored PostgreSQL schema files without corrupting valid SQL that happens to contain backslashes.
- Parse/codegen paths are intentionally permissive with warnings when users are in footgun territory.
- Apply/live-DB paths stay stricter and reject client-side script behavior that sqlc cannot reproduce safely.
- This does **not** try to become a full `psql` interpreter; full arbitrary client-side script semantics remain out of scope here.

## Testing

- `go test ./internal/migrations ./internal/compiler ./internal/schemautil ./internal/cmd ./internal/sqltest/...`
- `go test ./internal/migrations -coverprofile=/tmp/sqlc-migrations.cover` reports `100.0%` statement coverage for `internal/migrations`

## Related

Co-authored-by: Andrew Benton <andrew@sqlc.dev>

Addresses [gbarr's comment](https://github.com/sqlc-dev/sqlc/pull/4082#discussion_r2403920635) in https://github.com/sqlc-dev/sqlc/pull/4082 which closes https://github.com/sqlc-dev/sqlc/issues/4065
