### PR TITLE
refactor(ast): add named DropBehavior constants

### DIFF
--- a/internal/sql/ast/drop_behavior.go
+++ b/internal/sql/ast/drop_behavior.go
@@ -1,6 +1,19 @@
 package ast
 
+// DropBehavior captures whether a Postgres DROP statement was qualified with
+// RESTRICT or CASCADE. The numeric values mirror pganalyze/pg_query_go's
+// DropBehavior enum:
+//
+//	DropBehavior_UNDEFINED = 0  (no behavior word supplied — same as RESTRICT in PG)
+//	DROP_RESTRICT          = 1
+//	DROP_CASCADE           = 2
 type DropBehavior uint
+
+const (
+	DropBehaviorUndefined DropBehavior = 0
+	DropBehaviorRestrict  DropBehavior = 1
+	DropBehaviorCascade   DropBehavior = 2
+)
 
 func (n *DropBehavior) Pos() int {
 	return 0


### PR DESCRIPTION
Adds named `DropBehavior` constants to `internal/sql/ast/drop_behavior.go`. No behavior change — purely additive.

## Why

`internal/sql/ast` currently has:

```go
type DropBehavior uint

func (n *DropBehavior) Pos() int {
	return 0
}
```

The numeric values come from pganalyze/pg_query_go's `DropBehavior` enum, but they are nowhere named on the sqlc side. Callers comparing against the wire value have to write `stmt.Behavior == 2` for CASCADE — a magic number that's invisible to grep and silently miscompiles if pg_query reshuffles the enum.

This PR adds:

```go
const (
	DropBehaviorUndefined DropBehavior = 0
	DropBehaviorRestrict  DropBehavior = 1
	DropBehaviorCascade   DropBehavior = 2
)
```

Comments at the top of the file document where the values come from so future contributors don't have to chase the pg_query source.

## What does NOT change

- No use-site is updated in this PR. Existing comparisons against integer literals continue to compile.
- No behavior or AST shape changes — only constants.
- No new tests required: the constants are typed and validated by the compiler.

## Context

This is the follow-up I offered in a review note on #4419. That PR uses `stmt.Behavior == 2` in `internal/sql/catalog/table.go`. Once the constants land, refactoring those use-sites to `stmt.Behavior == ast.DropBehaviorCascade` is a 1-line change — happy to bundle into #4419 (if maintainers prefer one PR) or send as a separate sweep PR after #4419 merges. Both work; I have no preference.
