### PR TITLE
Fix parameter handling in CAST expressions for duplicate params

### DIFF
--- a/internal/compiler/resolve.go
+++ b/internal/compiler/resolve.go
@@ -513,10 +513,11 @@ func (comp *Compiler) resolveCatalogRefs(qc *QueryCatalog, rvs []*ast.RangeVar, 
 			}
 			col := toColumn(n.TypeName)
 			defaultP := named.NewInferredParam(col.Name, col.NotNull)
-			p, _ := params.FetchMerge(ref.ref.Number, defaultP)
+			p, isNamed := params.FetchMerge(ref.ref.Number, defaultP)
 
 			col.Name = p.Name()
 			col.NotNull = p.NotNull()
+			col.IsNamedParam = isNamed
 			a = append(a, Parameter{
 				Number: ref.ref.Number,
 				Column: col,

--- a/internal/endtoend/testdata/params_duplicate/mysql/go/models.go
+++ b/internal/endtoend/testdata/params_duplicate/mysql/go/models.go
@@ -12,4 +12,5 @@ type User struct {
 	ID        int32
 	FirstName sql.NullString
 	LastName  sql.NullString
+	Age       sql.NullInt32
 }

--- a/internal/endtoend/testdata/params_duplicate/mysql/go/query.sql.go
+++ b/internal/endtoend/testdata/params_duplicate/mysql/go/query.sql.go
@@ -10,6 +10,39 @@ import (
 	"database/sql"
 )
 
+const selectUserByAgeCast = `-- name: SelectUserByAgeCast :many
+SELECT first_name FROM users
+WHERE age > CAST(? AS SIGNED)
+   OR age < CAST(? AS SIGNED)
+`
+
+type SelectUserByAgeCastParams struct {
+	Threshold int64
+}
+
+func (q *Queries) SelectUserByAgeCast(ctx context.Context, arg SelectUserByAgeCastParams) ([]sql.NullString, error) {
+	rows, err := q.db.QueryContext(ctx, selectUserByAgeCast, arg.Threshold, arg.Threshold)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []sql.NullString
+	for rows.Next() {
+		var first_name sql.NullString
+		if err := rows.Scan(&first_name); err != nil {
+			return nil, err
+		}
+		items = append(items, first_name)
+	}
+	if err := rows.Close(); err != nil {
+		return nil, err
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
 const selectUserByID = `-- name: SelectUserByID :many
 SELECT first_name from
 users where (? = id OR ? = 0)

--- a/internal/endtoend/testdata/params_duplicate/mysql/query.sql
+++ b/internal/endtoend/testdata/params_duplicate/mysql/query.sql
@@ -11,3 +11,8 @@ WHERE first_name = sqlc.arg(name)
 /* name: SelectUserQuestion :many */
 SELECT first_name from
 users where (? = id OR  ? = 0);
+
+/* name: SelectUserByAgeCast :many */
+SELECT first_name FROM users
+WHERE age > CAST(sqlc.arg(threshold) AS SIGNED)
+   OR age < CAST(sqlc.arg(threshold) AS SIGNED);

--- a/internal/endtoend/testdata/params_duplicate/mysql/schema.sql
+++ b/internal/endtoend/testdata/params_duplicate/mysql/schema.sql
@@ -1,5 +1,6 @@
 CREATE TABLE users (
     id integer NOT NULL AUTO_INCREMENT PRIMARY KEY,
     first_name varchar(255),
-    last_name varchar(255)
+    last_name varchar(255),
+    age int
 ) ENGINE=InnoDB;


### PR DESCRIPTION
## Summary
This PR fixes parameter handling in SQL queries that use CAST expressions with duplicate parameters. Previously, parameters used multiple times within CAST functions were not properly tracked as named parameters, causing incorrect code generation.

Fixes https://github.com/sqlc-dev/sqlc/issues/4376

## Key Changes
- **Schema Update**: Added `age` column to the test users table to support the new test case
- **Model Update**: Added `Age` field to the User struct to reflect the schema change
- **Query Addition**: Added `SelectUserByAgeCast` test query that uses the same parameter twice within CAST expressions
- **Compiler Fix**: Modified `resolveCatalogRefs` in `internal/compiler/resolve.go` to properly track whether a parameter is named when resolving CAST type references
  - Now captures the `isNamed` return value from `params.FetchMerge()`
  - Sets `col.IsNamedParam = isNamed` to correctly mark parameters used in CAST expressions

## Implementation Details
The fix ensures that when a parameter appears multiple times in a query (particularly within CAST expressions), the compiler correctly identifies it as a named parameter and generates the appropriate Go code. This prevents duplicate parameter passing and ensures proper parameter binding in the generated SQL execution code.

https://claude.ai/code/session_011tJhgjfWrTPw9yY4EpeJXG