### PR TITLE
docs: add sqlc-gen-sqlx to community language support

### DIFF
--- a/docs/reference/language-support.rst
+++ b/docs/reference/language-support.rst
@@ -26,6 +26,7 @@ PHP       `lcarilla/sqlc-plugin-php-dbal`_    Beta             N/A              
 Ruby      `DaredevilOSS/sqlc-gen-ruby`_       Beta             Beta             Beta           
 Zig       `tinyzimmer/sqlc-gen-zig`_          N/A              Beta             Beta            
 Python    `rayakame/sqlc-gen-better-python`_  N/A              Beta             Beta          
+Rust      `mathematic-inc/sqlc-gen-sqlx`_     N/A              Beta             N/A
 [Any]     `fdietze/sqlc-gen-from-template`_   Stable           Stable           Stable
 ========  ==================================  ===============  ===============  ===============
 
@@ -53,4 +54,5 @@ Gleam     `daniellionel01/parrot`_           Stable           Stable           S
 .. _tinyzimmer/sqlc-gen-zig: https://github.com/tinyzimmer/sqlc-gen-zig
 .. _daniellionel01/parrot: https://github.com/daniellionel01/parrot
 .. _rayakame/sqlc-gen-better-python: https://github.com/rayakame/sqlc-gen-better-python
+.. _mathematic-inc/sqlc-gen-sqlx: https://github.com/mathematic-inc/sqlc-gen-sqlx
 .. _github topic: https://github.com/topics/sqlc-plugin


### PR DESCRIPTION
## Summary
- add `mathematic-inc/sqlc-gen-sqlx` to the community language support table
- mark the plugin as PostgreSQL beta support with MySQL/SQLite marked N/A

## Why
`sqlc-gen-sqlx` is a community Rust plugin that generates type-safe `sqlx` Rust code from SQL queries.

## Validation
- `make -C docs help >/dev/null && make -C docs html` (build succeeded; existing Sphinx warnings remain)
