### PR TITLE
Upgrade Go version to 1.26.0

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,7 +12,7 @@ jobs:
     - uses: actions/checkout@v6
     - uses: actions/setup-go@v6
       with:
-        go-version: '1.25.0'
+        go-version: '1.26.0'
     - name: install ./...
       run: go build ./...
       env:

--- a/.github/workflows/ci-kotlin.yml
+++ b/.github/workflows/ci-kotlin.yml
@@ -13,7 +13,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: actions/setup-go@v6
         with:
-          go-version: '1.24.1'
+          go-version: '1.26.0'
       - name: install ./...
         run: go install ./...
       - uses: actions/checkout@v6

--- a/.github/workflows/ci-python.yml
+++ b/.github/workflows/ci-python.yml
@@ -13,7 +13,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: actions/setup-go@v6
         with:
-          go-version: '1.24.1'
+          go-version: '1.26.0'
       - name: install ./...
         run: go install ./...
       - uses: actions/checkout@v6

--- a/.github/workflows/ci-typescript.yml
+++ b/.github/workflows/ci-typescript.yml
@@ -13,7 +13,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: actions/setup-go@v6
         with:
-          go-version: '1.24.1'
+          go-version: '1.26.0'
       - name: install ./...
         run: go install ./...
       - uses: actions/checkout@v6

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
     - uses: actions/checkout@v6
     - uses: actions/setup-go@v6
       with:
-        go-version: '1.25.0'
+        go-version: '1.26.0'
     - run: go build ./...
       env:
         CGO_ENABLED: "0"
@@ -28,7 +28,7 @@ jobs:
     - uses: actions/checkout@v6
     - uses: actions/setup-go@v6
       with:
-        go-version: '1.25.0'
+        go-version: '1.26.0'
 
     - name: install gotestsum
       run: go install gotest.tools/gotestsum@latest

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,7 +6,7 @@ This document provides essential information for working with the sqlc codebase,
 
 ### Prerequisites
 
-- **Go 1.25.0+** - Required for building and testing
+- **Go 1.26.0+** - Required for building and testing
 - **Docker & Docker Compose** - Required for integration tests with databases (local development)
 - **Git** - For version control
 
@@ -147,7 +147,7 @@ make start             # Start database containers
 ### GitHub Actions Workflow
 
 - **File:** `.github/workflows/ci.yml`
-- **Go Version:** 1.25.0
+- **Go Version:** 1.26.0
 - **Database Setup:** Uses `sqlc-test-setup` (not Docker) to install and start PostgreSQL and MySQL directly on the runner
 - **Test Command:** `gotestsum --junitfile junit.xml -- --tags=examples -timeout 20m ./...`
 - **Additional Checks:** `govulncheck` for vulnerability scanning

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/sqlc-dev/sqlc
 
-go 1.24.7
+go 1.26.0
 
 require (
 	github.com/antlr4-go/antlr/v4 v4.13.1


### PR DESCRIPTION
Update Go version references across the project:
- go.mod: 1.24.7 -> 1.26.0
- CI workflows (ci.yml, build.yml): 1.25.0 -> 1.26.0
- Language CI workflows (python, kotlin, typescript): 1.24.1 -> 1.26.0
- CLAUDE.md: Update prerequisite and CI documentation
- Dockerfile was already at 1.26.0

https://claude.ai/code/session_016tGVCbKHnM72NpNcKjBhui