### PR TITLE
Strip psql meta-commands from schema files (fixes #4065)

### DIFF
--- a/internal/compiler/compile.go
+++ b/internal/compiler/compile.go
@@ -39,6 +39,7 @@ func (c *Compiler) parseCatalog(schemas []string) error {
 			continue
 		}
 		contents := migrations.RemoveRollbackStatements(string(blob))
+		contents = migrations.RemovePsqlMetaCommands(contents)
 		c.schema = append(c.schema, contents)
 
 		// In database-only mode, we parse the schema to validate syntax

--- a/internal/endtoend/testdata/pg_dump/schema.sql
+++ b/internal/endtoend/testdata/pg_dump/schema.sql
@@ -5,6 +5,8 @@
 -- Dumped from database version 15.3 (Debian 15.3-1.pgdg120+1)
 -- Dumped by pg_dump version 15.3
 
+\restrict auwherpfqaiuwrhgp
+
 SET statement_timeout = 0;
 SET lock_timeout = 0;
 SET idle_in_transaction_session_timeout = 0;
@@ -82,6 +84,8 @@ ALTER TABLE ONLY public.authors ALTER COLUMN id SET DEFAULT nextval('public.auth
 ALTER TABLE ONLY public.authors
     ADD CONSTRAINT authors_pkey PRIMARY KEY (id);
 
+
+\unrestrict auwherpfqaiuwrhgp
 
 --
 -- PostgreSQL database dump complete

--- a/internal/migrations/migrations.go
+++ b/internal/migrations/migrations.go
@@ -2,8 +2,15 @@ package migrations
 
 import (
 	"bufio"
+	"regexp"
 	"strings"
 )
+
+// psqlMetaCommand matches a psql meta-command (a line that begins with a
+// backslash followed by a command name). pg_dump emits these starting with
+// PostgreSQL 17.6 / 16.10 / 15.14 / 14.19 / 13.22 (e.g. `\restrict KEY` and
+// `\unrestrict KEY`), and sqlc's SQL parsers cannot handle them.
+var psqlMetaCommand = regexp.MustCompile(`^\\[A-Za-z!?;][^\n]*$`)
 
 // Remove all lines after a rollback comment.
 //
@@ -29,6 +36,22 @@ func RemoveRollbackStatements(contents string) string {
 			break
 		}
 		lines = append(lines, s.Text())
+	}
+	return strings.Join(lines, "\n")
+}
+
+// RemovePsqlMetaCommands strips psql meta-command lines (e.g. `\restrict KEY`,
+// `\unrestrict KEY`, `\connect foo`) from SQL input. These are emitted by
+// pg_dump but are not valid SQL, so they must be removed before parsing.
+func RemovePsqlMetaCommands(contents string) string {
+	s := bufio.NewScanner(strings.NewReader(contents))
+	var lines []string
+	for s.Scan() {
+		line := s.Text()
+		if psqlMetaCommand.MatchString(line) {
+			continue
+		}
+		lines = append(lines, line)
 	}
 	return strings.Join(lines, "\n")
 }

--- a/internal/migrations/migrations_test.go
+++ b/internal/migrations/migrations_test.go
@@ -56,6 +56,17 @@ const outputDbmate = `
 -- migrate:up
 CREATE TABLE foo (bar int);`
 
+const inputPsqlMeta = `\restrict auwherpfqaiuwrhgp
+
+CREATE TABLE foo (id int);
+
+\unrestrict auwherpfqaiuwrhgp
+`
+
+const outputPsqlMeta = `
+CREATE TABLE foo (id int);
+`
+
 func TestRemoveRollback(t *testing.T) {
 	if diff := cmp.Diff(outputGoose, RemoveRollbackStatements(inputGoose)); diff != "" {
 		t.Errorf("goose migration mismatch:\n%s", diff)
@@ -68,6 +79,12 @@ func TestRemoveRollback(t *testing.T) {
 	}
 	if diff := cmp.Diff(outputDbmate, RemoveRollbackStatements(inputDbmate)); diff != "" {
 		t.Errorf("dbmate migration mismatch:\n%s", diff)
+	}
+}
+
+func TestRemovePsqlMetaCommands(t *testing.T) {
+	if diff := cmp.Diff(outputPsqlMeta, RemovePsqlMetaCommands(inputPsqlMeta)); diff != "" {
+		t.Errorf("psql meta-command mismatch:\n%s", diff)
 	}
 }
 


### PR DESCRIPTION
pg_dump 17.6+ (backported to 13.22, 14.19, 15.14, 16.10) emits
\restrict/\unrestrict meta-commands that are valid psql syntax but not
valid SQL, causing sqlc to fail when parsing schema.sql from pg_dump.

Add a regex-based preprocessor in the migrations package that strips
any line starting with a psql meta-command (\<command>), and call it
from parseCatalog after RemoveRollbackStatements. Extend the pg_dump
end-to-end schema fixture with \restrict/\unrestrict lines so TestReplay
exercises this path.