### PR TITLE
docs(tutorial): fix SQLite tutorial CreateAuthor return value (#3336)

### DIFF
--- a/docs/tutorials/getting-started-sqlite.md
+++ b/docs/tutorials/getting-started-sqlite.md
@@ -159,23 +159,28 @@ func run() error {
 	log.Println(authors)
 
 	// create an author
-	insertedAuthor, err := queries.CreateAuthor(ctx, tutorial.CreateAuthorParams{
+	result, err := queries.CreateAuthor(ctx, tutorial.CreateAuthorParams{
 		Name: "Brian Kernighan",
 		Bio:  sql.NullString{String: "Co-author of The C Programming Language and The Go Programming Language", Valid: true},
 	})
 	if err != nil {
 		return err
 	}
-	log.Println(insertedAuthor)
+
+	insertedAuthorID, err := result.LastInsertId()
+	if err != nil {
+		return err
+	}
+	log.Println(insertedAuthorID)
 
 	// get the author we just inserted
-	fetchedAuthor, err := queries.GetAuthor(ctx, insertedAuthor.ID)
+	fetchedAuthor, err := queries.GetAuthor(ctx, insertedAuthorID)
 	if err != nil {
 		return err
 	}
 
 	// prints true
-	log.Println(reflect.DeepEqual(insertedAuthor, fetchedAuthor))
+	log.Println(reflect.DeepEqual(insertedAuthorID, fetchedAuthor.ID))
 	return nil
 }
 


### PR DESCRIPTION
Fixes #3336. The SQLite getting-started tutorial showed:

```go
insertedAuthor, err := queries.CreateAuthor(ctx, ...)
queries.GetAuthor(ctx, insertedAuthor.ID)
```

`CreateAuthor` for SQLite returns `sql.Result`, which has no `.ID` field — readers following the tutorial got a compile error. The MySQL tutorial already shows the correct pattern (`result.LastInsertId()`); this PR mirrors that into the SQLite version exactly.

## Test plan

- [x] Snippet now compiles against the same `sql.Result`-returning shape used in the MySQL tutorial (`docs/tutorials/getting-started-mysql.md:135`)
- [x] Docs-only change, no code/build impact