### PR TITLE
refactor(compiler): replace panic with error returns in toColumn

### DIFF
--- a/internal/compiler/output_columns.go
+++ b/internal/compiler/output_columns.go
@@ -201,7 +201,10 @@ func (c *Compiler) outputColumns(qc *QueryCatalog, node ast.Node) ([]*Column, er
 					name = *res.Name
 				}
 				// TODO Validate column names
-				col := toColumn(tc.TypeName)
+				col, err := toColumn(tc.TypeName)
+				if err != nil {
+					return nil, err
+				}
 				col.Name = name
 				cols = append(cols, col)
 			} else if aconst, ok := n.Defresult.(*ast.A_Const); ok {
@@ -358,7 +361,10 @@ func (c *Compiler) outputColumns(qc *QueryCatalog, node ast.Node) ([]*Column, er
 				name = *res.Name
 			}
 			// TODO Validate column names
-			col := toColumn(n.TypeName)
+			col, err := toColumn(n.TypeName)
+			if err != nil {
+				return nil, err
+			}
 			col.Name = name
 			// TODO Add correct, real type inference
 			if constant, ok := n.Arg.(*ast.A_Const); ok {

--- a/internal/compiler/resolve.go
+++ b/internal/compiler/resolve.go
@@ -511,7 +511,10 @@ func (comp *Compiler) resolveCatalogRefs(qc *QueryCatalog, rvs []*ast.RangeVar, 
 			if n.TypeName == nil {
 				return nil, fmt.Errorf("*ast.TypeCast has nil type name")
 			}
-			col := toColumn(n.TypeName)
+			col, err := toColumn(n.TypeName)
+			if err != nil {
+				return nil, err
+			}
 			defaultP := named.NewInferredParam(col.Name, col.NotNull)
 			p, _ := params.FetchMerge(ref.ref.Number, defaultP)
 

--- a/internal/compiler/to_column.go
+++ b/internal/compiler/to_column.go
@@ -1,6 +1,7 @@
 package compiler
 
 import (
+	"fmt"
 	"strings"
 
 	"github.com/sqlc-dev/sqlc/internal/sql/ast"
@@ -14,13 +15,13 @@ func arrayDims(n *ast.TypeName) int {
 	return len(n.ArrayBounds.Items)
 }
 
-func toColumn(n *ast.TypeName) *Column {
+func toColumn(n *ast.TypeName) (*Column, error) {
 	if n == nil {
-		panic("can't build column for nil type name")
+		return nil, fmt.Errorf("can't build column for nil type name")
 	}
 	typ, err := ParseTypeName(n)
 	if err != nil {
-		panic("toColumn: " + err.Error())
+		return nil, fmt.Errorf("toColumn: %w", err)
 	}
 	arrayDims := arrayDims(n)
 	return &Column{
@@ -29,5 +30,5 @@ func toColumn(n *ast.TypeName) *Column {
 		NotNull:   true, // XXX: How do we know if this should be null?
 		IsArray:   arrayDims > 0,
 		ArrayDims: arrayDims,
-	}
+	}, nil
 }


### PR DESCRIPTION
  Convert toColumn function from using panic() to returning errors,
  improving error handling for invalid SQL type names. This allows
  callers to handle errors gracefully instead of crashing.

  Changes:
  - toColumn now returns (*Column, error) instead of *Column
  - Updated 3 call sites in resolve.go and output_columns.go