### PR TITLE
Coerce SQLite JSONB output regardless of type casing

### DIFF
--- a/internal/compiler/selector.go
+++ b/internal/compiler/selector.go
@@ -1,5 +1,7 @@
 package compiler
 
+import "strings"
+
 // selector is an interface used by a compiler for generating expressions for
 // output columns in a `SELECT ...` or `RETURNING ...` statement.
 //
@@ -39,7 +41,7 @@ func (s *sqliteSelector) ColumnExpr(name string, column *Column) string {
 	// outside of the database itself. For jsonb columns in SQLite, wrap values
 	// in `json(col)` to coerce the internal binary format to JSON parsable by
 	// the user-space application.
-	if column.DataType == "jsonb" {
+	if strings.EqualFold(column.DataType, "jsonb") {
 		return "json(" + name + ")"
 	}
 	return name

--- a/internal/compiler/selector_test.go
+++ b/internal/compiler/selector_test.go
@@ -30,6 +30,8 @@ func TestSelector(t *testing.T) {
 		selectorExpectColumnExpr(t, selector, "my_column", "my_column", &Column{DataType: "integer"})
 		selectorExpectColumnExpr(t, selector, "my_column", "my_column", &Column{DataType: "json"})
 		selectorExpectColumnExpr(t, selector, "json(my_column)", "my_column", &Column{DataType: "jsonb"})
+		selectorExpectColumnExpr(t, selector, "json(my_column)", "my_column", &Column{DataType: "JSONB"})
+		selectorExpectColumnExpr(t, selector, "json(my_column)", "my_column", &Column{DataType: "JsonB"})
 		selectorExpectColumnExpr(t, selector, "my_column", "my_column", &Column{DataType: "text"})
 	})
 }

--- a/internal/compiler/selector_test.go
+++ b/internal/compiler/selector_test.go
@@ -30,8 +30,6 @@ func TestSelector(t *testing.T) {
 		selectorExpectColumnExpr(t, selector, "my_column", "my_column", &Column{DataType: "integer"})
 		selectorExpectColumnExpr(t, selector, "my_column", "my_column", &Column{DataType: "json"})
 		selectorExpectColumnExpr(t, selector, "json(my_column)", "my_column", &Column{DataType: "jsonb"})
-		selectorExpectColumnExpr(t, selector, "json(my_column)", "my_column", &Column{DataType: "JSONB"})
-		selectorExpectColumnExpr(t, selector, "json(my_column)", "my_column", &Column{DataType: "JsonB"})
 		selectorExpectColumnExpr(t, selector, "my_column", "my_column", &Column{DataType: "text"})
 	})
 }

--- a/internal/endtoend/testdata/jsonb/sqlite/go/models.go
+++ b/internal/endtoend/testdata/jsonb/sqlite/go/models.go
@@ -13,4 +13,8 @@ type Foo struct {
 	B json.RawMessage
 	C json.RawMessage
 	D json.RawMessage
+	E json.RawMessage
+	F json.RawMessage
+	G json.RawMessage
+	H json.RawMessage
 }

--- a/internal/endtoend/testdata/jsonb/sqlite/go/query.sql.go
+++ b/internal/endtoend/testdata/jsonb/sqlite/go/query.sql.go
@@ -15,13 +15,21 @@ INSERT INTO foo (
     a,
     b,
     c,
-    d
+    d,
+    e,
+    f,
+    g,
+    h
 ) VALUES (
     ?1,
     ?2,
     ?3,
-    ?4
-) RETURNING a, json(b), c, json(d)
+    ?4,
+    ?5,
+    ?6,
+    ?7,
+    ?8
+) RETURNING a, json(b), c, json(d), e, json(f), g, json(h)
 `
 
 type InsertFooParams struct {
@@ -29,6 +37,10 @@ type InsertFooParams struct {
 	B json.RawMessage
 	C json.RawMessage
 	D json.RawMessage
+	E json.RawMessage
+	F json.RawMessage
+	G json.RawMessage
+	H json.RawMessage
 }
 
 func (q *Queries) InsertFoo(ctx context.Context, arg InsertFooParams) error {
@@ -37,12 +49,16 @@ func (q *Queries) InsertFoo(ctx context.Context, arg InsertFooParams) error {
 		arg.B,
 		arg.C,
 		arg.D,
+		arg.E,
+		arg.F,
+		arg.G,
+		arg.H,
 	)
 	return err
 }
 
 const selectFoo = `-- name: SelectFoo :exec
-SELECT a, json(b), c, json(d) FROM foo
+SELECT a, json(b), c, json(d), e, json(f), g, json(h) FROM foo
 `
 
 func (q *Queries) SelectFoo(ctx context.Context) error {

--- a/internal/endtoend/testdata/jsonb/sqlite/query.sql
+++ b/internal/endtoend/testdata/jsonb/sqlite/query.sql
@@ -3,12 +3,20 @@ INSERT INTO foo (
     a,
     b,
     c,
-    d
+    d,
+    e,
+    f,
+    g,
+    h
 ) VALUES (
     @a,
     @b,
     @c,
-    @d
+    @d,
+    @e,
+    @f,
+    @g,
+    @h
 ) RETURNING *;
 
 -- name: SelectFoo :exec

--- a/internal/endtoend/testdata/jsonb/sqlite/schema.sql
+++ b/internal/endtoend/testdata/jsonb/sqlite/schema.sql
@@ -2,6 +2,10 @@ CREATE TABLE foo (
     a json not null,
     b jsonb not null,
     c json,
-    d jsonb
+    d jsonb,
+    e JSON not null,
+    f JSONB not null,
+    g JSON,
+    h JSONB
 );
 


### PR DESCRIPTION
The sqliteSelector was doing a case-sensitive comparison against
"jsonb", so columns declared with capitalized variants like JSONB or
JsonB were not wrapped in json(col) on SELECT/RETURNING. Use
strings.EqualFold to match the type name case-insensitively.

fixes #4337