### PR TITLE
refactor(ast): Removed redundant type ast.DistinctExpr

### DIFF
--- a/internal/sql/ast/typedefs.go
+++ b/internal/sql/ast/typedefs.go
@@ -8,12 +8,6 @@ func (n *AclMode) Pos() int {
 	return 0
 }
 
-type DistinctExpr OpExpr
-
-func (n *DistinctExpr) Pos() int {
-	return 0
-}
-
 type NullIfExpr OpExpr
 
 func (n *NullIfExpr) Pos() int {


### PR DESCRIPTION
Because no parsers which produces instance of this type