### PR TITLE
Add GitHub Topic to the plugins page

### DIFF
--- a/docs/reference/language-support.rst
+++ b/docs/reference/language-support.rst
@@ -29,7 +29,7 @@ Python    `rayakame/sqlc-gen-better-python`_  N/A              Beta             
 [Any]     `fdietze/sqlc-gen-from-template`_   Stable           Stable           Stable
 ========  ==================================  ===============  ===============  ===============
 
-Plugins developed by our Community can also be found using the `github topic`_.
+Plugins developed by our Community can also be found using our `github topic`_.
 
 Community projects
 ******************


### PR DESCRIPTION
Mentioning the GitHub topic on the docs would make it easier for small plugins to find people that may be looking for them.

Small discussion can be found [on discord](https://discord.com/channels/946447283321438248/946450074131636297/1457752822329376890).

https://github.com/topics/sqlc-plugin

Adding the topic to the official plugins would make sense too.
