### PR TITLE
refactor(ast): Removed redundant type ast.FunctionParameterMode

### DIFF
--- a/internal/engine/postgresql/convert.go
+++ b/internal/engine/postgresql/convert.go
@@ -1649,7 +1649,6 @@ func convertFunctionParameter(n *pg.FunctionParameter) *ast.FunctionParameter {
 	return &ast.FunctionParameter{
 		Name:    makeString(n.Name),
 		ArgType: convertTypeName(n.ArgType),
-		Mode:    ast.FunctionParameterMode(n.Mode),
 		Defexpr: convertNode(n.Defexpr),
 	}
 }

--- a/internal/sql/ast/function_parameter.go
+++ b/internal/sql/ast/function_parameter.go
@@ -3,7 +3,6 @@ package ast
 type FunctionParameter struct {
 	Name    *string
 	ArgType *TypeName
-	Mode    FunctionParameterMode
 	Defexpr Node
 }
 

--- a/internal/sql/ast/function_parameter_mode.go
+++ b/internal/sql/ast/function_parameter_mode.go
@@ -1,7 +1,0 @@
-package ast
-
-type FunctionParameterMode uint
-
-func (n *FunctionParameterMode) Pos() int {
-	return 0
-}


### PR DESCRIPTION
Because specified only from PG parser but no usages after