### PR TITLE
Fix parameter name collision in :one query return values

### DIFF
--- a/internal/codegen/golang/result.go
+++ b/internal/codegen/golang/result.go
@@ -268,8 +268,26 @@ func buildQueries(req *plugin.GenerateRequest, options *opts.Options, structs []
 			c := query.Columns[0]
 			name := columnName(c, 0)
 			name = strings.Replace(name, "$", "_", -1)
+			retName := escape(name)
+			// For :one queries the scan destination lives in the same scope as
+			// the query parameters, so reusing a parameter's name would cause
+			// Scan to overwrite the input and leak it back to the caller on
+			// sql.ErrNoRows (see sqlc-dev/sqlc#4354). Rename the return
+			// variable when it would collide.
+			if query.Cmd == metadata.CmdOne {
+				argNames := map[string]struct{}{}
+				for _, p := range gq.Arg.Pairs() {
+					argNames[p.Name] = struct{}{}
+				}
+				for {
+					if _, conflict := argNames[retName]; !conflict {
+						break
+					}
+					retName += "_2"
+				}
+			}
 			gq.Ret = QueryValue{
-				Name:      escape(name),
+				Name:      retName,
 				DBName:    name,
 				Typ:       goType(req, options, c),
 				SQLDriver: sqlpkg,

--- a/internal/endtoend/testdata/single_param_conflict/mysql/go/query.sql.go
+++ b/internal/endtoend/testdata/single_param_conflict/mysql/go/query.sql.go
@@ -32,8 +32,9 @@ LIMIT   1
 
 func (q *Queries) GetAuthorIDByID(ctx context.Context, id int64) (int64, error) {
 	row := q.db.QueryRowContext(ctx, getAuthorIDByID, id)
-	err := row.Scan(&id)
-	return id, err
+	var id_2 int64
+	err := row.Scan(&id_2)
+	return id_2, err
 }
 
 const getUser = `-- name: GetUser :one
@@ -45,6 +46,7 @@ LIMIT   1
 
 func (q *Queries) GetUser(ctx context.Context, sub string) (string, error) {
 	row := q.db.QueryRowContext(ctx, getUser, sub)
-	err := row.Scan(&sub)
-	return sub, err
+	var sub_2 string
+	err := row.Scan(&sub_2)
+	return sub_2, err
 }

--- a/internal/endtoend/testdata/single_param_conflict/postgresql/pgx/v4/go/query.sql.go
+++ b/internal/endtoend/testdata/single_param_conflict/postgresql/pgx/v4/go/query.sql.go
@@ -34,8 +34,9 @@ LIMIT   1
 
 func (q *Queries) GetAuthorIDByID(ctx context.Context, id int64) (int64, error) {
 	row := q.db.QueryRow(ctx, getAuthorIDByID, id)
-	err := row.Scan(&id)
-	return id, err
+	var id_2 int64
+	err := row.Scan(&id_2)
+	return id_2, err
 }
 
 const getUser = `-- name: GetUser :one
@@ -47,8 +48,9 @@ LIMIT   1
 
 func (q *Queries) GetUser(ctx context.Context, sub uuid.UUID) (uuid.UUID, error) {
 	row := q.db.QueryRow(ctx, getUser, sub)
-	err := row.Scan(&sub)
-	return sub, err
+	var sub_2 uuid.UUID
+	err := row.Scan(&sub_2)
+	return sub_2, err
 }
 
 const setDefaultName = `-- name: SetDefaultName :one
@@ -62,6 +64,7 @@ RETURNING id
 // https://github.com/sqlc-dev/sqlc/issues/1235
 func (q *Queries) SetDefaultName(ctx context.Context, id int64) (int64, error) {
 	row := q.db.QueryRow(ctx, setDefaultName, id)
-	err := row.Scan(&id)
-	return id, err
+	var id_2 int64
+	err := row.Scan(&id_2)
+	return id_2, err
 }

--- a/internal/endtoend/testdata/single_param_conflict/postgresql/pgx/v5/go/query.sql.go
+++ b/internal/endtoend/testdata/single_param_conflict/postgresql/pgx/v5/go/query.sql.go
@@ -34,8 +34,9 @@ LIMIT   1
 
 func (q *Queries) GetAuthorIDByID(ctx context.Context, id int64) (int64, error) {
 	row := q.db.QueryRow(ctx, getAuthorIDByID, id)
-	err := row.Scan(&id)
-	return id, err
+	var id_2 int64
+	err := row.Scan(&id_2)
+	return id_2, err
 }
 
 const getUser = `-- name: GetUser :one
@@ -47,8 +48,9 @@ LIMIT   1
 
 func (q *Queries) GetUser(ctx context.Context, sub pgtype.UUID) (pgtype.UUID, error) {
 	row := q.db.QueryRow(ctx, getUser, sub)
-	err := row.Scan(&sub)
-	return sub, err
+	var sub_2 pgtype.UUID
+	err := row.Scan(&sub_2)
+	return sub_2, err
 }
 
 const setDefaultName = `-- name: SetDefaultName :one
@@ -62,6 +64,7 @@ RETURNING id
 // https://github.com/sqlc-dev/sqlc/issues/1235
 func (q *Queries) SetDefaultName(ctx context.Context, id int64) (int64, error) {
 	row := q.db.QueryRow(ctx, setDefaultName, id)
-	err := row.Scan(&id)
-	return id, err
+	var id_2 int64
+	err := row.Scan(&id_2)
+	return id_2, err
 }

--- a/internal/endtoend/testdata/single_param_conflict/postgresql/stdlib/go/query.sql.go
+++ b/internal/endtoend/testdata/single_param_conflict/postgresql/stdlib/go/query.sql.go
@@ -34,8 +34,9 @@ LIMIT   1
 
 func (q *Queries) GetAuthorIDByID(ctx context.Context, id int64) (int64, error) {
 	row := q.db.QueryRowContext(ctx, getAuthorIDByID, id)
-	err := row.Scan(&id)
-	return id, err
+	var id_2 int64
+	err := row.Scan(&id_2)
+	return id_2, err
 }
 
 const getUser = `-- name: GetUser :one
@@ -47,8 +48,9 @@ LIMIT   1
 
 func (q *Queries) GetUser(ctx context.Context, sub uuid.UUID) (uuid.UUID, error) {
 	row := q.db.QueryRowContext(ctx, getUser, sub)
-	err := row.Scan(&sub)
-	return sub, err
+	var sub_2 uuid.UUID
+	err := row.Scan(&sub_2)
+	return sub_2, err
 }
 
 const setDefaultName = `-- name: SetDefaultName :one
@@ -62,6 +64,7 @@ RETURNING id
 // https://github.com/sqlc-dev/sqlc/issues/1235
 func (q *Queries) SetDefaultName(ctx context.Context, id int64) (int64, error) {
 	row := q.db.QueryRowContext(ctx, setDefaultName, id)
-	err := row.Scan(&id)
-	return id, err
+	var id_2 int64
+	err := row.Scan(&id_2)
+	return id_2, err
 }

--- a/internal/endtoend/testdata/single_param_conflict/sqlite/go/query.sql.go
+++ b/internal/endtoend/testdata/single_param_conflict/sqlite/go/query.sql.go
@@ -32,8 +32,9 @@ LIMIT   1
 
 func (q *Queries) GetAuthorIDByID(ctx context.Context, id int64) (int64, error) {
 	row := q.db.QueryRowContext(ctx, getAuthorIDByID, id)
-	err := row.Scan(&id)
-	return id, err
+	var id_2 int64
+	err := row.Scan(&id_2)
+	return id_2, err
 }
 
 const getUser = `-- name: GetUser :one
@@ -45,6 +46,7 @@ LIMIT   1
 
 func (q *Queries) GetUser(ctx context.Context, sub string) (string, error) {
 	row := q.db.QueryRowContext(ctx, getUser, sub)
-	err := row.Scan(&sub)
-	return sub, err
+	var sub_2 string
+	err := row.Scan(&sub_2)
+	return sub_2, err
 }

--- a/internal/endtoend/testdata/vet_explain/mysql/db/query.sql.go
+++ b/internal/endtoend/testdata/vet_explain/mysql/db/query.sql.go
@@ -438,6 +438,7 @@ WHERE id = ? LIMIT 1
 
 func (q *Queries) SelectById(ctx context.Context, id int64) (int64, error) {
 	row := q.db.QueryRowContext(ctx, selectById, id)
-	err := row.Scan(&id)
-	return id, err
+	var id_2 int64
+	err := row.Scan(&id_2)
+	return id_2, err
 }


### PR DESCRIPTION
## Summary
This PR fixes a bug where `:one` queries would overwrite input parameters when the return value name collides with a parameter name, causing data corruption on `sql.ErrNoRows` errors.

## Problem
When a `:one` query has a single return column with the same name as an input parameter, the generated code would reuse the parameter variable as the scan destination. This causes the `Scan()` call to overwrite the input parameter, and if `sql.ErrNoRows` is returned, the corrupted value leaks back to the caller.

Example of the bug:
```go
func (q *Queries) GetAuthorIDByID(ctx context.Context, id int64) (int64, error) {
    row := q.db.QueryRow(ctx, getAuthorIDByID, id)
    err := row.Scan(&id)  // Overwrites input parameter!
    return id, err
}
```

## Solution
For `:one` queries, the code generator now detects when the return variable name would collide with any parameter name and automatically renames the return variable by appending `_2` (and further suffixes if needed).

## Key Changes
- Modified `buildQueries()` in `internal/codegen/golang/result.go` to detect parameter name collisions for `:one` queries
- When a collision is detected, the return variable is renamed (e.g., `id` → `id_2`)
- Updated all affected test fixtures to reflect the corrected generated code

## Implementation Details
- The collision detection only applies to `:one` queries (where the scan destination shares scope with parameters)
- A map of parameter names is built and checked against the return variable name
- If a collision exists, the return variable name is suffixed with `_2`, `_3`, etc. until no collision remains
- This ensures the scan destination is a separate variable that won't corrupt the input parameters

Fixes sqlc-dev/sqlc#4354

https://claude.ai/code/session_01Ly2rRRcRPXhT2bm6odjeqx