### PR TITLE
feat: graduate parsecmd experiment

### DIFF
--- a/internal/cmd/parse.go
+++ b/internal/cmd/parse.go
@@ -16,28 +16,20 @@ import (
 
 var parseCmd = &cobra.Command{
 	Use:   "parse [file]",
-	Short: "Parse SQL and output the AST as JSON (experimental)",
+	Short: "Parse SQL and output the AST as JSON",
 	Long: `Parse SQL from a file or stdin and output the abstract syntax tree as JSON.
-
-This command is experimental and requires the 'parsecmd' experiment to be enabled.
-Enable it by setting: SQLCEXPERIMENT=parsecmd
 
 Examples:
   # Parse a SQL file with PostgreSQL dialect
-  SQLCEXPERIMENT=parsecmd sqlc parse --dialect postgresql schema.sql
+  sqlc parse --dialect postgresql schema.sql
 
   # Parse from stdin with MySQL dialect
-  echo "SELECT * FROM users" | SQLCEXPERIMENT=parsecmd sqlc parse --dialect mysql
+  echo "SELECT * FROM users" | sqlc parse --dialect mysql
 
   # Parse SQLite SQL
-  SQLCEXPERIMENT=parsecmd sqlc parse --dialect sqlite queries.sql`,
+  sqlc parse --dialect sqlite queries.sql`,
 	Args: cobra.MaximumNArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
-		env := ParseEnv(cmd)
-		if !env.Experiment.ParseCmd {
-			return fmt.Errorf("parse command requires the 'parsecmd' experiment to be enabled.\nSet SQLCEXPERIMENT=parsecmd to use this command")
-		}
-
 		dialect, err := cmd.Flags().GetString("dialect")
 		if err != nil {
 			return err

--- a/internal/opts/experiment.go
+++ b/internal/opts/experiment.go
@@ -14,7 +14,7 @@ import (
 //
 // Available experiments:
 //
-//	(none currently defined - add experiments here as they are introduced)
+//	analyzerv2 - enables database-only analyzer mode
 //
 // Example usage:
 //
@@ -28,8 +28,6 @@ type Experiment struct {
 	// AnalyzerV2 enables the database-only analyzer mode (analyzer.database: only)
 	// which uses the database for all type resolution instead of parsing schema files.
 	AnalyzerV2 bool
-	// ParseCmd enables the parse subcommand which outputs AST as JSON.
-	ParseCmd bool
 }
 
 // ExperimentFromEnv returns an Experiment initialized from the SQLCEXPERIMENT
@@ -77,7 +75,7 @@ func ExperimentFromString(val string) Experiment {
 // known experiment.
 func isKnownExperiment(name string) bool {
 	switch strings.ToLower(name) {
-	case "analyzerv2", "parsecmd":
+	case "analyzerv2":
 		return true
 	default:
 		return false
@@ -89,8 +87,6 @@ func setExperiment(e *Experiment, name string, enabled bool) {
 	switch strings.ToLower(name) {
 	case "analyzerv2":
 		e.AnalyzerV2 = enabled
-	case "parsecmd":
-		e.ParseCmd = enabled
 	}
 }
 
@@ -99,9 +95,6 @@ func (e Experiment) Enabled() []string {
 	var enabled []string
 	if e.AnalyzerV2 {
 		enabled = append(enabled, "analyzerv2")
-	}
-	if e.ParseCmd {
-		enabled = append(enabled, "parsecmd")
 	}
 	return enabled
 }


### PR DESCRIPTION
Remove the parsecmd experiment requirement, making `sqlc parse` available
to all users without requiring SQLCEXPERIMENT=parsecmd.

The parse command now works out of the box for parsing SQL and outputting
the AST as JSON.