### PR TITLE
fix: Add json_tags_id_uppercase functionality to the JSON style PascalCase

### DIFF
--- a/internal/codegen/golang/field.go
+++ b/internal/codegen/golang/field.go
@@ -69,7 +69,7 @@ func SetJSONCaseStyle(name string, style string, idUppercase bool) string {
 	case "camel":
 		return toJsonCamelCase(name, idUppercase)
 	case "pascal":
-		return toPascalCase(name)
+		return toJsonPascalCase(name, idUppercase)
 	case "snake":
 		return toSnakeCase(name)
 	default:
@@ -95,6 +95,9 @@ func toCamelCase(s string) string {
 func toPascalCase(s string) string {
 	return toCamelInitCase(s, true)
 }
+func toJsonPascalCase(s string, idUppercase bool) string {
+	return toJsonCamelInitCase(s, true, idUppercase)
+}
 
 func toCamelInitCase(name string, initUpper bool) string {
 	var out strings.Builder
@@ -113,6 +116,10 @@ func toCamelInitCase(name string, initUpper bool) string {
 }
 
 func toJsonCamelCase(name string, idUppercase bool) string {
+	return toJsonCamelInitCase(name, false, idUppercase)
+}
+
+func toJsonCamelInitCase(name string, initUpper bool, idUppercase bool) string {
 	var out strings.Builder
 	idStr := "Id"
 
@@ -121,7 +128,7 @@ func toJsonCamelCase(name string, idUppercase bool) string {
 	}
 
 	for i, p := range strings.Split(name, "_") {
-		if i == 0 {
+		if !initUpper && i == 0 {
 			out.WriteString(p)
 			continue
 		}

--- a/internal/endtoend/testdata/json_tags_null_enum/pascal_case/postgresql/stdlib/go/models.go
+++ b/internal/endtoend/testdata/json_tags_null_enum/pascal_case/postgresql/stdlib/go/models.go
@@ -54,7 +54,7 @@ func (ns NullJobPostLocationType) Value() (driver.Value, error) {
 }
 
 type Author struct {
-	ID   int64                   `json:"ID"`
+	ID   int64                   `json:"Id"`
 	Type NullJobPostLocationType `json:"Type"`
 	Name string                  `json:"Name"`
 	Bio  sql.NullString          `json:"Bio"`


### PR DESCRIPTION
Re-opening: https://github.com/sqlc-dev/sqlc/pull/3747#issuecomment-4651367480
After rebase and resolving conflicts.

I was having trouble with the `json_tags_id_uppercase` config with the pascal json tag style.

When the json_tags_id_uppercase is set to false I expected the json output to be:
user_id -> UserId , however resulted in UserID
id -> Id , however resulted in ID

If my undertanding of the config was incorrect, please let me know.