### PR TITLE
fix(golang): reject go_type specs with slash before type name

### DIFF
--- a/internal/codegen/golang/opts/go_type.go
+++ b/internal/codegen/golang/opts/go_type.go
@@ -146,7 +146,12 @@ func (gt GoType) parse() (*ParsedGoType, error) {
 		o.BasicType = true
 	} else {
 		// assume the type lives in a Go package
-		if lastDot == -1 {
+		if lastDot == -1 || lastDot < lastSlash {
+			// Either no dot at all, or every dot is part of the import path
+			// (e.g. "github.com/foo/pkg/Type"). Without a dot separating
+			// package from type after the last slash, we cannot tell where
+			// the import path ends and the type name begins, and silently
+			// guessing produces a broken import like "github".
 			return nil, fmt.Errorf("Package override `go_type` specifier %q is not the proper format, expected 'package.type', e.g. 'github.com/segmentio/ksuid.KSUID'", input)
 		}
 		typename = input[lastSlash+1:]

--- a/internal/codegen/golang/opts/override_test.go
+++ b/internal/codegen/golang/opts/override_test.go
@@ -86,6 +86,19 @@ func TestTypeOverrides(t *testing.T) {
 			},
 			"Package override `go_type` specifier \"untyped rune\" is not a Go basic type e.g. 'string'",
 		},
+		{
+			// Regression for sqlc-dev/sqlc#4192: when the user writes the
+			// type name with a slash separator instead of a dot (i.e.
+			// "path/to/pkg/Type" rather than "path/to/pkg.Type"), the
+			// previous parser silently used the dot inside "github.com" and
+			// emitted a broken import like `"github"`. Reject these specs
+			// with a clear error instead.
+			Override{
+				DBType: "text",
+				GoType: GoType{Spec: "github.com/example/pkg/SomeType"},
+			},
+			"Package override `go_type` specifier \"github.com/example/pkg/SomeType\" is not the proper format, expected 'package.type', e.g. 'github.com/segmentio/ksuid.KSUID'",
+		},
 	} {
 		tt := test
 		t.Run(tt.override.GoType.Spec, func(t *testing.T) {


### PR DESCRIPTION
Fixes #4192.

A `go_type` spec like `github.com/foo/pkg/Type` (slash before the type name instead of the conventional dot) used to fall back to the last dot anywhere in the spec, which lands inside `github.com`. The generated `models.go` ended up with `import ("github")`, which does not compile.

This change rejects these specs in the parser with the same error already used for specs that contain no dot, pointing the user at the expected `'package.type'` format. Adds a regression case in `TestTypeOverrides`.