### PR TITLE
Add Datalog evaluator and type resolution packages

### DIFF
--- a/internal/datalog/datalog.go
+++ b/internal/datalog/datalog.go
@@ -1,0 +1,722 @@
+// Package datalog implements a self-contained Datalog evaluator supporting
+// semi-naive bottom-up evaluation with stratified negation. It provides an
+// in-memory deductive database suitable for computing fixed-point analyses
+// over relational data.
+//
+// The evaluator works by repeatedly applying rules to derive new facts until
+// no more new facts can be produced (a fixpoint). Stratified negation allows
+// rules to reference the absence of facts, provided there are no recursive
+// dependencies through negation.
+package datalog
+
+import (
+	"errors"
+	"fmt"
+	"sort"
+	"strings"
+)
+
+// ---------------------------------------------------------------------------
+// Symbol table — interned strings
+// ---------------------------------------------------------------------------
+
+// Symbol is an interned string represented as an integer index.
+type Symbol int
+
+// SymbolTable maps strings to Symbol IDs and back for efficient storage and
+// comparison of string values.
+type SymbolTable struct {
+	forward map[string]Symbol
+	reverse []string
+}
+
+// NewSymbolTable creates an empty symbol table.
+func NewSymbolTable() *SymbolTable {
+	return &SymbolTable{
+		forward: make(map[string]Symbol),
+	}
+}
+
+// Intern adds a string to the table (if not already present) and returns its
+// Symbol ID.
+func (st *SymbolTable) Intern(s string) Symbol {
+	if id, ok := st.forward[s]; ok {
+		return id
+	}
+	id := Symbol(len(st.reverse))
+	st.forward[s] = id
+	st.reverse = append(st.reverse, s)
+	return id
+}
+
+// Resolve returns the string for a given Symbol. It panics if the symbol is
+// out of range.
+func (st *SymbolTable) Resolve(sym Symbol) string {
+	return st.reverse[int(sym)]
+}
+
+// ---------------------------------------------------------------------------
+// Tuples and relations
+// ---------------------------------------------------------------------------
+
+// Tuple is a fixed-length slice of Symbol values representing a single ground
+// fact.
+type Tuple []Symbol
+
+// tupleKey produces a string key for deduplication. The null byte separator
+// cannot appear in interned strings.
+func tupleKey(t Tuple) string {
+	var b strings.Builder
+	for i, s := range t {
+		if i > 0 {
+			b.WriteByte(0)
+		}
+		fmt.Fprintf(&b, "%d", int(s))
+	}
+	return b.String()
+}
+
+// relation is a named collection of tuples with deduplication.
+type relation struct {
+	arity  int
+	tuples []Tuple
+	index  map[string]struct{}
+}
+
+func newRelation(arity int) *relation {
+	return &relation{
+		arity: arity,
+		index: make(map[string]struct{}),
+	}
+}
+
+// add inserts a tuple if it is not already present. Returns true if the tuple
+// was new.
+func (r *relation) add(t Tuple) bool {
+	k := tupleKey(t)
+	if _, exists := r.index[k]; exists {
+		return false
+	}
+	r.index[k] = struct{}{}
+	cp := make(Tuple, len(t))
+	copy(cp, t)
+	r.tuples = append(r.tuples, cp)
+	return true
+}
+
+// contains checks whether the tuple exists.
+func (r *relation) contains(t Tuple) bool {
+	_, exists := r.index[tupleKey(t)]
+	return exists
+}
+
+// clone returns a deep copy of the relation.
+func (r *relation) clone() *relation {
+	nr := newRelation(r.arity)
+	for _, t := range r.tuples {
+		nr.add(t)
+	}
+	return nr
+}
+
+// ---------------------------------------------------------------------------
+// Terms, atoms, and rules
+// ---------------------------------------------------------------------------
+
+// TermExpr is an opaque term expression used when constructing rules via the
+// builder API. It represents either a variable reference or a constant value.
+type TermExpr struct {
+	isVar bool
+	name  string // variable name when isVar; constant string value otherwise
+}
+
+// Var creates a variable term expression.
+func Var(name string) TermExpr { return TermExpr{isVar: true, name: name} }
+
+// Const creates a constant term expression.
+func Const(value string) TermExpr { return TermExpr{isVar: false, name: value} }
+
+// Term is a resolved term inside a rule — either a variable or a constant
+// symbol.
+type Term struct {
+	IsVariable bool
+	VarName    string
+	Value      Symbol
+}
+
+// Atom is a predicate name paired with a list of terms. It appears in rule
+// heads and bodies.
+type Atom struct {
+	Predicate string
+	Terms     []Term
+}
+
+// Rule is a Horn clause: a head atom derived from a conjunction of positive
+// body atoms and negated body atoms.
+type Rule struct {
+	Head    Atom
+	Body    []Atom
+	Negated []Atom
+}
+
+// ---------------------------------------------------------------------------
+// Rule builder
+// ---------------------------------------------------------------------------
+
+type atomExpr struct {
+	pred  string
+	terms []TermExpr
+}
+
+// RuleBuilder provides a fluent API for constructing rules.
+type RuleBuilder struct {
+	st        *SymbolTable
+	headPred  string
+	headTerms []TermExpr
+	body      []atomExpr
+	negBody   []atomExpr
+}
+
+// NewRule begins building a rule with the given head predicate and terms. The
+// symbol table is used to intern constant values when Build is called.
+func NewRule(st *SymbolTable, headPred string, headTerms ...TermExpr) *RuleBuilder {
+	return &RuleBuilder{
+		st:        st,
+		headPred:  headPred,
+		headTerms: headTerms,
+	}
+}
+
+// Where adds a positive body atom to the rule.
+func (rb *RuleBuilder) Where(pred string, terms ...TermExpr) *RuleBuilder {
+	rb.body = append(rb.body, atomExpr{pred: pred, terms: terms})
+	return rb
+}
+
+// WhereNot adds a negated body atom to the rule.
+func (rb *RuleBuilder) WhereNot(pred string, terms ...TermExpr) *RuleBuilder {
+	rb.negBody = append(rb.negBody, atomExpr{pred: pred, terms: terms})
+	return rb
+}
+
+// Build finalises the rule, interning any constant values that appear in the
+// terms.
+func (rb *RuleBuilder) Build() Rule {
+	resolve := func(te TermExpr) Term {
+		if te.isVar {
+			return Term{IsVariable: true, VarName: te.name}
+		}
+		return Term{IsVariable: false, Value: rb.st.Intern(te.name)}
+	}
+	makeAtom := func(ae atomExpr) Atom {
+		a := Atom{Predicate: ae.pred, Terms: make([]Term, len(ae.terms))}
+		for i, te := range ae.terms {
+			a.Terms[i] = resolve(te)
+		}
+		return a
+	}
+
+	head := Atom{Predicate: rb.headPred, Terms: make([]Term, len(rb.headTerms))}
+	for i, te := range rb.headTerms {
+		head.Terms[i] = resolve(te)
+	}
+
+	r := Rule{Head: head}
+	for _, ae := range rb.body {
+		r.Body = append(r.Body, makeAtom(ae))
+	}
+	for _, ae := range rb.negBody {
+		r.Negated = append(r.Negated, makeAtom(ae))
+	}
+	return r
+}
+
+// ---------------------------------------------------------------------------
+// Program
+// ---------------------------------------------------------------------------
+
+// Program holds the initial facts (extensional database) and the rules that
+// will be evaluated to compute derived facts (intensional database).
+type Program struct {
+	st    *SymbolTable
+	facts map[string]*relation
+	rules []Rule
+}
+
+// NewProgram creates an empty program bound to the given symbol table.
+func NewProgram(st *SymbolTable) *Program {
+	return &Program{
+		st:    st,
+		facts: make(map[string]*relation),
+	}
+}
+
+// AddFact adds a ground fact. String values are interned automatically.
+func (p *Program) AddFact(predicate string, values ...string) {
+	t := make(Tuple, len(values))
+	for i, v := range values {
+		t[i] = p.st.Intern(v)
+	}
+	rel, ok := p.facts[predicate]
+	if !ok {
+		rel = newRelation(len(values))
+		p.facts[predicate] = rel
+	}
+	rel.add(t)
+}
+
+// AddRule adds a derivation rule to the program.
+func (p *Program) AddRule(r Rule) {
+	p.rules = append(p.rules, r)
+}
+
+// ---------------------------------------------------------------------------
+// Database — query interface over computed facts
+// ---------------------------------------------------------------------------
+
+// Database holds the final set of facts after evaluation.
+type Database struct {
+	st    *SymbolTable
+	facts map[string]*relation
+}
+
+// Query returns all tuples for the given predicate, with symbol values
+// resolved back to strings. The results are sorted lexicographically.
+func (db *Database) Query(predicate string) [][]string {
+	rel, ok := db.facts[predicate]
+	if !ok {
+		return nil
+	}
+	result := make([][]string, len(rel.tuples))
+	for i, t := range rel.tuples {
+		row := make([]string, len(t))
+		for j, sym := range t {
+			row[j] = db.st.Resolve(sym)
+		}
+		result[i] = row
+	}
+	return result
+}
+
+// Contains checks whether a specific ground fact exists in the database.
+func (db *Database) Contains(predicate string, values ...string) bool {
+	rel, ok := db.facts[predicate]
+	if !ok {
+		return false
+	}
+	t := make(Tuple, len(values))
+	for i, v := range values {
+		sym, exists := db.st.forward[v]
+		if !exists {
+			return false
+		}
+		t[i] = sym
+	}
+	return rel.contains(t)
+}
+
+// ---------------------------------------------------------------------------
+// Stratification
+// ---------------------------------------------------------------------------
+
+// stratum groups predicates that can be evaluated together.
+type stratum struct {
+	predicates map[string]bool
+	rules      []Rule
+}
+
+// stratify computes strata by analyzing negation dependencies among rules.
+// Predicates that appear in negated body atoms must be fully computed before
+// the stratum that negates them. Returns an error if a cycle through negation
+// is detected, which makes stratification impossible.
+func stratify(rules []Rule) ([]stratum, error) {
+	// Collect all predicates mentioned in rule heads.
+	preds := make(map[string]bool)
+	for _, r := range rules {
+		preds[r.Head.Predicate] = true
+	}
+
+	// Build dependency graph.
+	// posEdges: head depends positively on body predicate.
+	// negEdges: head depends (through negation) on negated body predicate.
+	posEdges := make(map[string]map[string]bool)
+	negEdges := make(map[string]map[string]bool)
+	ensureSet := func(m map[string]map[string]bool, k string) {
+		if m[k] == nil {
+			m[k] = make(map[string]bool)
+		}
+	}
+
+	for _, r := range rules {
+		h := r.Head.Predicate
+		ensureSet(posEdges, h)
+		ensureSet(negEdges, h)
+		for _, b := range r.Body {
+			if preds[b.Predicate] {
+				posEdges[h][b.Predicate] = true
+			}
+		}
+		for _, b := range r.Negated {
+			preds[b.Predicate] = true // ensure negated predicates are tracked
+			negEdges[h][b.Predicate] = true
+		}
+	}
+
+	// Assign stratum numbers using iterative relaxation.
+	// A predicate's stratum must be:
+	//   >= stratum of any positive dependency
+	//   >  stratum of any negated dependency
+	stratumOf := make(map[string]int)
+	for p := range preds {
+		stratumOf[p] = 0
+	}
+
+	changed := true
+	maxIter := len(preds) + 1
+	for iter := 0; changed && iter < maxIter; iter++ {
+		changed = false
+		for p := range preds {
+			cur := stratumOf[p]
+			for dep := range posEdges[p] {
+				if stratumOf[dep] > cur {
+					stratumOf[p] = stratumOf[dep]
+					changed = true
+					cur = stratumOf[p]
+				}
+			}
+			for dep := range negEdges[p] {
+				need := stratumOf[dep] + 1
+				if need > cur {
+					stratumOf[p] = need
+					changed = true
+					cur = stratumOf[p]
+				}
+			}
+		}
+	}
+
+	// If still changing after maxIter iterations, a negation cycle exists.
+	if changed {
+		return nil, errors.New("datalog: negation cycle detected; stratification is impossible")
+	}
+
+	// Group predicates by stratum number.
+	maxStratum := 0
+	for _, s := range stratumOf {
+		if s > maxStratum {
+			maxStratum = s
+		}
+	}
+
+	strata := make([]stratum, maxStratum+1)
+	for i := range strata {
+		strata[i].predicates = make(map[string]bool)
+	}
+	for p, s := range stratumOf {
+		strata[s].predicates[p] = true
+	}
+
+	// Assign each rule to the stratum of its head predicate.
+	for _, r := range rules {
+		s := stratumOf[r.Head.Predicate]
+		strata[s].rules = append(strata[s].rules, r)
+	}
+
+	return strata, nil
+}
+
+// ---------------------------------------------------------------------------
+// Evaluation engine
+// ---------------------------------------------------------------------------
+
+// binding maps variable names to symbol values during rule evaluation.
+type binding map[string]Symbol
+
+// copyBinding returns a shallow copy of a binding.
+func copyBinding(b binding) binding {
+	nb := make(binding, len(b))
+	for k, v := range b {
+		nb[k] = v
+	}
+	return nb
+}
+
+// matchAtom attempts to unify an atom against a tuple under the given binding.
+// It returns an extended binding on success, or nil if unification fails.
+func matchAtom(a Atom, t Tuple, b binding) binding {
+	if len(a.Terms) != len(t) {
+		return nil
+	}
+	nb := copyBinding(b)
+	for i, term := range a.Terms {
+		if term.IsVariable {
+			if prev, bound := nb[term.VarName]; bound {
+				if prev != t[i] {
+					return nil
+				}
+			} else {
+				nb[term.VarName] = t[i]
+			}
+		} else {
+			if term.Value != t[i] {
+				return nil
+			}
+		}
+	}
+	return nb
+}
+
+// projectHead builds a tuple from the head atom using the given binding.
+func projectHead(head Atom, b binding) Tuple {
+	t := make(Tuple, len(head.Terms))
+	for i, term := range head.Terms {
+		if term.IsVariable {
+			t[i] = b[term.VarName]
+		} else {
+			t[i] = term.Value
+		}
+	}
+	return t
+}
+
+// evaluateRuleBody performs a nested-loop join over the positive body atoms,
+// collecting all satisfying bindings. The useDelta parameter specifies which
+// body atom index should read from the delta relation instead of the full
+// fact set; pass -1 to use full relations for all atoms.
+func evaluateRuleBody(
+	body []Atom,
+	facts map[string]*relation,
+	delta map[string]*relation,
+	useDelta int,
+) []binding {
+	bindings := []binding{make(binding)}
+
+	for i, atom := range body {
+		source := facts[atom.Predicate]
+		if i == useDelta {
+			if d, ok := delta[atom.Predicate]; ok {
+				source = d
+			} else {
+				return nil
+			}
+		}
+		if source == nil {
+			return nil
+		}
+
+		var next []binding
+		for _, b := range bindings {
+			for _, t := range source.tuples {
+				nb := matchAtom(atom, t, b)
+				if nb != nil {
+					next = append(next, nb)
+				}
+			}
+		}
+		bindings = next
+		if len(bindings) == 0 {
+			return nil
+		}
+	}
+	return bindings
+}
+
+// checkNegation returns true if none of the negated atoms are satisfied under
+// the binding (i.e., all negation conditions hold).
+func checkNegation(negated []Atom, facts map[string]*relation, b binding) bool {
+	for _, atom := range negated {
+		rel := facts[atom.Predicate]
+		if rel == nil {
+			continue // no facts — negation trivially satisfied
+		}
+		// Try to build a fully-ground tuple from the binding.
+		t := make(Tuple, len(atom.Terms))
+		fullyBound := true
+		for i, term := range atom.Terms {
+			if term.IsVariable {
+				val, ok := b[term.VarName]
+				if !ok {
+					fullyBound = false
+					break
+				}
+				t[i] = val
+			} else {
+				t[i] = term.Value
+			}
+		}
+		if fullyBound {
+			if rel.contains(t) {
+				return false
+			}
+		} else {
+			// Partially bound: scan for any matching tuple.
+			if anyMatch(atom, rel, b) {
+				return false
+			}
+		}
+	}
+	return true
+}
+
+// anyMatch checks whether any tuple in rel matches the partially-bound atom.
+func anyMatch(atom Atom, rel *relation, b binding) bool {
+	for _, t := range rel.tuples {
+		if matchAtom(atom, t, b) != nil {
+			return true
+		}
+	}
+	return false
+}
+
+// evaluateRule derives new tuples for a single rule using the semi-naive
+// strategy: for each positive body atom position, it evaluates the rule with
+// that position reading from the delta relation, ensuring at least one delta
+// atom participates.
+func evaluateRule(
+	r Rule,
+	facts map[string]*relation,
+	delta map[string]*relation,
+) []Tuple {
+	if len(r.Body) == 0 {
+		// Rules with no body are treated as ground facts. They are handled via
+		// EDB seeding; returning nothing here avoids infinite derivation.
+		return nil
+	}
+
+	seen := make(map[string]struct{})
+	var results []Tuple
+
+	for i, atom := range r.Body {
+		if _, ok := delta[atom.Predicate]; !ok {
+			continue
+		}
+		bindings := evaluateRuleBody(r.Body, facts, delta, i)
+		for _, b := range bindings {
+			if !checkNegation(r.Negated, facts, b) {
+				continue
+			}
+			t := projectHead(r.Head, b)
+			k := tupleKey(t)
+			if _, dup := seen[k]; dup {
+				continue
+			}
+			seen[k] = struct{}{}
+			results = append(results, t)
+		}
+	}
+	return results
+}
+
+// ensureRelation returns the relation for pred, creating it with the given
+// arity if absent.
+func ensureRelation(m map[string]*relation, pred string, arity int) *relation {
+	if r, ok := m[pred]; ok {
+		return r
+	}
+	r := newRelation(arity)
+	m[pred] = r
+	return r
+}
+
+// ---------------------------------------------------------------------------
+// Evaluate — main entry point
+// ---------------------------------------------------------------------------
+
+// Evaluate runs the Datalog program to a fixpoint using semi-naive evaluation
+// with stratified negation and returns the resulting database. It returns an
+// error if stratification fails (e.g., due to a negation cycle) or if arity
+// mismatches are detected between rules and facts for the same predicate.
+func (p *Program) Evaluate() (*Database, error) {
+	// Validate arity consistency between rules and existing facts.
+	arities := make(map[string]int)
+	for pred, rel := range p.facts {
+		arities[pred] = rel.arity
+	}
+	for _, r := range p.rules {
+		headArity := len(r.Head.Terms)
+		if prev, ok := arities[r.Head.Predicate]; ok {
+			if prev != headArity {
+				return nil, fmt.Errorf(
+					"datalog: arity mismatch for predicate %q: have %d, rule head has %d",
+					r.Head.Predicate, prev, headArity,
+				)
+			}
+		} else {
+			arities[r.Head.Predicate] = headArity
+		}
+	}
+
+	// Stratify rules.
+	strata, err := stratify(p.rules)
+	if err != nil {
+		return nil, err
+	}
+
+	// Initialize the fact base with a deep copy of EDB facts.
+	facts := make(map[string]*relation)
+	for pred, rel := range p.facts {
+		facts[pred] = rel.clone()
+	}
+
+	// Process each stratum in order.
+	for _, st := range strata {
+		if len(st.rules) == 0 {
+			continue
+		}
+
+		// Seed delta with current facts for predicates relevant to this stratum.
+		// This includes both IDB predicates defined in this stratum and any EDB
+		// predicates referenced in rule bodies, so the first iteration can find
+		// matches.
+		delta := make(map[string]*relation)
+		for pred := range st.predicates {
+			if rel, ok := facts[pred]; ok {
+				delta[pred] = rel.clone()
+			}
+		}
+		for _, r := range st.rules {
+			for _, atom := range r.Body {
+				if _, ok := delta[atom.Predicate]; !ok {
+					if rel, ok := facts[atom.Predicate]; ok {
+						delta[atom.Predicate] = rel.clone()
+					}
+				}
+			}
+		}
+
+		// Semi-naive fixpoint loop.
+		for {
+			nextDelta := make(map[string]*relation)
+			for _, r := range st.rules {
+				derived := evaluateRule(r, facts, delta)
+				for _, t := range derived {
+					pred := r.Head.Predicate
+					rel := ensureRelation(facts, pred, len(t))
+					if rel.add(t) {
+						nd := ensureRelation(nextDelta, pred, len(t))
+						nd.add(t)
+					}
+				}
+			}
+			if len(nextDelta) == 0 {
+				break // fixpoint reached
+			}
+			delta = nextDelta
+		}
+	}
+
+	// Sort tuples for deterministic query results.
+	for _, rel := range facts {
+		sort.Slice(rel.tuples, func(i, j int) bool {
+			a, b := rel.tuples[i], rel.tuples[j]
+			for k := 0; k < len(a) && k < len(b); k++ {
+				if a[k] != b[k] {
+					return a[k] < b[k]
+				}
+			}
+			return len(a) < len(b)
+		})
+	}
+
+	return &Database{st: p.st, facts: facts}, nil
+}

