### PR TITLE
feat(codegen): Preserve casing of names by uppercasing the first character...

### DIFF
--- a/internal/codegen/golang/struct.go
+++ b/internal/codegen/golang/struct.go
@@ -35,7 +35,9 @@ func StructName(name string, options *opts.Options) string {
 		if _, found := options.InitialismsMap[p]; found {
 			out += strings.ToUpper(p)
 		} else {
-			out += strings.Title(p)
+			if len(p) > 0 {
+				out += strings.ToUpper(p[:1]) + p[1:]
+			}
 		}
 	}
 


### PR DESCRIPTION
and leaving the rest in their original case.

closes #4202 