### PR TITLE
sqlite: reject invalid qualified column references in correlated subqueries

### DIFF
--- a/internal/compiler/analyze.go
+++ b/internal/compiler/analyze.go
@@ -181,6 +181,12 @@ func (c *Compiler) _analyzeQuery(raw *ast.RawStmt, query string, failfast bool) 
 		return nil, err
 	}
 
+	if c.conf.Engine == config.EngineSQLite {
+		if err := check(validate.ValidateSQLiteQualifiedColumnRefs(raw.Stmt)); err != nil {
+			return nil, err
+		}
+	}
+
 	params, err := c.resolveCatalogRefs(qc, rvs, refs, namedParams, embeds)
 	if err := check(err); err != nil {
 		return nil, err

--- a/internal/endtoend/testdata/base/sqlite_invalid_correlated_ref/sqlite/query.sql
+++ b/internal/endtoend/testdata/base/sqlite_invalid_correlated_ref/sqlite/query.sql
@@ -1,0 +1,9 @@
+-- name: GetByPublicID :one
+SELECT *
+FROM locations l
+WHERE l.public_id = ?
+AND EXISTS (
+    SELECT 1
+    FROM projects p
+    WHERE p.id = location.project_id
+);

--- a/internal/endtoend/testdata/base/sqlite_invalid_correlated_ref/sqlite/schema.sql
+++ b/internal/endtoend/testdata/base/sqlite_invalid_correlated_ref/sqlite/schema.sql
@@ -1,0 +1,20 @@
+CREATE TABLE organizations (
+    id INTEGER PRIMARY KEY
+);
+
+CREATE TABLE organization_members (
+    id INTEGER PRIMARY KEY,
+    organization_id INTEGER NOT NULL,
+    account_id INTEGER NOT NULL
+);
+
+CREATE TABLE projects (
+    id INTEGER PRIMARY KEY,
+    organization_id INTEGER NOT NULL
+);
+
+CREATE TABLE locations (
+    id INTEGER PRIMARY KEY,
+    public_id TEXT UNIQUE NOT NULL,
+    project_id INTEGER NOT NULL
+) STRICT;

--- a/internal/endtoend/testdata/base/sqlite_invalid_correlated_ref/sqlite/sqlc.yaml
+++ b/internal/endtoend/testdata/base/sqlite_invalid_correlated_ref/sqlite/sqlc.yaml
@@ -1,0 +1,12 @@
+version: "2"
+
+sql:
+  - engine: "sqlite"
+    schema: "schema.sql"
+    queries: "query.sql"
+    rules:
+      - sqlc/db-prepare
+    gen:
+      go:
+        package: "db"
+        out: "generated"

--- a/internal/endtoend/testdata/base/sqlite_invalid_correlated_ref/sqlite/stderr.txt
+++ b/internal/endtoend/testdata/base/sqlite_invalid_correlated_ref/sqlite/stderr.txt
@@ -1,0 +1,2 @@
+# package db
+query.sql:8:18: table alias "location" does not exist

--- a/internal/endtoend/testdata/invalid_table_alias/sqlite/stderr.txt
+++ b/internal/endtoend/testdata/invalid_table_alias/sqlite/stderr.txt
@@ -1,2 +1,2 @@
 # package querytest
-query.sql:1:1: sqlite3: SQL logic error: no such column: p.id
+query.sql:4:9: table alias "p" does not exist

--- a/internal/endtoend/testdata/managed-db/sqlite_invalid_correlated_ref/sqlite/query.sql
+++ b/internal/endtoend/testdata/managed-db/sqlite_invalid_correlated_ref/sqlite/query.sql
@@ -1,0 +1,9 @@
+-- name: GetByPublicID :one
+SELECT *
+FROM locations l
+WHERE l.public_id = ?
+AND EXISTS (
+    SELECT 1
+    FROM projects p
+    WHERE p.id = location.project_id
+);

--- a/internal/endtoend/testdata/managed-db/sqlite_invalid_correlated_ref/sqlite/schema.sql
+++ b/internal/endtoend/testdata/managed-db/sqlite_invalid_correlated_ref/sqlite/schema.sql
@@ -1,0 +1,20 @@
+CREATE TABLE organizations (
+    id INTEGER PRIMARY KEY
+);
+
+CREATE TABLE organization_members (
+    id INTEGER PRIMARY KEY,
+    organization_id INTEGER NOT NULL,
+    account_id INTEGER NOT NULL
+);
+
+CREATE TABLE projects (
+    id INTEGER PRIMARY KEY,
+    organization_id INTEGER NOT NULL
+);
+
+CREATE TABLE locations (
+    id INTEGER PRIMARY KEY,
+    public_id TEXT UNIQUE NOT NULL,
+    project_id INTEGER NOT NULL
+) STRICT;

--- a/internal/endtoend/testdata/managed-db/sqlite_invalid_correlated_ref/sqlite/sqlc.yaml
+++ b/internal/endtoend/testdata/managed-db/sqlite_invalid_correlated_ref/sqlite/sqlc.yaml
@@ -1,0 +1,12 @@
+version: "2"
+
+sql:
+  - engine: "sqlite"
+    schema: "schema.sql"
+    queries: "query.sql"
+    rules:
+      - sqlc/db-prepare
+    gen:
+      go:
+        package: "db"
+        out: "generated"

--- a/internal/endtoend/testdata/managed-db/sqlite_invalid_correlated_ref/sqlite/stderr.txt
+++ b/internal/endtoend/testdata/managed-db/sqlite_invalid_correlated_ref/sqlite/stderr.txt
@@ -1,0 +1,2 @@
+# package db
+query.sql:8:18: table alias "location" does not exist

--- a/internal/sql/validate/sqlite_qualified_refs.go
+++ b/internal/sql/validate/sqlite_qualified_refs.go
@@ -1,0 +1,217 @@
+package validate
+
+import (
+	"fmt"
+	"reflect"
+
+	"github.com/sqlc-dev/sqlc/internal/sql/ast"
+	"github.com/sqlc-dev/sqlc/internal/sql/sqlerr"
+)
+
+// ValidateSQLiteQualifiedColumnRefs validates that qualified column references
+// only use visible tables/aliases in the current or outer SELECT scopes.
+func ValidateSQLiteQualifiedColumnRefs(root ast.Node) error {
+	return validateNodeSQLite(root, nil)
+}
+
+type scope struct {
+	parent *scope
+	names  map[string]struct{}
+}
+
+func newScope(parent *scope) *scope {
+	return &scope{parent: parent, names: map[string]struct{}{}}
+}
+
+func (s *scope) add(name string) {
+	if name == "" {
+		return
+	}
+	s.names[name] = struct{}{}
+}
+
+func (s *scope) has(name string) bool {
+	for cur := s; cur != nil; cur = cur.parent {
+		if _, ok := cur.names[name]; ok {
+			return true
+		}
+	}
+	return false
+}
+
+func stringSlice(list *ast.List) []string {
+	if list == nil {
+		return nil
+	}
+	out := make([]string, 0, len(list.Items))
+	for _, it := range list.Items {
+		if s, ok := it.(*ast.String); ok {
+			out = append(out, s.Str)
+		}
+	}
+	return out
+}
+
+func qualifierFromColumnRef(ref *ast.ColumnRef) (string, bool) {
+	if ref == nil || ref.Fields == nil {
+		return "", false
+	}
+	items := stringSlice(ref.Fields)
+	switch len(items) {
+	case 2:
+		return items[0], true
+	case 3:
+		return items[1], true
+	default:
+		return "", false
+	}
+}
+
+func addFromItemToScope(sc *scope, n ast.Node) {
+	switch t := n.(type) {
+	case *ast.RangeVar:
+		if t.Relname != nil {
+			sc.add(*t.Relname)
+		}
+		if t.Alias != nil && t.Alias.Aliasname != nil {
+			sc.add(*t.Alias.Aliasname)
+		}
+	case *ast.JoinExpr:
+		addFromItemToScope(sc, t.Larg)
+		addFromItemToScope(sc, t.Rarg)
+	case *ast.RangeSubselect:
+		if t.Alias != nil && t.Alias.Aliasname != nil {
+			sc.add(*t.Alias.Aliasname)
+		}
+	case *ast.RangeFunction:
+		if t.Alias != nil && t.Alias.Aliasname != nil {
+			sc.add(*t.Alias.Aliasname)
+		}
+	}
+}
+
+func validateNodeSQLite(node ast.Node, parent *scope) error {
+	switch n := node.(type) {
+	case *ast.SelectStmt:
+		sc := newScope(parent)
+		if n.FromClause != nil {
+			for _, item := range n.FromClause.Items {
+				addFromItemToScope(sc, item)
+			}
+		}
+		return walkSQLite(n, sc)
+	default:
+		return nil
+	}
+}
+
+func walkSQLite(node ast.Node, sc *scope) error {
+	if node == nil {
+		return nil
+	}
+
+	if ref, ok := node.(*ast.ColumnRef); ok {
+		if qual, ok := qualifierFromColumnRef(ref); ok && !sc.has(qual) {
+			return &sqlerr.Error{
+				Code:     "42703",
+				Message:  fmt.Sprintf("table alias %q does not exist", qual),
+				Location: ref.Location,
+			}
+		}
+	}
+
+	switch n := node.(type) {
+	case *ast.SubLink:
+		if n.Subselect != nil {
+			return validateNodeSQLite(n.Subselect, sc)
+		}
+		return nil
+	case *ast.RangeSubselect:
+		if n.Subquery != nil {
+			return validateNodeSQLite(n.Subquery, sc)
+		}
+		return nil
+	}
+
+	return walkSQLiteReflect(node, sc)
+}
+
+func walkSQLiteReflect(node ast.Node, sc *scope) error {
+	v := reflect.ValueOf(node)
+	if v.Kind() == reflect.Pointer {
+		if v.IsNil() {
+			return nil
+		}
+		v = v.Elem()
+	}
+	if v.Kind() != reflect.Struct {
+		return nil
+	}
+
+	t := v.Type()
+	for i := 0; i < v.NumField(); i++ {
+		if t.Field(i).PkgPath != "" {
+			continue
+		}
+		f := v.Field(i)
+		if !f.IsValid() {
+			continue
+		}
+
+		for f.Kind() == reflect.Pointer {
+			if f.IsNil() {
+				goto next
+			}
+			f = f.Elem()
+		}
+
+		if f.Type() == reflect.TypeOf(ast.List{}) {
+			list := f.Addr().Interface().(*ast.List)
+			for _, n := range list.Items {
+				if err := walkSQLite(n, sc); err != nil {
+					return err
+				}
+			}
+			continue
+		}
+
+		if f.CanAddr() {
+			if pl, ok := f.Addr().Interface().(**ast.List); ok && *pl != nil {
+				for _, n := range (*pl).Items {
+					if err := walkSQLite(n, sc); err != nil {
+						return err
+					}
+				}
+				continue
+			}
+		}
+
+		if f.CanInterface() {
+			if n, ok := f.Interface().(ast.Node); ok {
+				if err := walkSQLite(n, sc); err != nil {
+					return err
+				}
+				continue
+			}
+		}
+
+		if f.Kind() == reflect.Slice {
+			for j := 0; j < f.Len(); j++ {
+				elem := f.Index(j)
+				if elem.Kind() == reflect.Pointer && elem.IsNil() {
+					continue
+				}
+				if elem.CanInterface() {
+					if n, ok := elem.Interface().(ast.Node); ok {
+						if err := walkSQLite(n, sc); err != nil {
+							return err
+						}
+					}
+				}
+			}
+		}
+
+	next:
+	}
+	return nil
+}


### PR DESCRIPTION
SQLite allows some invalid correlated references to parse successfully but
fails at runtime (e.g. referencing a table alias that is not in scope).

sqlc previously accepted these queries. This PR adds a SQLite-specific
validator that walks the AST with a parent-linked scope chain and rejects
qualified column references whose table/alias is not visible.

A new end-to-end regression test reproduces the issue and verifies the fix.

Fixes: #4223 