--- a/internal/datalog/datalog_test.go
+++ b/internal/datalog/datalog_test.go
@@ -1,0 +1,243 @@
+package datalog
+
+import (
+	"testing"
+)
+
+func TestSymbolTable(t *testing.T) {
+	st := NewSymbolTable()
+	a := st.Intern("hello")
+	b := st.Intern("world")
+	c := st.Intern("hello")
+
+	if a != c {
+		t.Fatalf("expected same symbol for same string, got %d and %d", a, c)
+	}
+	if a == b {
+		t.Fatal("expected different symbols for different strings")
+	}
+	if st.Resolve(a) != "hello" {
+		t.Fatalf("expected 'hello', got %q", st.Resolve(a))
+	}
+	if st.Resolve(b) != "world" {
+		t.Fatalf("expected 'world', got %q", st.Resolve(b))
+	}
+}
+
+func TestTransitiveClosure(t *testing.T) {
+	// Classic Datalog example: compute reachability in a graph.
+	// edge(a,b), edge(b,c), edge(c,d)
+	// reach(X,Y) :- edge(X,Y).
+	// reach(X,Y) :- reach(X,Z), edge(Z,Y).
+	st := NewSymbolTable()
+	p := NewProgram(st)
+
+	p.AddFact("edge", "a", "b")
+	p.AddFact("edge", "b", "c")
+	p.AddFact("edge", "c", "d")
+
+	p.AddRule(NewRule(st, "reach", Var("X"), Var("Y")).
+		Where("edge", Var("X"), Var("Y")).
+		Build())
+
+	p.AddRule(NewRule(st, "reach", Var("X"), Var("Y")).
+		Where("reach", Var("X"), Var("Z")).
+		Where("edge", Var("Z"), Var("Y")).
+		Build())
+
+	db, err := p.Evaluate()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Should derive: reach(a,b), reach(a,c), reach(a,d), reach(b,c), reach(b,d), reach(c,d)
+	for _, tc := range []struct{ from, to string }{
+		{"a", "b"}, {"a", "c"}, {"a", "d"},
+		{"b", "c"}, {"b", "d"},
+		{"c", "d"},
+	} {
+		if !db.Contains("reach", tc.from, tc.to) {
+			t.Errorf("expected reach(%s, %s)", tc.from, tc.to)
+		}
+	}
+
+	// Should NOT have: reach(d, a), reach(b, a), etc.
+	if db.Contains("reach", "d", "a") {
+		t.Error("unexpected reach(d, a)")
+	}
+	if db.Contains("reach", "b", "a") {
+		t.Error("unexpected reach(b, a)")
+	}
+
+	results := db.Query("reach")
+	if len(results) != 6 {
+		t.Errorf("expected 6 reach facts, got %d", len(results))
+	}
+}
+
+func TestStratifiedNegation(t *testing.T) {
+	// alive(X) :- person(X), not dead(X).
+	st := NewSymbolTable()
+	p := NewProgram(st)
+
+	p.AddFact("person", "alice")
+	p.AddFact("person", "bob")
+	p.AddFact("person", "carol")
+	p.AddFact("dead", "bob")
+
+	p.AddRule(NewRule(st, "alive", Var("X")).
+		Where("person", Var("X")).
+		WhereNot("dead", Var("X")).
+		Build())
+
+	db, err := p.Evaluate()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if !db.Contains("alive", "alice") {
+		t.Error("expected alive(alice)")
+	}
+	if db.Contains("alive", "bob") {
+		t.Error("unexpected alive(bob)")
+	}
+	if !db.Contains("alive", "carol") {
+		t.Error("expected alive(carol)")
+	}
+}
+
+func TestNegationCycleDetected(t *testing.T) {
+	// p(X) :- q(X), not p(X). — this is a negation cycle
+	st := NewSymbolTable()
+	p := NewProgram(st)
+
+	p.AddFact("q", "a")
+
+	p.AddRule(NewRule(st, "p", Var("X")).
+		Where("q", Var("X")).
+		WhereNot("p", Var("X")).
+		Build())
+
+	_, err := p.Evaluate()
+	if err == nil {
+		t.Fatal("expected error for negation cycle")
+	}
+}
+
+func TestConstants(t *testing.T) {
+	// type_is_numeric(X) :- base_type(X, "numeric").
+	st := NewSymbolTable()
+	p := NewProgram(st)
+
+	p.AddFact("base_type", "int4", "numeric")
+	p.AddFact("base_type", "int8", "numeric")
+	p.AddFact("base_type", "text", "string")
+
+	p.AddRule(NewRule(st, "numeric_type", Var("X")).
+		Where("base_type", Var("X"), Const("numeric")).
+		Build())
+
+	db, err := p.Evaluate()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if !db.Contains("numeric_type", "int4") {
+		t.Error("expected numeric_type(int4)")
+	}
+	if !db.Contains("numeric_type", "int8") {
+		t.Error("expected numeric_type(int8)")
+	}
+	if db.Contains("numeric_type", "text") {
+		t.Error("unexpected numeric_type(text)")
+	}
+}
+
+func TestMultipleStrata(t *testing.T) {
+	// Stratum 0: castable(X,Y) :- implicit_cast(X,Y).
+	// Stratum 0: castable(X,Y) :- castable(X,Z), implicit_cast(Z,Y).
+	// Stratum 1: not_castable(X,Y) :- type(X), type(Y), not castable(X,Y).
+	st := NewSymbolTable()
+	p := NewProgram(st)
+
+	p.AddFact("type", "int4")
+	p.AddFact("type", "int8")
+	p.AddFact("type", "text")
+	p.AddFact("implicit_cast", "int4", "int8")
+
+	p.AddRule(NewRule(st, "castable", Var("X"), Var("Y")).
+		Where("implicit_cast", Var("X"), Var("Y")).
+		Build())
+	p.AddRule(NewRule(st, "castable", Var("X"), Var("Y")).
+		Where("castable", Var("X"), Var("Z")).
+		Where("implicit_cast", Var("Z"), Var("Y")).
+		Build())
+	p.AddRule(NewRule(st, "not_castable", Var("X"), Var("Y")).
+		Where("type", Var("X")).
+		Where("type", Var("Y")).
+		WhereNot("castable", Var("X"), Var("Y")).
+		Build())
+
+	db, err := p.Evaluate()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if !db.Contains("castable", "int4", "int8") {
+		t.Error("expected castable(int4, int8)")
+	}
+	if !db.Contains("not_castable", "int4", "text") {
+		t.Error("expected not_castable(int4, text)")
+	}
+	// int4 IS castable to int8, so it should NOT be in not_castable
+	if db.Contains("not_castable", "int4", "int8") {
+		t.Error("unexpected not_castable(int4, int8)")
+	}
+}
+
+func TestArityMismatch(t *testing.T) {
+	st := NewSymbolTable()
+	p := NewProgram(st)
+
+	p.AddFact("r", "a", "b")
+
+	// Rule head has arity 1, but fact has arity 2
+	p.AddRule(NewRule(st, "r", Var("X")).
+		Where("r", Var("X"), Var("Y")).
+		Build())
+
+	_, err := p.Evaluate()
+	if err == nil {
+		t.Fatal("expected arity mismatch error")
+	}
+}
+
+func TestEmptyProgram(t *testing.T) {
+	st := NewSymbolTable()
+	p := NewProgram(st)
+
+	db, err := p.Evaluate()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	results := db.Query("anything")
+	if results != nil {
+		t.Errorf("expected nil results, got %v", results)
+	}
+}
+
+func TestQueryNonexistent(t *testing.T) {
+	st := NewSymbolTable()
+	p := NewProgram(st)
+	p.AddFact("a", "1")
+
+	db, err := p.Evaluate()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if db.Contains("b", "1") {
+		t.Error("should not contain fact in nonexistent relation")
+	}
+}

