### PR TITLE
Skip CI/RTD builds when changes are irrelevant to each pipeline

### DIFF
--- a/.github/workflows/buf.yml
+++ b/.github/workflows/buf.yml
@@ -1,5 +1,9 @@
 name: buf
-on: pull_request
+on:
+  pull_request:
+    paths-ignore:
+      - 'docs/**'
+      - '.readthedocs.yaml'
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci-kotlin.yml
+++ b/.github/workflows/ci-kotlin.yml
@@ -3,7 +3,13 @@ on:
   push:
     branches:
       - main
+    paths-ignore:
+      - 'docs/**'
+      - '.readthedocs.yaml'
   pull_request:
+    paths-ignore:
+      - 'docs/**'
+      - '.readthedocs.yaml'
 jobs:
   build:
     if: false

--- a/.github/workflows/ci-python.yml
+++ b/.github/workflows/ci-python.yml
@@ -3,7 +3,13 @@ on:
   push:
     branches:
       - main
+    paths-ignore:
+      - 'docs/**'
+      - '.readthedocs.yaml'
   pull_request:
+    paths-ignore:
+      - 'docs/**'
+      - '.readthedocs.yaml'
 jobs:
   build:
     if: false

--- a/.github/workflows/ci-typescript.yml
+++ b/.github/workflows/ci-typescript.yml
@@ -3,7 +3,13 @@ on:
   push:
     branches:
       - main
+    paths-ignore:
+      - 'docs/**'
+      - '.readthedocs.yaml'
   pull_request:
+    paths-ignore:
+      - 'docs/**'
+      - '.readthedocs.yaml'
 jobs:
   build:
     if: false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,7 +3,13 @@ on:
   push:
     branches:
       - main
+    paths-ignore:
+      - 'docs/**'
+      - '.readthedocs.yaml'
   pull_request:
+    paths-ignore:
+      - 'docs/**'
+      - '.readthedocs.yaml'
 jobs:
   build:
     strategy:

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -10,6 +10,14 @@ build:
   os: ubuntu-22.04
   tools:
     python: "3.11"
+  jobs:
+    post_checkout:
+      # Cancel PR builds that don't touch the docs.
+      # https://docs.readthedocs.io/en/stable/build-customization.html#cancel-build-based-on-a-condition
+      - |
+        if [ "$READTHEDOCS_VERSION_TYPE" = "external" ] && git diff --quiet origin/main -- docs/ .readthedocs.yaml; then
+          exit 183
+        fi
 
 # Build documentation in the docs/ directory with Sphinx
 sphinx:


### PR DESCRIPTION
## Summary
- Add `paths-ignore: ['docs/**', '.readthedocs.yaml']` to the `go`, `buf`, `kotlin`, `python`, and `typescript` workflows — doc-only PRs no longer spin up the Go test matrix.
- Add a Read the Docs `post_checkout` job that exits `183` (RTD's [documented](https://docs.readthedocs.io/en/stable/build-customization.html#cancel-build-based-on-a-condition) "cancel build successfully" code) when a PR build doesn't touch `docs/` or `.readthedocs.yaml`. Mirrors the GitHub-side filter so Go-only PRs don't burn an RTD build.

## How the RTD gate works
RTD doesn't expose path filters in config, but their build system honors exit code 183 from any `jobs.*` hook as "cancel this build, mark it successful." The `post_checkout` step diffs `HEAD` against `origin/main` for `docs/` + `.readthedocs.yaml`; if nothing changed there on a PR build (`READTHEDOCS_VERSION_TYPE=external`), the build exits early.

## Caveat — required status checks
If any of the `go / test`, `buf / build`, etc. checks are configured as **required** in branch protection, a doc-only PR will block waiting for them to report. Two follow-up options:
- Make those checks non-required, or
- Add a companion workflow with the same job name that runs under the inverse `paths:` filter and no-ops, so the check always reports.

## Test plan
- [ ] Open a doc-only PR; confirm Go/buf/language workflows are skipped and RTD still builds
- [ ] Open a Go-only PR; confirm RTD build is cancelled with exit 183 and Go workflows run normally
- [ ] Mixed PR (touches both) runs everything

🤖 Generated with [Claude Code](https://claude.com/claude-code)