### PR TITLE
Upgrade Go toolchain to 1.26.2

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,7 +12,7 @@ jobs:
     - uses: actions/checkout@v6
     - uses: actions/setup-go@v6
       with:
-        go-version: '1.26.0'
+        go-version: '1.26.2'
     - name: install ./...
       run: go build ./...
       env:

--- a/.github/workflows/ci-kotlin.yml
+++ b/.github/workflows/ci-kotlin.yml
@@ -13,7 +13,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: actions/setup-go@v6
         with:
-          go-version: '1.26.0'
+          go-version: '1.26.2'
       - name: install ./...
         run: go install ./...
       - uses: actions/checkout@v6

--- a/.github/workflows/ci-python.yml
+++ b/.github/workflows/ci-python.yml
@@ -13,7 +13,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: actions/setup-go@v6
         with:
-          go-version: '1.26.0'
+          go-version: '1.26.2'
       - name: install ./...
         run: go install ./...
       - uses: actions/checkout@v6

--- a/.github/workflows/ci-typescript.yml
+++ b/.github/workflows/ci-typescript.yml
@@ -13,7 +13,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: actions/setup-go@v6
         with:
-          go-version: '1.26.0'
+          go-version: '1.26.2'
       - name: install ./...
         run: go install ./...
       - uses: actions/checkout@v6

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
     - uses: actions/checkout@v6
     - uses: actions/setup-go@v6
       with:
-        go-version: '1.26.0'
+        go-version: '1.26.2'
     - run: go build ./...
       env:
         CGO_ENABLED: "0"
@@ -28,7 +28,7 @@ jobs:
     - uses: actions/checkout@v6
     - uses: actions/setup-go@v6
       with:
-        go-version: '1.26.0'
+        go-version: '1.26.2'
 
     - name: install gotestsum
       run: go install gotest.tools/gotestsum@latest

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,7 +6,7 @@ This document provides essential information for working with the sqlc codebase,
 
 ### Prerequisites
 
-- **Go 1.26.0+** - Required for building and testing
+- **Go 1.26.2+** - Required for building and testing
 - **Docker & Docker Compose** - Required for integration tests with databases (local development)
 - **Git** - For version control
 
@@ -147,7 +147,7 @@ make start             # Start database containers
 ### GitHub Actions Workflow
 
 - **File:** `.github/workflows/ci.yml`
-- **Go Version:** 1.26.0
+- **Go Version:** 1.26.2
 - **Database Setup:** Uses `sqlc-test-setup` (not Docker) to install and start PostgreSQL and MySQL directly on the runner
 - **Test Command:** `gotestsum --junitfile junit.xml -- --tags=examples -timeout 20m ./...`
 - **Additional Checks:** `govulncheck` for vulnerability scanning

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # STEP 1: Build sqlc
-FROM golang:1.26.1 AS builder
+FROM golang:1.26.2 AS builder
 
 COPY . /workspace
 WORKDIR /workspace

--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,8 @@ module github.com/sqlc-dev/sqlc
 
 go 1.26.0
 
+toolchain go1.26.2
+
 require (
 	github.com/antlr4-go/antlr/v4 v4.13.1
 	github.com/cubicdaiya/gonp v1.0.4


### PR DESCRIPTION
## Summary
- Bumps the Go toolchain used in CI workflows, Docker image, and developer docs to 1.26.2
- Adds a `toolchain go1.26.2` directive to `go.mod` while keeping the `go 1.26.0` minimum-version directive unchanged

## Test plan
- [ ] CI passes on the updated Go version
- [ ] Docker build succeeds with `golang:1.26.2`

🤖 Generated with [Claude Code](https://claude.com/claude-code)