--- a/internal/datalog/typeres/typeres.go
+++ b/internal/datalog/typeres/typeres.go
@@ -1,0 +1,683 @@
+// Package typeres expresses SQL type resolution as Datalog rules over a fixed
+// schema of relations. It models how PostgreSQL resolves types for expressions,
+// casts, operators, and functions.
+package typeres
+
+import (
+	"fmt"
+	"strconv"
+
+	"github.com/sqlc-dev/sqlc/internal/datalog"
+)
+
+// ---------------------------------------------------------------------------
+// Resolver accumulates EDB facts and, on Resolve(), evaluates the Datalog
+// program to derive resolved types.
+// ---------------------------------------------------------------------------
+
+// Resolver holds the type resolution program.
+type Resolver struct {
+	// EDB facts stored as string tuples keyed by predicate name.
+	facts map[string][][]string
+}
+
+// New creates a new Resolver.
+func New() *Resolver {
+	return &Resolver{
+		facts: make(map[string][][]string),
+	}
+}
+
+func (r *Resolver) addFact(pred string, vals ...string) {
+	r.facts[pred] = append(r.facts[pred], vals)
+}
+
+// --- Methods to populate EDB (base facts) ---
+
+// AddBaseType registers a type with its category and preferred flag.
+// Category codes follow PostgreSQL: "N"=numeric, "S"=string, "B"=boolean,
+// "D"=datetime, "U"=user-defined, etc.
+func (r *Resolver) AddBaseType(name, category string, preferred bool) {
+	r.addFact("base_type", name, category, strconv.FormatBool(preferred))
+}
+
+// AddImplicitCast registers an implicit (automatic) cast path.
+func (r *Resolver) AddImplicitCast(from, to string) {
+	r.addFact("implicit_cast", from, to)
+}
+
+// AddExplicitCast registers a cast that requires explicit CAST().
+func (r *Resolver) AddExplicitCast(from, to string) {
+	r.addFact("explicit_cast", from, to)
+}
+
+// AddAssignmentCast registers a cast allowed in assignment context.
+func (r *Resolver) AddAssignmentCast(from, to string) {
+	r.addFact("assignment_cast", from, to)
+}
+
+// AddOperator registers an operator signature.
+func (r *Resolver) AddOperator(op, leftType, rightType, resultType string) {
+	r.addFact("operator", op, leftType, rightType, resultType)
+}
+
+// AddFunction registers one parameter of a function signature.
+// paramIndex is the 0-based index of the parameter.
+func (r *Resolver) AddFunction(name string, paramIndex int, paramType, returnType string) {
+	r.addFact("function_sig", name, strconv.Itoa(paramIndex), paramType, returnType)
+}
+
+// --- Methods to add expression structure ---
+
+// SetExprType sets the known type of an expression (from a literal, column ref, etc.).
+func (r *Resolver) SetExprType(exprID, typeName string) {
+	r.addFact("expr_type", exprID, typeName)
+}
+
+// SetExprContext sets the expected type from context (e.g. INSERT target column).
+func (r *Resolver) SetExprContext(exprID, contextType string) {
+	r.addFact("expr_context", exprID, contextType)
+}
+
+// AddBinaryExpr registers a binary expression node.
+func (r *Resolver) AddBinaryExpr(exprID, op, leftID, rightID string) {
+	r.addFact("binary_expr", exprID, op, leftID, rightID)
+}
+
+// AddFuncCall registers a function call argument.
+func (r *Resolver) AddFuncCall(exprID, funcName string, argIndex int, argExprID string) {
+	r.addFact("func_call", exprID, funcName, strconv.Itoa(argIndex), argExprID)
+}
+
+// AddCastExpr registers an explicit CAST expression.
+func (r *Resolver) AddCastExpr(exprID, innerExprID, targetType string) {
+	r.addFact("cast_expr", exprID, innerExprID, targetType)
+}
+
+// AddCoalesceExpr registers a COALESCE argument.
+func (r *Resolver) AddCoalesceExpr(exprID string, argIndex int, argExprID string) {
+	r.addFact("coalesce_expr", exprID, strconv.Itoa(argIndex), argExprID)
+}
+
+// AddCaseExpr registers a CASE branch result expression.
+func (r *Resolver) AddCaseExpr(exprID string, branchIndex int, resultExprID string) {
+	r.addFact("case_expr", exprID, strconv.Itoa(branchIndex), resultExprID)
+}
+
+// ---------------------------------------------------------------------------
+// Resolve
+// ---------------------------------------------------------------------------
+
+// Resolve runs the Datalog evaluation and returns results.
+func (r *Resolver) Resolve() (*Result, error) {
+	st := datalog.NewSymbolTable()
+	p := datalog.NewProgram(st)
+
+	// Populate EDB facts.
+	for pred, tuples := range r.facts {
+		for _, vals := range tuples {
+			p.AddFact(pred, vals...)
+		}
+	}
+
+	// Add the fixed set of type-resolution rules.
+	addTypeRules(p, st)
+
+	db, err := p.Evaluate()
+	if err != nil {
+		return nil, fmt.Errorf("typeres: evaluation failed: %w", err)
+	}
+
+	return &Result{db: db}, nil
+}
+
+// ---------------------------------------------------------------------------
+// Result
+// ---------------------------------------------------------------------------
+
+// Result provides query methods over the evaluated type resolution database.
+type Result struct {
+	db *datalog.Database
+}
+
+// TypeOf returns the resolved type for the given expression ID.
+func (res *Result) TypeOf(exprID string) (string, bool) {
+	rows := res.db.Query("resolved_type")
+	for _, row := range rows {
+		if len(row) == 2 && row[0] == exprID {
+			return row[1], true
+		}
+	}
+	return "", false
+}
+
+// AllTypes returns a map of expression ID to resolved type name.
+func (res *Result) AllTypes() map[string]string {
+	m := make(map[string]string)
+	rows := res.db.Query("resolved_type")
+	for _, row := range rows {
+		if len(row) == 2 {
+			m[row[0]] = row[1]
+		}
+	}
+	return m
+}
+
+// CanCast returns true if "from" can be implicitly cast to "to" (transitively).
+func (res *Result) CanCast(from, to string) bool {
+	if from == to {
+		return true
+	}
+	return res.db.Contains("castable", from, to)
+}
+
+// CommonType returns the common supertype of two types if one exists.
+func (res *Result) CommonType(a, b string) (string, bool) {
+	if a == b {
+		return a, true
+	}
+	rows := res.db.Query("common_type")
+	for _, row := range rows {
+		if len(row) == 3 && row[0] == a && row[1] == b {
+			return row[2], true
+		}
+	}
+	return "", false
+}
+
+// ---------------------------------------------------------------------------
+// Datalog rules for type resolution
+// ---------------------------------------------------------------------------
+
+func addTypeRules(p *datalog.Program, st *datalog.SymbolTable) {
+	V := datalog.Var
+	C := datalog.Const
+	rule := func(headPred string, headTerms ...datalog.TermExpr) *datalog.RuleBuilder {
+		return datalog.NewRule(st, headPred, headTerms...)
+	}
+
+	// Rule 1: Direct type propagation.
+	// resolved_type(E, T) :- expr_type(E, T).
+	p.AddRule(rule("resolved_type", V("E"), V("T")).
+		Where("expr_type", V("E"), V("T")).
+		Build())
+
+	// Rule 2a: Castable — base case from implicit_cast.
+	// castable(A, B) :- implicit_cast(A, B).
+	p.AddRule(rule("castable", V("A"), V("B")).
+		Where("implicit_cast", V("A"), V("B")).
+		Build())
+
+	// Rule 2b: Castable — transitive closure.
+	// castable(A, C) :- castable(A, B), implicit_cast(B, C).
+	p.AddRule(rule("castable", V("A"), V("C")).
+		Where("castable", V("A"), V("B")).
+		Where("implicit_cast", V("B"), V("C")).
+		Build())
+
+	// Rule 3: Cast expressions — resolved type is the target type.
+	// resolved_type(E, T) :- cast_expr(E, _, T).
+	p.AddRule(rule("resolved_type", V("E"), V("T")).
+		Where("cast_expr", V("E"), V("_inner"), V("T")).
+		Build())
+
+	// Rule 4: Binary operators — direct match.
+	// operator_result(Op, LT, RT, Res) :- operator(Op, LT, RT, Res).
+	p.AddRule(rule("operator_result", V("Op"), V("LT"), V("RT"), V("Res")).
+		Where("operator", V("Op"), V("LT"), V("RT"), V("Res")).
+		Build())
+
+	// Rule 4a: Binary operators — promote left via implicit cast.
+	// operator_result(Op, LT, RT, Res) :-
+	//   castable(LT, LT2), operator(Op, LT2, RT, Res).
+	p.AddRule(rule("operator_result", V("Op"), V("LT"), V("RT"), V("Res")).
+		Where("castable", V("LT"), V("LT2")).
+		Where("operator", V("Op"), V("LT2"), V("RT"), V("Res")).
+		Build())
+
+	// Rule 4b: Binary operators — promote right via implicit cast.
+	// operator_result(Op, LT, RT, Res) :-
+	//   castable(RT, RT2), operator(Op, LT, RT2, Res).
+	p.AddRule(rule("operator_result", V("Op"), V("LT"), V("RT"), V("Res")).
+		Where("castable", V("RT"), V("RT2")).
+		Where("operator", V("Op"), V("LT"), V("RT2"), V("Res")).
+		Build())
+
+	// Rule 4c: Binary operators — promote both sides.
+	// operator_result(Op, LT, RT, Res) :-
+	//   castable(LT, LT2), castable(RT, RT2), operator(Op, LT2, RT2, Res).
+	p.AddRule(rule("operator_result", V("Op"), V("LT"), V("RT"), V("Res")).
+		Where("castable", V("LT"), V("LT2")).
+		Where("castable", V("RT"), V("RT2")).
+		Where("operator", V("Op"), V("LT2"), V("RT2"), V("Res")).
+		Build())
+
+	// Rule 4d: Resolve binary expression types.
+	// resolved_type(E, Res) :-
+	//   binary_expr(E, Op, L, R), resolved_type(L, LT), resolved_type(R, RT),
+	//   operator_result(Op, LT, RT, Res).
+	p.AddRule(rule("resolved_type", V("E"), V("Res")).
+		Where("binary_expr", V("E"), V("Op"), V("L"), V("R")).
+		Where("resolved_type", V("L"), V("LT")).
+		Where("resolved_type", V("R"), V("RT")).
+		Where("operator_result", V("Op"), V("LT"), V("RT"), V("Res")).
+		Build())
+
+	// Rule 5: Function calls — resolve via function signature.
+	// For single-argument functions (simplest case):
+	// resolved_type(E, RetT) :-
+	//   func_call(E, Fn, Idx, ArgE),
+	//   resolved_type(ArgE, ArgT),
+	//   function_sig(Fn, Idx, ArgT, RetT).
+	p.AddRule(rule("resolved_type", V("E"), V("RetT")).
+		Where("func_call", V("E"), V("Fn"), V("Idx"), V("ArgE")).
+		Where("resolved_type", V("ArgE"), V("ArgT")).
+		Where("function_sig", V("Fn"), V("Idx"), V("ArgT"), V("RetT")).
+		Build())
+
+	// Rule 5a: Function calls — with implicit cast on argument.
+	// resolved_type(E, RetT) :-
+	//   func_call(E, Fn, Idx, ArgE),
+	//   resolved_type(ArgE, ArgT),
+	//   castable(ArgT, ParamT),
+	//   function_sig(Fn, Idx, ParamT, RetT).
+	p.AddRule(rule("resolved_type", V("E"), V("RetT")).
+		Where("func_call", V("E"), V("Fn"), V("Idx"), V("ArgE")).
+		Where("resolved_type", V("ArgE"), V("ArgT")).
+		Where("castable", V("ArgT"), V("ParamT")).
+		Where("function_sig", V("Fn"), V("Idx"), V("ParamT"), V("RetT")).
+		Build())
+
+	// Rule 6: Common type — same type.
+	// common_type(A, A, A) :- base_type(A, _, _).
+	p.AddRule(rule("common_type", V("A"), V("A"), V("A")).
+		Where("base_type", V("A"), V("_cat"), V("_pref")).
+		Build())
+
+	// Rule 6a: Common type — A castable to B, B is preferred in its category.
+	// common_type(A, B, B) :- castable(A, B), base_type(B, _, "true").
+	p.AddRule(rule("common_type", V("A"), V("B"), V("B")).
+		Where("castable", V("A"), V("B")).
+		Where("base_type", V("B"), V("_cat"), C("true")).
+		Build())
+
+	// Rule 6b: Common type — B castable to A, A is preferred.
+	// common_type(A, B, A) :- castable(B, A), base_type(A, _, "true").
+	p.AddRule(rule("common_type", V("A"), V("B"), V("A")).
+		Where("castable", V("B"), V("A")).
+		Where("base_type", V("A"), V("_cat"), C("true")).
+		Build())
+
+	// Rule 6c: Common type — A castable to B (B not necessarily preferred).
+	// common_type(A, B, B) :- castable(A, B), base_type(B, _, _).
+	p.AddRule(rule("common_type", V("A"), V("B"), V("B")).
+		Where("castable", V("A"), V("B")).
+		Where("base_type", V("B"), V("_cat2"), V("_pref2")).
+		Build())
+
+	// Rule 6d: Common type — B castable to A.
+	// common_type(A, B, A) :- castable(B, A), base_type(A, _, _).
+	p.AddRule(rule("common_type", V("A"), V("B"), V("A")).
+		Where("castable", V("B"), V("A")).
+		Where("base_type", V("A"), V("_cat3"), V("_pref3")).
+		Build())
+
+	// Rule 6e: Common type — both castable to a third type (preferred).
+	// common_type(A, B, C) :-
+	//   castable(A, C), castable(B, C),
+	//   base_type(C, _, "true").
+	p.AddRule(rule("common_type", V("A"), V("B"), V("C")).
+		Where("castable", V("A"), V("C")).
+		Where("castable", V("B"), V("C")).
+		Where("base_type", V("C"), V("_cat4"), C("true")).
+		Build())
+
+	// Rule 7: COALESCE — resolved type from common type of arguments.
+	// For two arguments sharing the same coalesce expression:
+	// resolved_type(E, CT) :-
+	//   coalesce_expr(E, _, A1),
+	//   coalesce_expr(E, _, A2),
+	//   resolved_type(A1, T1),
+	//   resolved_type(A2, T2),
+	//   common_type(T1, T2, CT).
+	p.AddRule(rule("resolved_type", V("E"), V("CT")).
+		Where("coalesce_expr", V("E"), V("_i1"), V("A1")).
+		Where("coalesce_expr", V("E"), V("_i2"), V("A2")).
+		Where("resolved_type", V("A1"), V("T1")).
+		Where("resolved_type", V("A2"), V("T2")).
+		Where("common_type", V("T1"), V("T2"), V("CT")).
+		Build())
+
+	// Rule 8: CASE — resolved type from common type of branch results.
+	// resolved_type(E, CT) :-
+	//   case_expr(E, _, R1),
+	//   case_expr(E, _, R2),
+	//   resolved_type(R1, T1),
+	//   resolved_type(R2, T2),
+	//   common_type(T1, T2, CT).
+	p.AddRule(rule("resolved_type", V("E"), V("CT")).
+		Where("case_expr", V("E"), V("_b1"), V("R1")).
+		Where("case_expr", V("E"), V("_b2"), V("R2")).
+		Where("resolved_type", V("R1"), V("T1")).
+		Where("resolved_type", V("R2"), V("T2")).
+		Where("common_type", V("T1"), V("T2"), V("CT")).
+		Build())
+
+	// Rule 9: Context propagation — use context type if expression is castable.
+	// resolved_type(E, CT) :-
+	//   expr_context(E, CT),
+	//   resolved_type(E, T),
+	//   castable(T, CT).
+	p.AddRule(rule("resolved_type", V("E"), V("CT")).
+		Where("expr_context", V("E"), V("CT")).
+		Where("resolved_type", V("E"), V("T")).
+		Where("castable", V("T"), V("CT")).
+		Build())
+}
+
+// ---------------------------------------------------------------------------
+// LoadPostgreSQLTypes pre-populates the resolver with PostgreSQL's built-in
+// type catalog covering the most common ~25 types and their cast paths.
+// ---------------------------------------------------------------------------
+
+// LoadPostgreSQLTypes adds PostgreSQL's common built-in types, their categories,
+// preferred flags, and implicit cast paths to the resolver.
+func LoadPostgreSQLTypes(r *Resolver) {
+	// --- Base types ---
+	// Format: name, category, preferred
+	// Categories: B=boolean, N=numeric, S=string, D=datetime, U=user-defined,
+	//             V=bit-string, T=timespan
+
+	type baseType struct {
+		name      string
+		category  string
+		preferred bool
+	}
+
+	types := []baseType{
+		// Boolean
+		{"bool", "B", true},
+
+		// Numeric
+		{"int2", "N", false},
+		{"int4", "N", false},
+		{"int8", "N", false},
+		{"float4", "N", false},
+		{"float8", "N", true},
+		{"numeric", "N", false},
+
+		// String
+		{"text", "S", true},
+		{"varchar", "S", false},
+		{"char", "S", false},
+		{"name", "S", false},
+
+		// Binary
+		{"bytea", "U", false},
+
+		// Date/Time
+		{"date", "D", false},
+		{"time", "D", false},
+		{"timetz", "D", false},
+		{"timestamp", "D", false},
+		{"timestamptz", "D", true},
+		{"interval", "T", true},
+
+		// UUID
+		{"uuid", "U", false},
+
+		// JSON
+		{"json", "U", false},
+		{"jsonb", "U", false},
+
+		// XML
+		{"xml", "U", false},
+
+		// OID / internal
+		{"oid", "N", false},
+	}
+
+	for _, t := range types {
+		r.AddBaseType(t.name, t.category, t.preferred)
+	}
+
+	// --- Implicit casts ---
+	// These follow PostgreSQL's pg_cast entries with castcontext = 'i'.
+
+	implicitCasts := [][2]string{
+		// Integer promotions
+		{"int2", "int4"},
+		{"int2", "int8"},
+		{"int2", "float4"},
+		{"int2", "float8"},
+		{"int2", "numeric"},
+		{"int4", "int8"},
+		{"int4", "float4"},
+		{"int4", "float8"},
+		{"int4", "numeric"},
+		{"int8", "float4"},
+		{"int8", "float8"},
+		{"int8", "numeric"},
+
+		// Float promotions
+		{"float4", "float8"},
+
+		// Numeric to float
+		{"numeric", "float4"},
+		{"numeric", "float8"},
+
+		// String conversions
+		{"char", "varchar"},
+		{"char", "text"},
+		{"varchar", "text"},
+		{"name", "text"},
+
+		// Date/time promotions
+		{"date", "timestamp"},
+		{"date", "timestamptz"},
+		{"timestamp", "timestamptz"},
+		{"time", "timetz"},
+		{"time", "interval"},
+
+		// OID
+		{"int4", "oid"},
+		{"int8", "oid"},
+
+		// JSON
+		{"json", "jsonb"},
+	}
+
+	for _, c := range implicitCasts {
+		r.AddImplicitCast(c[0], c[1])
+	}
+
+	// --- Assignment casts ---
+	assignCasts := [][2]string{
+		{"int4", "int2"},
+		{"int8", "int4"},
+		{"int8", "int2"},
+		{"float8", "float4"},
+		{"float8", "numeric"},
+		{"float4", "numeric"},
+		{"numeric", "int2"},
+		{"numeric", "int4"},
+		{"numeric", "int8"},
+		{"text", "varchar"},
+		{"text", "char"},
+		{"varchar", "char"},
+		{"timestamptz", "timestamp"},
+		{"timestamptz", "date"},
+		{"timestamp", "date"},
+		{"timetz", "time"},
+	}
+
+	for _, c := range assignCasts {
+		r.AddAssignmentCast(c[0], c[1])
+	}
+
+	// --- Explicit casts ---
+	explicitCasts := [][2]string{
+		{"text", "int4"},
+		{"text", "int8"},
+		{"text", "float8"},
+		{"text", "numeric"},
+		{"text", "bool"},
+		{"text", "date"},
+		{"text", "timestamp"},
+		{"text", "timestamptz"},
+		{"text", "interval"},
+		{"text", "uuid"},
+		{"text", "json"},
+		{"text", "jsonb"},
+		{"int4", "bool"},
+		{"bool", "int4"},
+		{"float8", "int4"},
+		{"float8", "int8"},
+		{"float8", "int2"},
+		{"jsonb", "json"},
+	}
+
+	for _, c := range explicitCasts {
+		r.AddExplicitCast(c[0], c[1])
+	}
+
+	// --- Common operators ---
+	// Arithmetic: +, -, *, /
+	arithOps := []string{"+", "-", "*", "/"}
+	numericTypes := []string{"int2", "int4", "int8", "float4", "float8", "numeric"}
+
+	for _, op := range arithOps {
+		for _, t := range numericTypes {
+			r.AddOperator(op, t, t, t)
+		}
+	}
+
+	// Comparison: =, <>, <, >, <=, >=
+	cmpOps := []string{"=", "<>", "<", ">", "<=", ">="}
+	allComparable := append(numericTypes, "text", "varchar", "char", "date",
+		"time", "timetz", "timestamp", "timestamptz", "interval",
+		"bool", "uuid", "bytea")
+
+	for _, op := range cmpOps {
+		for _, t := range allComparable {
+			r.AddOperator(op, t, t, "bool")
+		}
+	}
+
+	// String concatenation
+	r.AddOperator("||", "text", "text", "text")
+	r.AddOperator("||", "varchar", "varchar", "text")
+	r.AddOperator("||", "text", "varchar", "text")
+	r.AddOperator("||", "varchar", "text", "text")
+
+	// Boolean operators
+	r.AddOperator("AND", "bool", "bool", "bool")
+	r.AddOperator("OR", "bool", "bool", "bool")
+
+	// --- Common functions ---
+	// length(text) -> int4
+	r.AddFunction("length", 0, "text", "int4")
+	r.AddFunction("length", 0, "bytea", "int4")
+
+	// upper/lower(text) -> text
+	r.AddFunction("upper", 0, "text", "text")
+	r.AddFunction("lower", 0, "text", "text")
+
+	// trim(text) -> text
+	r.AddFunction("trim", 0, "text", "text")
+	r.AddFunction("btrim", 0, "text", "text")
+	r.AddFunction("ltrim", 0, "text", "text")
+	r.AddFunction("rtrim", 0, "text", "text")
+
+	// substring(text, int4, int4) -> text
+	r.AddFunction("substring", 0, "text", "text")
+	r.AddFunction("substring", 1, "int4", "text")
+	r.AddFunction("substring", 2, "int4", "text")
+
+	// replace(text, text, text) -> text
+	r.AddFunction("replace", 0, "text", "text")
+	r.AddFunction("replace", 1, "text", "text")
+	r.AddFunction("replace", 2, "text", "text")
+
+	// abs(numeric) -> numeric
+	r.AddFunction("abs", 0, "int4", "int4")
+	r.AddFunction("abs", 0, "int8", "int8")
+	r.AddFunction("abs", 0, "float8", "float8")
+	r.AddFunction("abs", 0, "numeric", "numeric")
+
+	// round/ceil/floor
+	r.AddFunction("round", 0, "numeric", "numeric")
+	r.AddFunction("round", 0, "float8", "float8")
+	r.AddFunction("ceil", 0, "numeric", "numeric")
+	r.AddFunction("ceil", 0, "float8", "float8")
+	r.AddFunction("floor", 0, "numeric", "numeric")
+	r.AddFunction("floor", 0, "float8", "float8")
+
+	// now() -> timestamptz
+	r.AddFunction("now", 0, "void", "timestamptz")
+
+	// coalesce is handled structurally, not as a function
+
+	// count(*) -> int8 (aggregate)
+	r.AddFunction("count", 0, "any", "int8")
+
+	// sum
+	r.AddFunction("sum", 0, "int4", "int8")
+	r.AddFunction("sum", 0, "int8", "numeric")
+	r.AddFunction("sum", 0, "float4", "float4")
+	r.AddFunction("sum", 0, "float8", "float8")
+	r.AddFunction("sum", 0, "numeric", "numeric")
+
+	// avg
+	r.AddFunction("avg", 0, "int4", "numeric")
+	r.AddFunction("avg", 0, "int8", "numeric")
+	r.AddFunction("avg", 0, "float4", "float8")
+	r.AddFunction("avg", 0, "float8", "float8")
+	r.AddFunction("avg", 0, "numeric", "numeric")
+
+	// min/max — same type in, same type out
+	for _, fn := range []string{"min", "max"} {
+		for _, t := range allComparable {
+			r.AddFunction(fn, 0, t, t)
+		}
+	}
+
+	// string_agg(text, text) -> text
+	r.AddFunction("string_agg", 0, "text", "text")
+	r.AddFunction("string_agg", 1, "text", "text")
+
+	// array_agg is complex; skip for now
+
+	// to_char, to_date, to_timestamp, to_number
+	r.AddFunction("to_char", 0, "timestamptz", "text")
+	r.AddFunction("to_char", 0, "timestamp", "text")
+	r.AddFunction("to_char", 0, "interval", "text")
+	r.AddFunction("to_char", 0, "numeric", "text")
+	r.AddFunction("to_char", 0, "int4", "text")
+	r.AddFunction("to_char", 0, "int8", "text")
+	r.AddFunction("to_char", 0, "float8", "text")
+	r.AddFunction("to_char", 1, "text", "text")
+
+	r.AddFunction("to_date", 0, "text", "date")
+	r.AddFunction("to_date", 1, "text", "date")
+
+	r.AddFunction("to_timestamp", 0, "text", "timestamptz")
+	r.AddFunction("to_timestamp", 0, "float8", "timestamptz")
+	r.AddFunction("to_timestamp", 1, "text", "timestamptz")
+
+	r.AddFunction("to_number", 0, "text", "numeric")
+	r.AddFunction("to_number", 1, "text", "numeric")
+
+	// gen_random_uuid() -> uuid
+	r.AddFunction("gen_random_uuid", 0, "void", "uuid")
+
+	// jsonb_build_object, json_build_object — variadic, simplified
+	r.AddFunction("jsonb_build_object", 0, "any", "jsonb")
+	r.AddFunction("json_build_object", 0, "any", "json")
+
+	// date_trunc(text, timestamptz) -> timestamptz
+	r.AddFunction("date_trunc", 0, "text", "timestamptz")
+	r.AddFunction("date_trunc", 1, "timestamptz", "timestamptz")
+	r.AddFunction("date_trunc", 0, "text", "timestamp")
+	r.AddFunction("date_trunc", 1, "timestamp", "timestamp")
+}

