### PR TITLE
draft: investigate MariaDB utf8mb4_uca1400_ai_ci collation handling

### DIFF
--- a/internal/engine/dolphin/parse.go
+++ b/internal/engine/dolphin/parse.go
@@ -52,7 +52,14 @@ func (p *Parser) Parse(r io.Reader) ([]ast.Statement, error) {
 	if err != nil {
 		return nil, err
 	}
-	stmtNodes, _, err := p.pingcap.Parse(string(blob), "", "")
+	sql := strings.ReplaceAll(
+    string(blob),
+    "utf8mb4_uca1400_ai_ci",
+    "utf8mb4_general_ci",
+)
+
+    stmtNodes, _, err := p.pingcap.Parse(sql, "", "")
+	
 	if err != nil {
 		return nil, normalizeErr(err)
 	}

--- a/internal/sql/rewrite/parameters_test.go
+++ b/internal/sql/rewrite/parameters_test.go
@@ -1,0 +1,39 @@
+package rewrite
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/sqlc-dev/sqlc/internal/config"
+	"github.com/sqlc-dev/sqlc/internal/engine/postgresql"
+)
+
+func TestNamedParametersInOrderBy(t *testing.T) {
+	query := `
+SELECT ID
+FROM Sequence
+WHERE SeriesID = sqlc.arg(series_id)
+ORDER BY (Name = sqlc.arg(name)) DESC, ID
+LIMIT 1;
+`
+
+	p := postgresql.NewParser()
+
+	stmts, err := p.Parse(strings.NewReader(query))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+raw := stmts[0].Raw
+
+_, params, _ := NamedParameters(
+	config.EngineSQLite,
+	raw,
+	map[int]bool{},
+	false,
+)
+
+if params == nil {
+	t.Fatalf("params should not be nil")
+}
+}


### PR DESCRIPTION
## Summary

This draft PR documents investigation work related to MariaDB collation issue #4222.

## What I investigated

* Reproduced the issue on current `main`
* Created a minimal MariaDB reproduction schema
* Traced parsing flow into `internal/engine/dolphin/parse.go`
* Investigated the `p.pingcap.Parse(...)` parser entrypoint
* Attempted a temporary normalization workaround for:

  ```text id="2vq6g0"
  utf8mb4_uca1400_ai_ci
  ```

## Current status

The attempted workaround did not fully resolve the issue and also caused parser-related test failures.

At the moment, it appears the unsupported collation handling likely occurs deeper in the parser / DDL validation layer.

Opening this draft PR mainly to share investigation findings and make future debugging easier.
