### PR TITLE
feat(sqlite): Support NOT NULL constraints

### DIFF
--- a/internal/engine/sqlite/analyzer/analyze.go
+++ b/internal/engine/sqlite/analyzer/analyze.go
@@ -88,18 +88,21 @@ func (a *Analyzer) Analyze(ctx context.Context, n ast.Node, query string, migrat
 	colCount := stmt.ColumnCount()
 	for i := 0; i < colCount; i++ {
 		name := stmt.ColumnName(i)
-		declType := stmt.ColumnDeclType(i)
+		dbName := stmt.ColumnDatabaseName(i)
 		tableName := stmt.ColumnTableName(i)
 		originName := stmt.ColumnOriginName(i)
-		dbName := stmt.ColumnDatabaseName(i)
-
-		// Normalize the data type
-		dataType := normalizeType(declType)
 
 		// Determine if column is NOT NULL
-		// SQLite doesn't provide this info directly from prepared statements,
-		// so we default to nullable (false)
-		notNull := false
+		var notNull bool
+		var dataType string
+		if originName != "" {
+			var declType string
+			declType, _, notNull, _, _, _ = a.conn.TableColumnMetadata(
+				dbName, tableName, originName)
+
+			// Normalize the data type
+			dataType = normalizeType(declType)
+		}
 
 		col := &core.Column{
 			Name:         name,

--- a/internal/engine/sqlite/analyzer/analyze.go
+++ b/internal/engine/sqlite/analyzer/analyze.go
@@ -88,6 +88,7 @@ func (a *Analyzer) Analyze(ctx context.Context, n ast.Node, query string, migrat
 	colCount := stmt.ColumnCount()
 	for i := 0; i < colCount; i++ {
 		name := stmt.ColumnName(i)
+		declType := stmt.ColumnDeclType(i)
 		dbName := stmt.ColumnDatabaseName(i)
 		tableName := stmt.ColumnTableName(i)
 		originName := stmt.ColumnOriginName(i)
@@ -96,13 +97,12 @@ func (a *Analyzer) Analyze(ctx context.Context, n ast.Node, query string, migrat
 		var notNull bool
 		var dataType string
 		if originName != "" {
-			var declType string
 			declType, _, notNull, _, _, _ = a.conn.TableColumnMetadata(
 				dbName, tableName, originName)
-
-			// Normalize the data type
-			dataType = normalizeType(declType)
 		}
+
+		// Normalize the data type
+		dataType = normalizeType(declType)
 
 		col := &core.Column{
 			Name:         name,

--- a/internal/engine/sqlite/analyzer/analyze_test.go
+++ b/internal/engine/sqlite/analyzer/analyze_test.go
@@ -40,10 +40,11 @@ func TestAnalyzer_Analyze(t *testing.T) {
 	expectedCols := []struct {
 		name     string
 		dataType string
+		notNull  bool
 	}{
-		{"id", "integer"},
-		{"name", "text"},
-		{"email", "text"},
+		{"id", "integer", false},
+		{"name", "text", true},
+		{"email", "text", false},
 	}
 
 	for i, expected := range expectedCols {
@@ -56,6 +57,9 @@ func TestAnalyzer_Analyze(t *testing.T) {
 		}
 		if col.DataType != expected.dataType {
 			t.Errorf("Column %d: expected dataType %q, got %q", i, expected.dataType, col.DataType)
+		}
+		if col.NotNull != expected.notNull {
+			t.Errorf("Column %d: expected notNull %v, got %v", i, expected.notNull, col.NotNull)
 		}
 		if col.Table == nil || col.Table.Name != "users" {
 			t.Errorf("Column %d: expected table 'users', got %v", i, col.Table)


### PR DESCRIPTION
You may have missed that [`sqlite3_table_column_metadata`](https://sqlite.org/c3ref/table_column_metadata.html) gets additional metadata for columns, in particular `NOT NULL` constraints.

Unfortunately because of [backwards compatibility](https://sqlite.org/lang_createtable.html#the_primary_key) a `PRIMARY KEY` column is not always `NOT NULL`, and it's really hard to _correctly_ detect `INTEGER PRIMARY KEY` columns which _are_ `NOT NULL`.

So this misses a few `NOT NULL` columns, but it's better than nothing, I guess.