### PR TITLE
fix(sqlite): normalize column names in ALTER TABLE ADD/DROP COLUMN

### DIFF
--- a/internal/engine/sqlite/catalog_test.go
+++ b/internal/engine/sqlite/catalog_test.go
@@ -83,6 +83,38 @@ func TestUpdate(t *testing.T) {
 			},
 		},
 		{
+			// Regression test for #4307: mixed-case column name in ALTER TABLE ADD COLUMN
+			`
+			CREATE TABLE foo (id INTEGER NOT NULL, xYz INTEGER NOT NULL DEFAULT 0);
+			ALTER TABLE foo ADD COLUMN barBaz TEXT NOT NULL DEFAULT '';
+			`,
+			&catalog.Schema{
+				Name: "main",
+				Tables: []*catalog.Table{
+					{
+						Rel: &ast.TableName{Name: "foo"},
+						Columns: []*catalog.Column{
+							{
+								Name:      "id",
+								Type:      ast.TypeName{Name: "INTEGER"},
+								IsNotNull: true,
+							},
+							{
+								Name:      "xyz",
+								Type:      ast.TypeName{Name: "INTEGER"},
+								IsNotNull: true,
+							},
+							{
+								Name:      "barbaz",
+								Type:      ast.TypeName{Name: "TEXT"},
+								IsNotNull: true,
+							},
+						},
+					},
+				},
+			},
+		},
+		{
 			`
 			CREATE TABLE foo (bar text);
 			ALTER TABLE foo RENAME COLUMN bar TO baz;

--- a/internal/engine/sqlite/convert.go
+++ b/internal/engine/sqlite/convert.go
@@ -67,7 +67,7 @@ func (c *cc) convertAlter_table_stmtContext(n *parser.Alter_table_stmtContext) a
 				Table: parseTableName(n),
 				Cmds:  &ast.List{},
 			}
-			name := def.Column_name().GetText()
+			name := identifier(def.Column_name().GetText())
 			stmt.Cmds.Items = append(stmt.Cmds.Items, &ast.AlterTableCmd{
 				Name:    &name,
 				Subtype: ast.AT_AddColumn,
@@ -88,7 +88,7 @@ func (c *cc) convertAlter_table_stmtContext(n *parser.Alter_table_stmtContext) a
 			Table: parseTableName(n),
 			Cmds:  &ast.List{},
 		}
-		name := n.Column_name(0).GetText()
+		name := identifier(n.Column_name(0).GetText())
 		stmt.Cmds.Items = append(stmt.Cmds.Items, &ast.AlterTableCmd{
 			Name:    &name,
 			Subtype: ast.AT_DropColumn,


### PR DESCRIPTION
Fixes #4307

## Problem
When  or  statements use mixed-case column names (e.g., `barBaz`), the column name was stored in the catalog with its original case. However,  queries normalize all unquoted identifiers to lowercase via the `identifier()` function, causing a mismatch and "column does not exist" errors.

## Solution
This fix ensures  also normalize column names using `identifier()`, matching the behavior of  and  queries. This aligns with SQLite's case-insensitive identifier handling.

## Changes
- `internal/engine/sqlite/convert.go`: Apply `identifier()` to column names in ALTER TABLE ADD COLUMN and DROP COLUMN handlers (lines 70 and 91)
- `internal/engine/sqlite/catalog_test.go`: Add regression test for mixed-case column names in ALTER TABLE ADD COLUMN

## Testing
All existing tests pass, including the new regression test case that reproduces the issue from #4307.

```bash
$ go test ./internal/engine/sqlite/ -run TestUpdate -v
--- PASS: TestUpdate (0.08s)
    --- PASS: TestUpdate/3 (0.01s)  # New mixed-case test
```