### PR TITLE
Prioritize native database installations over Docker

### DIFF
--- a/internal/sqltest/local/mysql.go
+++ b/internal/sqltest/local/mysql.go
@@ -26,21 +26,21 @@ func MySQL(t *testing.T, migrations []string) string {
 
 	dburi := os.Getenv("MYSQL_SERVER_URI")
 	if dburi == "" {
-		if ierr := docker.Installed(); ierr == nil {
-			u, err := docker.StartMySQLServer(ctx)
-			if err != nil {
-				t.Fatal(err)
-			}
-			dburi = u
-		} else if ierr := native.Supported(); ierr == nil {
-			// Fall back to native installation when Docker is not available
+		if ierr := native.Supported(); ierr == nil {
 			u, err := native.StartMySQLServer(ctx)
 			if err != nil {
 				t.Fatal(err)
 			}
 			dburi = u
+		} else if ierr := docker.Installed(); ierr == nil {
+			// Fall back to Docker when native installation is not available
+			u, err := docker.StartMySQLServer(ctx)
+			if err != nil {
+				t.Fatal(err)
+			}
+			dburi = u
 		} else {
-			t.Skip("MYSQL_SERVER_URI is empty and neither Docker nor native installation is available")
+			t.Skip("MYSQL_SERVER_URI is empty and neither native installation nor Docker is available")
 		}
 	}
 

--- a/internal/sqltest/local/postgres.go
+++ b/internal/sqltest/local/postgres.go
@@ -36,21 +36,21 @@ func postgreSQL(t *testing.T, migrations []string, rw bool) string {
 
 	dburi := os.Getenv("POSTGRESQL_SERVER_URI")
 	if dburi == "" {
-		if ierr := docker.Installed(); ierr == nil {
-			u, err := docker.StartPostgreSQLServer(ctx)
-			if err != nil {
-				t.Fatal(err)
-			}
-			dburi = u
-		} else if ierr := native.Supported(); ierr == nil {
-			// Fall back to native installation when Docker is not available
+		if ierr := native.Supported(); ierr == nil {
 			u, err := native.StartPostgreSQLServer(ctx)
 			if err != nil {
 				t.Fatal(err)
 			}
 			dburi = u
+		} else if ierr := docker.Installed(); ierr == nil {
+			// Fall back to Docker when native installation is not available
+			u, err := docker.StartPostgreSQLServer(ctx)
+			if err != nil {
+				t.Fatal(err)
+			}
+			dburi = u
 		} else {
-			t.Skip("POSTGRESQL_SERVER_URI is empty and neither Docker nor native installation is available")
+			t.Skip("POSTGRESQL_SERVER_URI is empty and neither native installation nor Docker is available")
 		}
 	}
 


### PR DESCRIPTION
## Summary
This change reorders the database server startup logic to prioritize native installations over Docker containers in the SQL test utilities for both MySQL and PostgreSQL.

## Key Changes
- **MySQL tests** (`internal/sqltest/local/mysql.go`):
  - Swapped the order of checks: now attempts native installation first, then falls back to Docker
  - Updated fallback comment to reflect the new priority

- **PostgreSQL tests** (`internal/sqltest/local/postgres.go`):
  - Applied the same reordering: native installation checked first, Docker as fallback
  - Updated fallback comment to reflect the new priority

- **Skip messages**: Updated error messages in both files to reflect the new priority order (native before Docker)

## Rationale
This change ensures that native database installations are preferred when available, as they typically offer better performance and lower overhead compared to Docker containers. Docker is now used as a fallback option only when native installations are not available.

https://claude.ai/code/session_01XbZNE4YfrtML4B6sLVf2E3