### PR TITLE
Apply go fix modernizations with Go 1.26.4

### DIFF
--- a/internal/cmd/cmd.go
+++ b/internal/cmd/cmd.go
@@ -100,7 +100,7 @@ var initCmd = &cobra.Command{
 		if err != nil {
 			return err
 		}
-		var yamlConfig interface{}
+		var yamlConfig any
 		if useV1 {
 			yamlConfig = config.V1GenerateSettings{Version: "1"}
 		} else {

--- a/internal/cmd/createdb.go
+++ b/internal/cmd/createdb.go
@@ -47,7 +47,6 @@ func CreateDB(ctx context.Context, dir, filename, querySetName string, o *Option
 	var queryset *config.SQL
 	var count int
 	for _, sql := range conf.SQL {
-		sql := sql
 		if querySetName != "" && sql.Name != querySetName {
 			continue
 		}

--- a/internal/codegen/golang/field.go
+++ b/internal/codegen/golang/field.go
@@ -97,23 +97,23 @@ func toPascalCase(s string) string {
 }
 
 func toCamelInitCase(name string, initUpper bool) string {
-	out := ""
+	var out strings.Builder
 	for i, p := range strings.Split(name, "_") {
 		if !initUpper && i == 0 {
-			out += p
+			out.WriteString(p)
 			continue
 		}
 		if p == "id" {
-			out += "ID"
+			out.WriteString("ID")
 		} else {
-			out += strings.Title(p)
+			out.WriteString(strings.Title(p))
 		}
 	}
-	return out
+	return out.String()
 }
 
 func toJsonCamelCase(name string, idUppercase bool) string {
-	out := ""
+	var out strings.Builder
 	idStr := "Id"
 
 	if idUppercase {
@@ -122,16 +122,16 @@ func toJsonCamelCase(name string, idUppercase bool) string {
 
 	for i, p := range strings.Split(name, "_") {
 		if i == 0 {
-			out += p
+			out.WriteString(p)
 			continue
 		}
 		if p == "id" {
-			out += idStr
+			out.WriteString(idStr)
 		} else {
-			out += strings.Title(p)
+			out.WriteString(strings.Title(p))
 		}
 	}
-	return out
+	return out.String()
 }
 
 func toLowerCase(str string) string {

--- a/internal/codegen/golang/gen.go
+++ b/internal/codegen/golang/gen.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"fmt"
 	"go/format"
+	"slices"
 	"strings"
 	"text/template"
 
@@ -348,10 +349,8 @@ func usesCopyFrom(queries []Query) bool {
 
 func usesBatch(queries []Query) bool {
 	for _, q := range queries {
-		for _, cmd := range []string{metadata.CmdBatchExec, metadata.CmdBatchMany, metadata.CmdBatchOne} {
-			if q.Cmd == cmd {
-				return true
-			}
+		if slices.Contains([]string{metadata.CmdBatchExec, metadata.CmdBatchMany, metadata.CmdBatchOne}, q.Cmd) {
+			return true
 		}
 	}
 	return false

--- a/internal/codegen/golang/go_type.go
+++ b/internal/codegen/golang/go_type.go
@@ -1,6 +1,7 @@
 package golang
 
 import (
+	"maps"
 	"strings"
 
 	"github.com/sqlc-dev/sqlc/internal/codegen/golang/opts"
@@ -15,9 +16,7 @@ func addExtraGoStructTags(tags map[string]string, req *plugin.GenerateRequest, o
 			continue
 		}
 		if override.MatchesColumn(col) {
-			for k, v := range oride.GoType.StructTags {
-				tags[k] = v
-			}
+			maps.Copy(tags, oride.GoType.StructTags)
 			continue
 		}
 		if !override.Matches(col.Table, req.Catalog.DefaultSchema) {
@@ -33,9 +32,7 @@ func addExtraGoStructTags(tags map[string]string, req *plugin.GenerateRequest, o
 			continue
 		}
 		// Add the extra tags.
-		for k, v := range oride.GoType.StructTags {
-			tags[k] = v
-		}
+		maps.Copy(tags, oride.GoType.StructTags)
 	}
 }
 

--- a/internal/codegen/golang/opts/go_type.go
+++ b/internal/codegen/golang/opts/go_type.go
@@ -51,7 +51,7 @@ func (o *GoType) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
-func (o *GoType) UnmarshalYAML(unmarshal func(interface{}) error) error {
+func (o *GoType) UnmarshalYAML(unmarshal func(any) error) error {
 	var spec string
 	if err := unmarshal(&spec); err == nil {
 		*o = GoType{Spec: spec}

--- a/internal/codegen/golang/qualify.go
+++ b/internal/codegen/golang/qualify.go
@@ -9,23 +9,23 @@ func stripQualifier(t, qualifier string) string {
 	if qualifier == "" {
 		return t
 	}
-	prefix := ""
+	var prefix strings.Builder
 	rest := t
 	for {
 		if strings.HasPrefix(rest, "[]") {
-			prefix += "[]"
+			prefix.WriteString("[]")
 			rest = rest[2:]
 			continue
 		}
 		if strings.HasPrefix(rest, "*") {
-			prefix += "*"
+			prefix.WriteString("*")
 			rest = rest[1:]
 			continue
 		}
 		break
 	}
 	if strings.HasPrefix(rest, qualifier) {
-		return prefix + rest[len(qualifier):]
+		return prefix.String() + rest[len(qualifier):]
 	}
 	return t
 }
@@ -57,23 +57,23 @@ func qualifyType(t string, models modelTypeSet, qualifier string) string {
 	if qualifier == "" || t == "" || len(models) == 0 {
 		return t
 	}
-	prefix := ""
+	var prefix strings.Builder
 	rest := t
 	for {
 		if strings.HasPrefix(rest, "[]") {
-			prefix += "[]"
+			prefix.WriteString("[]")
 			rest = rest[2:]
 			continue
 		}
 		if strings.HasPrefix(rest, "*") {
-			prefix += "*"
+			prefix.WriteString("*")
 			rest = rest[1:]
 			continue
 		}
 		break
 	}
 	if _, ok := models[rest]; ok {
-		return prefix + qualifier + rest
+		return prefix.String() + qualifier + rest
 	}
 	return t
 }

--- a/internal/codegen/golang/result.go
+++ b/internal/codegen/golang/result.go
@@ -169,17 +169,17 @@ func paramName(p *plugin.Parameter) string {
 }
 
 func argName(name string) string {
-	out := ""
+	var out strings.Builder
 	for i, p := range strings.Split(name, "_") {
 		if i == 0 {
-			out += strings.ToLower(p)
+			out.WriteString(strings.ToLower(p))
 		} else if p == "id" {
-			out += "ID"
+			out.WriteString("ID")
 		} else {
-			out += strings.Title(p)
+			out.WriteString(strings.Title(p))
 		}
 	}
-	return out
+	return out.String()
 }
 
 func buildQueries(req *plugin.GenerateRequest, options *opts.Options, enums []Enum, structs []Struct) ([]Query, error) {

--- a/internal/codegen/golang/struct.go
+++ b/internal/codegen/golang/struct.go
@@ -24,7 +24,7 @@ func StructName(name string, options *opts.Options) string {
 	if rename := options.Rename[name]; rename != "" {
 		return rename
 	}
-	out := ""
+	var out strings.Builder
 	name = strings.Map(func(r rune) rune {
 		if unicode.IsLetter(r) {
 			return r
@@ -35,19 +35,19 @@ func StructName(name string, options *opts.Options) string {
 		return rune('_')
 	}, name)
 
-	for _, p := range strings.Split(name, "_") {
+	for p := range strings.SplitSeq(name, "_") {
 		if _, found := options.InitialismsMap[p]; found {
-			out += strings.ToUpper(p)
+			out.WriteString(strings.ToUpper(p))
 		} else {
-			out += strings.Title(p)
+			out.WriteString(strings.Title(p))
 		}
 	}
 
 	// If a name has a digit as its first char, prepand an underscore to make it a valid Go name.
-	r, _ := utf8.DecodeRuneInString(out)
+	r, _ := utf8.DecodeRuneInString(out.String())
 	if unicode.IsDigit(r) {
-		return "_" + out
+		return "_" + out.String()
 	} else {
-		return out
+		return out.String()
 	}
 }

--- a/internal/compiler/output_columns.go
+++ b/internal/compiler/output_columns.go
@@ -517,7 +517,6 @@ func (c *Compiler) sourceTables(qc *QueryCatalog, node ast.Node) ([]*Table, erro
 
 	var tables []*Table
 	for _, item := range list.Items {
-		item := item
 		switch n := item.(type) {
 
 		case *ast.RangeFunction:

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -36,7 +36,7 @@ func (p *Paths) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
-func (p *Paths) UnmarshalYAML(unmarshal func(interface{}) error) error {
+func (p *Paths) UnmarshalYAML(unmarshal func(any) error) error {
 	out := []string{}
 	if sliceErr := unmarshal(&out); sliceErr != nil {
 		var ele string
@@ -61,7 +61,7 @@ type Config struct {
 	Cloud     Cloud                `json:"cloud" yaml:"cloud"`
 	Servers   []Server             `json:"servers" yaml:"servers"`
 	SQL       []SQL                `json:"sql" yaml:"sql"`
-	Overrides Overrides            `json:"overrides,omitempty" yaml:"overrides"`
+	Overrides Overrides            `json:"overrides" yaml:"overrides"`
 	Plugins   []Plugin             `json:"plugins" yaml:"plugins"`
 	Rules     []Rule               `json:"rules" yaml:"rules"`
 	Options   map[string]yaml.Node `json:"options" yaml:"options"`
@@ -125,8 +125,8 @@ type SQL struct {
 // AnalyzerDatabase represents the database analyzer setting.
 // It can be a boolean (true/false) or the string "only" for database-only mode.
 type AnalyzerDatabase struct {
-	value   *bool  // nil means not set, true/false for boolean values
-	isOnly  bool   // true when set to "only"
+	value  *bool // nil means not set, true/false for boolean values
+	isOnly bool  // true when set to "only"
 }
 
 // IsEnabled returns true if the database analyzer should be used.
@@ -166,7 +166,7 @@ func (a *AnalyzerDatabase) UnmarshalJSON(data []byte) error {
 	return errors.New("analyzer.database must be true, false, or \"only\"")
 }
 
-func (a *AnalyzerDatabase) UnmarshalYAML(unmarshal func(interface{}) error) error {
+func (a *AnalyzerDatabase) UnmarshalYAML(unmarshal func(any) error) error {
 	// Try to unmarshal as boolean first
 	var b bool
 	if err := unmarshal(&b); err == nil {

--- a/internal/config/convert/convert.go
+++ b/internal/config/convert/convert.go
@@ -8,11 +8,11 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
-func gen(n *yaml.Node) (interface{}, error) {
+func gen(n *yaml.Node) (any, error) {
 	switch n.Kind {
 
 	case yaml.MappingNode:
-		nn := map[string]interface{}{}
+		nn := map[string]any{}
 		for i, _ := range n.Content {
 			if i%2 == 0 {
 				k := n.Content[i]
@@ -26,7 +26,7 @@ func gen(n *yaml.Node) (interface{}, error) {
 		return nn, nil
 
 	case yaml.SequenceNode:
-		nn := []interface{}{}
+		nn := []any{}
 		for i, _ := range n.Content {
 			v, err := gen(n.Content[i])
 			if err != nil {

--- a/internal/dbmanager/client.go
+++ b/internal/dbmanager/client.go
@@ -90,7 +90,7 @@ func (m *ManagedClient) CreateDatabase(ctx context.Context, req *CreateDatabaseR
 	uri.Path = "/" + name
 
 	key := uri.String()
-	_, err, _ = flight.Do(key, func() (interface{}, error) {
+	_, err, _ = flight.Do(key, func() (any, error) {
 		// TODO: Use a parameterized query
 		row := pool.QueryRow(ctx,
 			fmt.Sprintf(`SELECT datname FROM pg_database WHERE datname = '%s'`, name))

--- a/internal/debug/dump.go
+++ b/internal/debug/dump.go
@@ -14,7 +14,7 @@ import (
 // specific setting can gate their output on "is debug mode on at all".
 var Active = sqlcdebug.Any()
 
-func Dump(n ...interface{}) {
+func Dump(n ...any) {
 	if Active {
 		spew.Dump(n)
 	}

--- a/internal/endtoend/ddl_test.go
+++ b/internal/endtoend/ddl_test.go
@@ -12,7 +12,6 @@ import (
 
 func TestValidSchema(t *testing.T) {
 	for _, replay := range FindTests(t, "testdata", "base") {
-		replay := replay // https://golang.org/doc/faq#closures_and_goroutines
 
 		if replay.Exec != nil {
 			if replay.Exec.Meta.InvalidSchema {
@@ -32,7 +31,6 @@ func TestValidSchema(t *testing.T) {
 		}
 
 		for j, pkg := range conf.SQL {
-			j, pkg := j, pkg
 			switch pkg.Engine {
 			case config.EnginePostgreSQL:
 				// pass

--- a/internal/endtoend/endtoend_test.go
+++ b/internal/endtoend/endtoend_test.go
@@ -237,8 +237,6 @@ func TestReplay(t *testing.T) {
 	}
 
 	for name, testctx := range contexts {
-		name := name
-		testctx := testctx
 
 		if !testctx.Enabled() {
 			continue
@@ -371,7 +369,6 @@ func cmpDirectory(t *testing.T, dir string, actual map[string]string) {
 	if !cmp.Equal(expected, actual, opts...) {
 		t.Errorf("%s contents differ", dir)
 		for name, contents := range expected {
-			name := name
 			if actual[name] == "" {
 				t.Errorf("%s is empty", name)
 				return

--- a/internal/endtoend/fmt_test.go
+++ b/internal/endtoend/fmt_test.go
@@ -31,7 +31,6 @@ type sqlFormatter interface {
 func TestFormat(t *testing.T) {
 	t.Parallel()
 	for _, tc := range FindTests(t, "testdata", "base") {
-		tc := tc
 		t.Run(tc.Name, func(t *testing.T) {
 			// Parse the config file to determine the engine
 			configPath := filepath.Join(tc.Path, tc.ConfigName)
@@ -145,7 +144,6 @@ func TestFormat(t *testing.T) {
 				}
 
 				for i, stmt := range stmts {
-					stmt := stmt
 					t.Run(fmt.Sprintf("%d", i), func(t *testing.T) {
 						// Extract the original query text using statement location and length
 						start := stmt.Raw.StmtLocation

--- a/internal/engine/postgresql/catalog.go
+++ b/internal/engine/postgresql/catalog.go
@@ -4,8 +4,10 @@ import "github.com/sqlc-dev/sqlc/internal/sql/catalog"
 
 // toPointer converts an int to a pointer without a temporary
 // variable at the call-site, and is used by the generated schemas
+//
+//go:fix inline
 func toPointer(x int) *int {
-	return &x
+	return new(x)
 }
 
 func NewCatalog() *catalog.Catalog {

--- a/internal/engine/sqlite/analyzer/analyze.go
+++ b/internal/engine/sqlite/analyzer/analyze.go
@@ -86,7 +86,7 @@ func (a *Analyzer) Analyze(ctx context.Context, n ast.Node, query string, migrat
 
 	// Get column information
 	colCount := stmt.ColumnCount()
-	for i := 0; i < colCount; i++ {
+	for i := range colCount {
 		name := stmt.ColumnName(i)
 		declType := stmt.ColumnDeclType(i)
 		dbName := stmt.ColumnDatabaseName(i)
@@ -251,7 +251,7 @@ func (a *Analyzer) GetColumnNames(ctx context.Context, query string) ([]string, 
 
 	colCount := stmt.ColumnCount()
 	columns := make([]string, colCount)
-	for i := 0; i < colCount; i++ {
+	for i := range colCount {
 		columns[i] = stmt.ColumnName(i)
 	}
 

--- a/internal/engine/sqlite/parse.go
+++ b/internal/engine/sqlite/parse.go
@@ -17,7 +17,7 @@ type errorListener struct {
 	err string
 }
 
-func (el *errorListener) SyntaxError(recognizer antlr.Recognizer, offendingSymbol interface{}, line, column int, msg string, e antlr.RecognitionException) {
+func (el *errorListener) SyntaxError(recognizer antlr.Recognizer, offendingSymbol any, line, column int, msg string, e antlr.RecognitionException) {
 	el.err = msg
 }
 

--- a/internal/ext/wasm/wasm.go
+++ b/internal/ext/wasm/wasm.go
@@ -59,7 +59,7 @@ func (r *Runner) loadAndCompile(ctx context.Context) (*runtimeAndCode, error) {
 	if err != nil {
 		return nil, err
 	}
-	value, err, _ := flight.Do(expected, func() (interface{}, error) {
+	value, err, _ := flight.Do(expected, func() (any, error) {
 		return r.loadAndCompileWASM(ctx, cacheDir, expected)
 	})
 	if err != nil {

--- a/internal/metadata/meta.go
+++ b/internal/metadata/meta.go
@@ -59,7 +59,7 @@ func validateQueryName(name string) error {
 }
 
 func ParseQueryNameAndType(t string, commentStyle CommentSyntax) (string, string, error) {
-	for _, line := range strings.Split(t, "\n") {
+	for line := range strings.SplitSeq(t, "\n") {
 		var prefix string
 		if strings.HasPrefix(line, "--") {
 			if !commentStyle.Dash {

--- a/internal/opts/experiment.go
+++ b/internal/opts/experiment.go
@@ -47,7 +47,7 @@ func ExperimentFromString(val string) Experiment {
 		return e
 	}
 
-	for _, name := range strings.Split(val, ",") {
+	for name := range strings.SplitSeq(val, ",") {
 		name = strings.TrimSpace(name)
 		if name == "" {
 			continue

--- a/internal/pattern/match.go
+++ b/internal/pattern/match.go
@@ -3,6 +3,7 @@ package pattern
 import (
 	"fmt"
 	"regexp"
+	"strings"
 	"sync"
 )
 
@@ -42,16 +43,16 @@ func MatchCompile(pattern string) (*Match, error) {
 }
 
 func matchCompile(pattern string) (match *Match, err error) {
-	regex := ""
+	var regex strings.Builder
 	escaped := false
 	arr := []byte(pattern)
 
-	for i := 0; i < len(arr); i++ {
+	for i := range arr {
 		if escaped {
 			escaped = false
 			switch arr[i] {
 			case '*', '?', '\\':
-				regex += "\\" + string(arr[i])
+				regex.WriteString("\\" + string(arr[i]))
 			default:
 				return nil, fmt.Errorf("Invalid escaped character '%c'", arr[i])
 			}
@@ -60,13 +61,13 @@ func matchCompile(pattern string) (match *Match, err error) {
 			case '\\':
 				escaped = true
 			case '*':
-				regex += ".*"
+				regex.WriteString(".*")
 			case '?':
-				regex += "."
+				regex.WriteString(".")
 			case '.', '(', ')', '+', '|', '^', '$', '[', ']', '{', '}':
-				regex += "\\" + string(arr[i])
+				regex.WriteString("\\" + string(arr[i]))
 			default:
-				regex += string(arr[i])
+				regex.WriteString(string(arr[i]))
 			}
 		}
 	}
@@ -77,7 +78,7 @@ func matchCompile(pattern string) (match *Match, err error) {
 
 	var r *regexp.Regexp
 
-	if r, err = regexp.Compile("^" + regex + "$"); err != nil {
+	if r, err = regexp.Compile("^" + regex.String() + "$"); err != nil {
 		return nil, err
 	}
 

--- a/internal/rpc/interceptor.go
+++ b/internal/rpc/interceptor.go
@@ -8,7 +8,7 @@ import (
 	"google.golang.org/grpc/status"
 )
 
-func UnaryInterceptor(ctx context.Context, method string, req, reply interface{}, cc *grpc.ClientConn, invoker grpc.UnaryInvoker, opts ...grpc.CallOption) error {
+func UnaryInterceptor(ctx context.Context, method string, req, reply any, cc *grpc.ClientConn, invoker grpc.UnaryInvoker, opts ...grpc.CallOption) error {
 	err := invoker(ctx, method, req, reply, cc, opts...)
 
 	switch status.Convert(err).Code() {

--- a/internal/source/code.go
+++ b/internal/source/code.go
@@ -110,8 +110,8 @@ func StripComments(sql string) (string, []string, error) {
 		if strings.HasPrefix(t, "# name:") {
 			continue
 		}
-		if strings.HasPrefix(t, "--") {
-			comments = append(comments, strings.TrimPrefix(t, "--"))
+		if after, ok := strings.CutPrefix(t, "--"); ok {
+			comments = append(comments, after)
 			continue
 		}
 		if strings.HasPrefix(t, "/*") && strings.HasSuffix(t, "*/") {
@@ -126,8 +126,8 @@ func StripComments(sql string) (string, []string, error) {
 			comments = append(comments, t)
 			continue
 		}
-		if strings.HasPrefix(t, "#") {
-			comments = append(comments, strings.TrimPrefix(t, "#"))
+		if after, ok := strings.CutPrefix(t, "#"); ok {
+			comments = append(comments, after)
 			continue
 		}
 		lines = append(lines, t)

--- a/internal/sql/ast/param_exec_data.go
+++ b/internal/sql/ast/param_exec_data.go
@@ -1,7 +1,7 @@
 package ast
 
 type ParamExecData struct {
-	ExecPlan interface{}
+	ExecPlan any
 	Value    Datum
 	Isnull   bool
 }

--- a/internal/sql/ast/param_list_info_data.go
+++ b/internal/sql/ast/param_list_info_data.go
@@ -1,8 +1,8 @@
 package ast
 
 type ParamListInfoData struct {
-	ParamFetchArg  interface{}
-	ParserSetupArg interface{}
+	ParamFetchArg  any
+	ParserSetupArg any
 	NumParams      int
 	ParamMask      []uint32
 }

--- a/internal/sql/astutils/rewrite.go
+++ b/internal/sql/astutils/rewrite.go
@@ -120,7 +120,7 @@ type application struct {
 
 func (a *application) apply(parent ast.Node, name string, iter *iterator, n ast.Node) {
 	// convert typed nil into untyped nil
-	if v := reflect.ValueOf(n); v.Kind() == reflect.Ptr && v.IsNil() {
+	if v := reflect.ValueOf(n); v.Kind() == reflect.Pointer && v.IsNil() {
 		n = nil
 	}
 

--- a/internal/sqlcdebug/sqlcdebug.go
+++ b/internal/sqlcdebug/sqlcdebug.go
@@ -144,7 +144,7 @@ func parse(raw string) map[string]string {
 	if raw == "" {
 		return out
 	}
-	for _, pair := range strings.Split(raw, ",") {
+	for pair := range strings.SplitSeq(raw, ",") {
 		pair = strings.TrimSpace(pair)
 		if pair == "" {
 			continue

--- a/internal/sqltest/docker/mysql.go
+++ b/internal/sqltest/docker/mysql.go
@@ -20,7 +20,7 @@ func StartMySQLServer(c context.Context) (string, error) {
 	if mysqlHost != "" {
 		return mysqlHost, nil
 	}
-	value, err, _ := flight.Do("mysql", func() (interface{}, error) {
+	value, err, _ := flight.Do("mysql", func() (any, error) {
 		host, err := startMySQLServer(c)
 		if err != nil {
 			return "", err

--- a/internal/sqltest/docker/postgres.go
+++ b/internal/sqltest/docker/postgres.go
@@ -20,7 +20,7 @@ func StartPostgreSQLServer(c context.Context) (string, error) {
 	if postgresHost != "" {
 		return postgresHost, nil
 	}
-	value, err, _ := flight.Do("postgresql", func() (interface{}, error) {
+	value, err, _ := flight.Do("postgresql", func() (any, error) {
 		host, err := startPostgreSQLServer(c)
 		if err != nil {
 			return "", err

--- a/internal/sqltest/local/postgres.go
+++ b/internal/sqltest/local/postgres.go
@@ -91,7 +91,7 @@ func postgreSQL(t *testing.T, migrations []string, rw bool) string {
 
 	key := uri.String()
 
-	_, err, _ = flight.Do(key, func() (interface{}, error) {
+	_, err, _ = flight.Do(key, func() (any, error) {
 		row := postgresPool.QueryRow(ctx,
 			fmt.Sprintf(`SELECT datname FROM pg_database WHERE datname = '%s'`, name))
 

--- a/internal/sqltest/native/mysql.go
+++ b/internal/sqltest/native/mysql.go
@@ -23,7 +23,7 @@ func StartMySQLServer(ctx context.Context) (string, error) {
 	if mysqlURI != "" {
 		return mysqlURI, nil
 	}
-	value, err, _ := mysqlFlight.Do("mysql", func() (interface{}, error) {
+	value, err, _ := mysqlFlight.Do("mysql", func() (any, error) {
 		uri, err := startMySQLServer(ctx)
 		if err != nil {
 			return "", err

--- a/internal/sqltest/native/postgres.go
+++ b/internal/sqltest/native/postgres.go
@@ -23,7 +23,7 @@ func StartPostgreSQLServer(ctx context.Context) (string, error) {
 	if postgresURI != "" {
 		return postgresURI, nil
 	}
-	value, err, _ := postgresFlight.Do("postgresql", func() (interface{}, error) {
+	value, err, _ := postgresFlight.Do("postgresql", func() (any, error) {
 		uri, err := startPostgreSQLServer(ctx)
 		if err != nil {
 			return "", err

--- a/internal/tools/sqlc-pg-gen/main.go
+++ b/internal/tools/sqlc-pg-gen/main.go
@@ -303,9 +303,9 @@ func run(ctx context.Context) error {
 	for _, extension := range extensions {
 		name := strings.Replace(extension, "-", "_", -1)
 
-		var funcName string
-		for _, part := range strings.Split(name, "_") {
-			funcName += strings.Title(part)
+		var funcName strings.Builder
+		for part := range strings.SplitSeq(name, "_") {
+			funcName.WriteString(strings.Title(part))
 		}
 
 		if _, err := conn.Exec(ctx, fmt.Sprintf("CREATE EXTENSION IF NOT EXISTS %q", extension)); err != nil {
@@ -343,14 +343,14 @@ func run(ctx context.Context) error {
 		err = writeFormattedGo(tmpl, tmplCtx{
 			Pkg:        "contrib",
 			SchemaName: "pg_catalog",
-			GenFnName:  funcName,
+			GenFnName:  funcName.String(),
 			Procs:      procs,
 		}, extensionPath)
 		if err != nil {
 			return fmt.Errorf("error generating extension %s: %w", extension, err)
 		}
 
-		loaded = append(loaded, extensionPair{Name: extension, Func: funcName})
+		loaded = append(loaded, extensionPair{Name: extension, Func: funcName.String()})
 	}
 
 	extensionTmpl, err := template.New("").Parse(loaderFuncTmpl)

--- a/internal/x/expander/expander_test.go
+++ b/internal/x/expander/expander_test.go
@@ -82,7 +82,7 @@ func (g *SQLiteColumnGetter) GetColumnNames(ctx context.Context, query string) (
 	// Get column names from the prepared statement
 	count := stmt.ColumnCount()
 	columns := make([]string, count)
-	for i := 0; i < count; i++ {
+	for i := range count {
 		columns[i] = stmt.ColumnName(i)
 	}
 

--- a/scripts/test-json-process-plugin/main.go
+++ b/scripts/test-json-process-plugin/main.go
@@ -17,7 +17,7 @@ type File struct {
 }
 
 func main() {
-	in := make(map[string]interface{})
+	in := make(map[string]any)
 	decoder := json.NewDecoder(os.Stdin)
 	err := decoder.Decode(&in)
 	if err != nil {
@@ -26,9 +26,9 @@ func main() {
 	}
 
 	buf := bytes.NewBuffer(nil)
-	queries := in["queries"].([]interface{})
+	queries := in["queries"].([]any)
 	for _, q := range queries {
-		text := q.(map[string]interface{})["text"].(string)
+		text := q.(map[string]any)["text"].(string)
 		buf.WriteString(text)
 		buf.WriteString("\n")
 	}


### PR DESCRIPTION
Run go fix using the Go 1.26.4 toolchain to apply modernizer rewrites
(range-over-int loops, strings.Builder, strings.CutPrefix, etc.).
No testdata files were modified.