### PR TITLE
refactor(ast): Removed redundant type ast.Expr

### DIFF
--- a/internal/engine/sqlite/convert.go
+++ b/internal/engine/sqlite/convert.go
@@ -311,10 +311,6 @@ func (c *cc) convertFuncContext(n *parser.Expr_functionContext) ast.Node {
 	return todo("convertFuncContext", n)
 }
 
-func (c *cc) convertExprContext(n *parser.ExprContext) ast.Node {
-	return &ast.Expr{}
-}
-
 func (c *cc) convertColumnNameExpr(n *parser.Expr_qualified_column_nameContext) *ast.ColumnRef {
 	var items []ast.Node
 	if schema, ok := n.Schema_name().(*parser.Schema_nameContext); ok {
@@ -826,7 +822,7 @@ func (c *cc) convertUnaryExpr(n *parser.Expr_unaryContext) ast.Node {
 		if opCtx.MINUS() != nil {
 			// Negative number: -expr
 			return &ast.A_Expr{
-				Name: &ast.List{Items: []ast.Node{&ast.String{Str: "-"}}},
+				Name:  &ast.List{Items: []ast.Node{&ast.String{Str: "-"}}},
 				Rexpr: expr,
 			}
 		}
@@ -837,7 +833,7 @@ func (c *cc) convertUnaryExpr(n *parser.Expr_unaryContext) ast.Node {
 		if opCtx.TILDE() != nil {
 			// Bitwise NOT: ~expr
 			return &ast.A_Expr{
-				Name: &ast.List{Items: []ast.Node{&ast.String{Str: "~"}}},
+				Name:  &ast.List{Items: []ast.Node{&ast.String{Str: "~"}}},
 				Rexpr: expr,
 			}
 		}
@@ -1266,9 +1262,6 @@ func (c *cc) convert(node node) ast.Node {
 
 	case *parser.Delete_stmt_limitedContext:
 		return c.convertDelete_stmtContext(n)
-
-	case *parser.ExprContext:
-		return c.convertExprContext(n)
 
 	case *parser.Expr_functionContext:
 		return c.convertFuncContext(n)

--- a/internal/sql/ast/expr.go
+++ b/internal/sql/ast/expr.go
@@ -1,8 +1,0 @@
-package ast
-
-type Expr struct {
-}
-
-func (n *Expr) Pos() int {
-	return 0
-}

--- a/internal/sql/astutils/rewrite.go
+++ b/internal/sql/astutils/rewrite.go
@@ -724,9 +724,6 @@ func (a *application) apply(parent ast.Node, name string, iter *iterator, n ast.
 		a.apply(n, "Query", nil, n.Query)
 		a.apply(n, "Options", nil, n.Options)
 
-	case *ast.Expr:
-		// pass
-
 	case *ast.FetchStmt:
 		// pass
 

--- a/internal/sql/astutils/walk.go
+++ b/internal/sql/astutils/walk.go
@@ -1134,9 +1134,6 @@ func Walk(f Visitor, node ast.Node) {
 			Walk(f, n.Options)
 		}
 
-	case *ast.Expr:
-		// pass
-
 	case *ast.FetchStmt:
 		// pass
 


### PR DESCRIPTION
specified only from SQLite parser as base (embedded) type for more Expr* types, no usages as standalone type

parser.ExprContext used as embedded type such as

https://github.com/sqlc-dev/sqlc/blob/2e0435c856c7d42ea58aaa2c24b6c9feda0509e9/internal/engine/sqlite/parser/sqlite_parser.go#L12337-L12339

https://github.com/sqlc-dev/sqlc/blob/2e0435c856c7d42ea58aaa2c24b6c9feda0509e9/internal/engine/sqlite/parser/sqlite_parser.go#L13340-L13342

https://github.com/sqlc-dev/sqlc/blob/2e0435c856c7d42ea58aaa2c24b6c9feda0509e9/internal/engine/sqlite/parser/sqlite_parser.go#L12480-L12482

etc