### PR TITLE
support standalone optimizer hints

### DIFF
--- a/internal/source/code.go
+++ b/internal/source/code.go
@@ -115,6 +115,11 @@ func StripComments(sql string) (string, []string, error) {
 			continue
 		}
 		if strings.HasPrefix(t, "/*") && strings.HasSuffix(t, "*/") {
+			if strings.HasPrefix(t, "/*+") {
+				// Optimizer hints (/*+ ... */) must be preserved in the SQL string
+				lines = append(lines, t)
+				continue
+			}
 			t = strings.TrimPrefix(t, "/*")
 			t = strings.TrimSuffix(t, "*/")
 			comments = append(comments, t)


### PR DESCRIPTION
## Context

When a MySQL query contains an optimizer hint (`/*+ ... */`) placed on  its own line, sqlc strips it from the generated SQL constant. This is  because `StripComments` in `internal/source/code.go` treats any line  starting with `/*` and ending with `*/` as a block comment and removes  it.

The inline form is unaffected — `SELECT /*+ MAX_EXECUTION_TIME(1000) */ id FROM t1` works correctly since the line does not start with `/*`.

Fixes #4353

## Fix Proposal

Add a `/*+` prefix check in `StripComments` before stripping a block  comment line. Lines starting with `/*+` are optimizer hints and must be  preserved as part of the SQL string.

The `/*+` syntax is a cross-database convention (MySQL, PostgreSQL with  pg_hint_plan), so placing this check in the shared `StripComments`  function is appropriate rather than adding engine-specific handling.

  I also considered the following alternatives:

  - **Add `OptimizerHint bool` to `CommentSyntax`**: Follows the project pattern of passing engine-specific behavior as parameters, but optimizer hints are not truly engine-specific so a per-engine flag felt like over-engineering.

  - **Add a `keepPatterns` parameter to `StripComments`**: More general, but requires changing the function signature and all call sites.

Happy to switch to the `CommentSyntax` approach if the project prefers  keeping engine-specific knowledge out of `StripComments`.

## Verification

**query**

```sql
-- name: GetAuthor :one
SELECT
/*+ MAX_EXECUTION_TIME(1000) */
*
FROM authors
WHERE id = ? LIMIT 1;
```

 **Before :**
```go
const getAuthor = `-- name: GetAuthor :one
SELECT
id, name, bio FROM authors
WHERE id = ? LIMIT 1
`

// + MAX_EXECUTION_TIME(1000)
func (q *Queries) GetAuthor(ctx context.Context, id int64) (Author, error) {
	row := q.db.QueryRowContext(ctx, getAuthor, id)
	var i Author
	err := row.Scan(&i.ID, &i.Name, &i.Bio)
	return i, err
}
```
  — the hint is lost.

**After :**
```go
const getAuthor = `-- name: GetAuthor :one
SELECT
/*+ MAX_EXECUTION_TIME(1000) */
id, name, bio FROM authors
WHERE id = ? LIMIT 1
`

func (q *Queries) GetAuthor(ctx context.Context, id int64) (Author, error) {
	row := q.db.QueryRowContext(ctx, getAuthor, id)
	var i Author
	err := row.Scan(&i.ID, &i.Name, &i.Bio)
	return i, err
}

```

 Note: the inline form (SELECT /*+ ... */ id FROM t1) was already working and is unaffected by this change.