--- a/internal/datalog/typeres/typeres_test.go
+++ b/internal/datalog/typeres/typeres_test.go
@@ -1,0 +1,193 @@
+package typeres
+
+import (
+	"testing"
+)
+
+func TestDirectTypePropagation(t *testing.T) {
+	r := New()
+	LoadPostgreSQLTypes(r)
+
+	r.SetExprType("e1", "int4")
+	r.SetExprType("e2", "text")
+
+	res, err := r.Resolve()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if typ, ok := res.TypeOf("e1"); !ok || typ != "int4" {
+		t.Errorf("expected e1=int4, got %q (ok=%v)", typ, ok)
+	}
+	if typ, ok := res.TypeOf("e2"); !ok || typ != "text" {
+		t.Errorf("expected e2=text, got %q (ok=%v)", typ, ok)
+	}
+}
+
+func TestImplicitCastTransitivity(t *testing.T) {
+	r := New()
+	LoadPostgreSQLTypes(r)
+
+	res, err := r.Resolve()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// int2 -> int4 -> int8 should be transitively castable
+	if !res.CanCast("int2", "int8") {
+		t.Error("expected int2 castable to int8")
+	}
+	if !res.CanCast("int4", "float8") {
+		t.Error("expected int4 castable to float8")
+	}
+	// text should not be castable to int4 implicitly
+	if res.CanCast("text", "int4") {
+		t.Error("unexpected: text castable to int4")
+	}
+}
+
+func TestBinaryExprResolution(t *testing.T) {
+	r := New()
+	LoadPostgreSQLTypes(r)
+
+	// e1:int4 + e2:int4 = e3:int4
+	r.SetExprType("e1", "int4")
+	r.SetExprType("e2", "int4")
+	r.AddBinaryExpr("e3", "+", "e1", "e2")
+
+	res, err := r.Resolve()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if typ, ok := res.TypeOf("e3"); !ok || typ != "int4" {
+		t.Errorf("expected e3=int4, got %q (ok=%v)", typ, ok)
+	}
+}
+
+func TestBinaryExprWithPromotion(t *testing.T) {
+	r := New()
+	LoadPostgreSQLTypes(r)
+
+	// e1:int4 + e2:int8 should promote to int8
+	r.SetExprType("e1", "int4")
+	r.SetExprType("e2", "int8")
+	r.AddBinaryExpr("e3", "+", "e1", "e2")
+
+	res, err := r.Resolve()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	typ, ok := res.TypeOf("e3")
+	if !ok {
+		t.Fatal("e3 type not resolved")
+	}
+	// Should resolve to int8 (int4 promoted to int8)
+	if typ != "int8" {
+		t.Errorf("expected e3=int8, got %q", typ)
+	}
+}
+
+func TestCastExpr(t *testing.T) {
+	r := New()
+	LoadPostgreSQLTypes(r)
+
+	r.SetExprType("e1", "int4")
+	r.AddCastExpr("e2", "e1", "text")
+
+	res, err := r.Resolve()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if typ, ok := res.TypeOf("e2"); !ok || typ != "text" {
+		t.Errorf("expected e2=text, got %q (ok=%v)", typ, ok)
+	}
+}
+
+func TestFunctionCall(t *testing.T) {
+	r := New()
+	LoadPostgreSQLTypes(r)
+
+	// length('hello') -> int4
+	r.SetExprType("e1", "text")
+	r.AddFuncCall("e2", "length", 0, "e1")
+
+	res, err := r.Resolve()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if typ, ok := res.TypeOf("e2"); !ok || typ != "int4" {
+		t.Errorf("expected e2=int4, got %q (ok=%v)", typ, ok)
+	}
+}
+
+func TestCommonType(t *testing.T) {
+	r := New()
+	LoadPostgreSQLTypes(r)
+
+	res, err := r.Resolve()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// int4 and int8 should have a common type
+	ct, ok := res.CommonType("int4", "int8")
+	if !ok {
+		t.Fatal("expected common type for int4, int8")
+	}
+	// int4 is castable to int8, so common type should be int8
+	if ct != "int8" {
+		t.Errorf("expected common type int8, got %q", ct)
+	}
+}
+
+func TestCoalesceExpr(t *testing.T) {
+	r := New()
+	LoadPostgreSQLTypes(r)
+
+	// COALESCE(e1:int4, e2:int4) -> should resolve to int4
+	r.SetExprType("e1", "int4")
+	r.SetExprType("e2", "int4")
+	r.AddCoalesceExpr("e3", 0, "e1")
+	r.AddCoalesceExpr("e3", 1, "e2")
+
+	res, err := r.Resolve()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	typ, ok := res.TypeOf("e3")
+	if !ok {
+		t.Fatal("e3 type not resolved")
+	}
+	if typ != "int4" {
+		t.Errorf("expected e3=int4, got %q", typ)
+	}
+}
+
+func TestAllTypes(t *testing.T) {
+	r := New()
+	LoadPostgreSQLTypes(r)
+
+	r.SetExprType("e1", "int4")
+	r.SetExprType("e2", "text")
+
+	res, err := r.Resolve()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	all := res.AllTypes()
+	if len(all) < 2 {
+		t.Errorf("expected at least 2 resolved types, got %d", len(all))
+	}
+	if all["e1"] != "int4" {
+		t.Errorf("expected e1=int4 in AllTypes, got %q", all["e1"])
+	}
+	if all["e2"] != "text" {
+		t.Errorf("expected e2=text in AllTypes, got %q", all["e2"])
+	}
+}


### PR DESCRIPTION
Introduce two new self-contained packages:

- internal/datalog: A purpose-built Datalog evaluator implementing
  semi-naïve bottom-up evaluation with stratified negation. Supports
  symbol interning, rule building, nested-loop joins, and fixpoint
  computation (~720 lines).

- internal/datalog/typeres: SQL type resolution expressed as Datalog
  rules over relations (base_type, implicit_cast, operator, function_sig,
  expr_type, etc.). Derives resolved_type, castable, and common_type.
  Includes LoadPostgreSQLTypes() with ~25 common PG types and their
  cast paths (~680 lines).

https://claude.ai/code/session_01Tp4qzqnkRGVxJnJa9ARtDi