### PR TITLE
refactor(ast): Removed redundant type ast.AlterTableType_PG

### DIFF
--- a/internal/sql/ast/alter_table_type.go
+++ b/internal/sql/ast/alter_table_type.go
@@ -1,7 +1,0 @@
-package ast
-
-type AlterTableType_PG uint
-
-func (n *AlterTableType_PG) Pos() int {
-	return 0
-}


### PR DESCRIPTION
Because no parsers which produces instance of this type