### PR TITLE
chore(docs): add sqlc-gen-better-typescript plugin to community page

### DIFF
--- a/docs/reference/language-support.rst
+++ b/docs/reference/language-support.rst
@@ -16,30 +16,32 @@ Community language support
 
 New languages can be added via :doc:`plugins <../guides/plugins>`.
 
-========  ==================================  ===============  ===============  ===============
-Language  Plugin                              MySQL            PostgreSQL       SQLite
-========  ==================================  ===============  ===============  ===============
-C#        `DaredevilOSS/sqlc-gen-csharp`_     Stable           Stable           Stable
-F#        `kaashyapan/sqlc-gen-fsharp`_       N/A              Beta             Beta
-Java      `tandemdude/sqlc-gen-java`_         Beta             Beta             N/A 
-PHP       `lcarilla/sqlc-plugin-php-dbal`_    Beta             N/A              N/A    
-Ruby      `DaredevilOSS/sqlc-gen-ruby`_       Beta             Beta             Beta           
-Zig       `tinyzimmer/sqlc-gen-zig`_          N/A              Beta             Beta            
-Python    `rayakame/sqlc-gen-better-python`_  N/A              Beta             Beta          
-Rust      `mathematic-inc/sqlc-gen-sqlx`_     N/A              Beta             N/A
-[Any]     `fdietze/sqlc-gen-from-template`_   Stable           Stable           Stable
-========  ==================================  ===============  ===============  ===============
+========  ==========================================  ===============  ===============  ===============
+Language  Plugin                                      MySQL            PostgreSQL       SQLite
+========  ==========================================  ===============  ===============  ===============
+C#        `DaredevilOSS/sqlc-gen-csharp`_             Stable           Stable           Stable
+F#        `kaashyapan/sqlc-gen-fsharp`_               N/A              Beta             Beta
+Java      `tandemdude/sqlc-gen-java`_                 Beta             Beta             N/A
+PHP       `lcarilla/sqlc-plugin-php-dbal`_            Beta             N/A              N/A
+Ruby      `DaredevilOSS/sqlc-gen-ruby`_               Beta             Beta             Beta
+Zig       `tinyzimmer/sqlc-gen-zig`_                  N/A              Beta             Beta
+Python    `rayakame/sqlc-gen-better-python`_          N/A              Beta             Beta
+Rust      `mathematic-inc/sqlc-gen-sqlx`_             N/A              Beta             N/A
+TS        `eikster-dk/sqlc-gen-better-typescript`_    N/A              Beta             N/A
+[Any]     `fdietze/sqlc-gen-from-template`_           Stable           Stable           Stable
+========  ==========================================  ===============  ===============  ===============
 
 Plugins developed by our Community can also be found using our `github topic`_.
 
 Community projects
 ******************
 
-========  =================================  ===============  ===============  ===============
-Language  Project                            MySQL            PostgreSQL       SQLite
-========  =================================  ===============  ===============  ===============
-Gleam     `daniellionel01/parrot`_           Stable           Stable           Stable
-========  =================================  ===============  ===============  ===============
+==========  ==========================================  ===============  ===============  ===============
+Language    Project                                     MySQL            PostgreSQL       SQLite
+==========  ==========================================  ===============  ===============  ===============
+Gleam       `daniellionel01/parrot`_                    Stable           Stable           Stable
+Effect v4   `eikster-dk/sqlc-gen-better-typescript`_    N/A              Beta             N/A
+==========  ==========================================  ===============  ===============  ===============
 
 .. _sqlc-gen-go: https://github.com/sqlc-dev/sqlc-gen-go
 .. _kaashyapan/sqlc-gen-fsharp: https://github.com/kaashyapan/sqlc-gen-fsharp
@@ -53,6 +55,7 @@ Gleam     `daniellionel01/parrot`_           Stable           Stable           S
 .. _tandemdude/sqlc-gen-java: https://github.com/tandemdude/sqlc-gen-java
 .. _tinyzimmer/sqlc-gen-zig: https://github.com/tinyzimmer/sqlc-gen-zig
 .. _daniellionel01/parrot: https://github.com/daniellionel01/parrot
+.. _eikster-dk/sqlc-gen-better-typescript: https://github.com/eikster-dk/sqlc-gen-better-typescript
 .. _rayakame/sqlc-gen-better-python: https://github.com/rayakame/sqlc-gen-better-python
 .. _mathematic-inc/sqlc-gen-sqlx: https://github.com/mathematic-inc/sqlc-gen-sqlx
 .. _github topic: https://github.com/topics/sqlc-plugin


### PR DESCRIPTION
Add eikster-dk/sqlc-gen-better-typescript (https://github.com/eikster-dk/sqlc-gen-better-typescript) to the language support reference.

This project contains two sqlc WASM plugins backed by a shared toolbelt package:
- Native TypeScript -- generates plain async functions with Zod validation and a SqlClient interface
- Effect v4 -- generates repository services using effect/unstable/sql and Effect Schema
- Both plugins support PostgreSQL only.

Changes
- Added TypeScript entry under Community language support (as a plugin)
- Added Effect v4 entry under Community projects (as a non-traditional language target)
- Widened the table columns to accommodate the new plugin name