### PR TITLE
chore: replace interface{} with any in Go/SQLite code generation

### DIFF
--- a/internal/codegen/golang/go_type.go
+++ b/internal/codegen/golang/go_type.go
@@ -87,6 +87,6 @@ func goInnerType(req *plugin.GenerateRequest, options *opts.Options, col *plugin
 	case "sqlite":
 		return sqliteType(req, options, col)
 	default:
-		return "interface{}"
+		return "any"
 	}
 }

--- a/internal/codegen/golang/result.go
+++ b/internal/codegen/golang/result.go
@@ -438,7 +438,7 @@ func columnsToStruct(req *plugin.GenerateRequest, options *opts.Options, name st
 	// field with the same name has a known type, assign
 	// the known type to the field without a known type
 	for i, field := range gs.Fields {
-		if len(seen[field.Name]) > 1 && field.Type == "interface{}" {
+		if len(seen[field.Name]) > 1 && field.Type == "any" {
 			for _, j := range seen[field.Name] {
 				if i == j {
 					continue

--- a/internal/codegen/golang/sqlite_type.go
+++ b/internal/codegen/golang/sqlite_type.go
@@ -60,7 +60,7 @@ func sqliteType(req *plugin.GenerateRequest, options *opts.Options, col *plugin.
 		return "json.RawMessage"
 
 	case "any":
-		return "interface{}"
+		return "any"
 
 	}
 
@@ -96,7 +96,7 @@ func sqliteType(req *plugin.GenerateRequest, options *opts.Options, col *plugin.
 			log.Printf("unknown SQLite type: %s\n", dt)
 		}
 
-		return "interface{}"
+		return "any"
 
 	}
 }

--- a/internal/codegen/golang/templates/stdlib/dbCode.tmpl
+++ b/internal/codegen/golang/templates/stdlib/dbCode.tmpl
@@ -1,9 +1,9 @@
 {{define "dbCodeTemplateStd"}}
 type DBTX interface {
-	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
 	PrepareContext(context.Context, string) (*sql.Stmt, error)
-	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
-	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
 }
 
 {{ if .EmitMethodsWithDBArgument}}
@@ -42,7 +42,7 @@ func (q *Queries) Close() error {
 	return err
 }
 
-func (q *Queries) exec(ctx context.Context, stmt *sql.Stmt, query string, args ...interface{}) (sql.Result, error) {
+func (q *Queries) exec(ctx context.Context, stmt *sql.Stmt, query string, args ...any) (sql.Result, error) {
 	switch {
 	case stmt != nil && q.tx != nil:
 		return q.tx.StmtContext(ctx, stmt).ExecContext(ctx, args...)
@@ -53,7 +53,7 @@ func (q *Queries) exec(ctx context.Context, stmt *sql.Stmt, query string, args .
 	}
 }
 
-func (q *Queries) query(ctx context.Context, stmt *sql.Stmt, query string, args ...interface{}) (*sql.Rows, error) {
+func (q *Queries) query(ctx context.Context, stmt *sql.Stmt, query string, args ...any) (*sql.Rows, error) {
 	switch {
 	case stmt != nil && q.tx != nil:
 		return q.tx.StmtContext(ctx, stmt).QueryContext(ctx, args...)
@@ -64,7 +64,7 @@ func (q *Queries) query(ctx context.Context, stmt *sql.Stmt, query string, args 
 	}
 }
 
-func (q *Queries) queryRow(ctx context.Context, stmt *sql.Stmt, query string, args ...interface{}) (*sql.Row) {
+func (q *Queries) queryRow(ctx context.Context, stmt *sql.Stmt, query string, args ...any) (*sql.Row) {
 	switch {
 	case stmt != nil && q.tx != nil:
 		return q.tx.StmtContext(ctx, stmt).QueryRowContext(ctx, args...)

--- a/internal/codegen/golang/templates/stdlib/queryCode.tmpl
+++ b/internal/codegen/golang/templates/stdlib/queryCode.tmpl
@@ -127,7 +127,7 @@ func (q *Queries) {{.MethodName}}(ctx context.Context, {{ dbarg }} {{.Arg.Pair}}
 {{define "queryCodeStdExec"}}
     {{- if .Arg.HasSqlcSlices }}
         query := {{.ConstantName}}
-        var queryParams []interface{}
+        var queryParams []any
         {{- if .Arg.Struct }}
             {{- $arg := .Arg }}
             {{- range .Arg.Struct.Fields }}

--- a/internal/codegen/golang/templates/template.tmpl
+++ b/internal/codegen/golang/templates/template.tmpl
@@ -96,7 +96,7 @@ const (
 	{{- end}}
 )
 
-func (e *{{.Name}}) Scan(src interface{}) error {
+func (e *{{.Name}}) Scan(src any) error {
 	switch s := src.(type) {
 	case []byte:
 		*e = {{.Name}}(s)
@@ -114,7 +114,7 @@ type Null{{.Name}} struct {
 }
 
 // Scan implements the Scanner interface.
-func (ns *Null{{.Name}}) Scan(value interface{}) error {
+func (ns *Null{{.Name}}) Scan(value any) error {
 	if value == nil {
 		ns.{{.Name}}, ns.Valid = "", false
 		return nil

--- a/internal/endtoend/testdata/accurate_sqlite/sqlite/stdlib/go/db.go
+++ b/internal/endtoend/testdata/accurate_sqlite/sqlite/stdlib/go/db.go
@@ -10,10 +10,10 @@ import (
 )
 
 type DBTX interface {
-	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
 	PrepareContext(context.Context, string) (*sql.Stmt, error)
-	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
-	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/alias/sqlite/go/db.go
+++ b/internal/endtoend/testdata/alias/sqlite/go/db.go
@@ -10,10 +10,10 @@ import (
 )
 
 type DBTX interface {
-	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
 	PrepareContext(context.Context, string) (*sql.Stmt, error)
-	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
-	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/between_args/sqlite/go/db.go
+++ b/internal/endtoend/testdata/between_args/sqlite/go/db.go
@@ -10,10 +10,10 @@ import (
 )
 
 type DBTX interface {
-	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
 	PrepareContext(context.Context, string) (*sql.Stmt, error)
-	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
-	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/builtins/sqlite/go/aggfunc.sql.go
+++ b/internal/endtoend/testdata/builtins/sqlite/go/aggfunc.sql.go
@@ -91,9 +91,9 @@ const getMaxInt = `-- name: GetMaxInt :one
 SELECT max(int_val) FROM test
 `
 
-func (q *Queries) GetMaxInt(ctx context.Context) (interface{}, error) {
+func (q *Queries) GetMaxInt(ctx context.Context) (any, error) {
 	row := q.db.QueryRowContext(ctx, getMaxInt)
-	var max interface{}
+	var max any
 	err := row.Scan(&max)
 	return max, err
 }
@@ -102,9 +102,9 @@ const getMaxText = `-- name: GetMaxText :one
 SELECT max(text_val) FROM test
 `
 
-func (q *Queries) GetMaxText(ctx context.Context) (interface{}, error) {
+func (q *Queries) GetMaxText(ctx context.Context) (any, error) {
 	row := q.db.QueryRowContext(ctx, getMaxText)
-	var max interface{}
+	var max any
 	err := row.Scan(&max)
 	return max, err
 }
@@ -113,9 +113,9 @@ const getMinInt = `-- name: GetMinInt :one
 SELECT min(int_val) FROM test
 `
 
-func (q *Queries) GetMinInt(ctx context.Context) (interface{}, error) {
+func (q *Queries) GetMinInt(ctx context.Context) (any, error) {
 	row := q.db.QueryRowContext(ctx, getMinInt)
-	var min interface{}
+	var min any
 	err := row.Scan(&min)
 	return min, err
 }
@@ -124,9 +124,9 @@ const getMinText = `-- name: GetMinText :one
 SELECT min(text_val) FROM test
 `
 
-func (q *Queries) GetMinText(ctx context.Context) (interface{}, error) {
+func (q *Queries) GetMinText(ctx context.Context) (any, error) {
 	row := q.db.QueryRowContext(ctx, getMinText)
-	var min interface{}
+	var min any
 	err := row.Scan(&min)
 	return min, err
 }

--- a/internal/endtoend/testdata/builtins/sqlite/go/db.go
+++ b/internal/endtoend/testdata/builtins/sqlite/go/db.go
@@ -10,10 +10,10 @@ import (
 )
 
 type DBTX interface {
-	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
 	PrepareContext(context.Context, string) (*sql.Stmt, error)
-	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
-	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/builtins/sqlite/go/scalarfunc.sql.go
+++ b/internal/endtoend/testdata/builtins/sqlite/go/scalarfunc.sql.go
@@ -58,9 +58,9 @@ const getCoalesce = `-- name: GetCoalesce :one
 SELECT coalesce(NULL, 1, 'test')
 `
 
-func (q *Queries) GetCoalesce(ctx context.Context) (interface{}, error) {
+func (q *Queries) GetCoalesce(ctx context.Context) (any, error) {
 	row := q.db.QueryRowContext(ctx, getCoalesce)
-	var coalesce interface{}
+	var coalesce any
 	err := row.Scan(&coalesce)
 	return coalesce, err
 }
@@ -102,9 +102,9 @@ const getIfnull = `-- name: GetIfnull :one
 SELECT ifnull(1, 2)
 `
 
-func (q *Queries) GetIfnull(ctx context.Context) (interface{}, error) {
+func (q *Queries) GetIfnull(ctx context.Context) (any, error) {
 	row := q.db.QueryRowContext(ctx, getIfnull)
-	var ifnull interface{}
+	var ifnull any
 	err := row.Scan(&ifnull)
 	return ifnull, err
 }
@@ -113,9 +113,9 @@ const getIif = `-- name: GetIif :one
 SELECT iif(1, 2, 3)
 `
 
-func (q *Queries) GetIif(ctx context.Context) (interface{}, error) {
+func (q *Queries) GetIif(ctx context.Context) (any, error) {
 	row := q.db.QueryRowContext(ctx, getIif)
-	var iif interface{}
+	var iif any
 	err := row.Scan(&iif)
 	return iif, err
 }
@@ -179,9 +179,9 @@ const getLikelihood = `-- name: GetLikelihood :one
 SELECT likelihood('12345', 0.5)
 `
 
-func (q *Queries) GetLikelihood(ctx context.Context) (interface{}, error) {
+func (q *Queries) GetLikelihood(ctx context.Context) (any, error) {
 	row := q.db.QueryRowContext(ctx, getLikelihood)
-	var likelihood interface{}
+	var likelihood any
 	err := row.Scan(&likelihood)
 	return likelihood, err
 }
@@ -190,9 +190,9 @@ const getLikely = `-- name: GetLikely :one
 SELECT likely('12345')
 `
 
-func (q *Queries) GetLikely(ctx context.Context) (interface{}, error) {
+func (q *Queries) GetLikely(ctx context.Context) (any, error) {
 	row := q.db.QueryRowContext(ctx, getLikely)
-	var likely interface{}
+	var likely any
 	err := row.Scan(&likely)
 	return likely, err
 }
@@ -234,9 +234,9 @@ const getMax3 = `-- name: GetMax3 :one
 SELECT max(1, 3, 2)
 `
 
-func (q *Queries) GetMax3(ctx context.Context) (interface{}, error) {
+func (q *Queries) GetMax3(ctx context.Context) (any, error) {
 	row := q.db.QueryRowContext(ctx, getMax3)
-	var max interface{}
+	var max any
 	err := row.Scan(&max)
 	return max, err
 }
@@ -245,9 +245,9 @@ const getMin3 = `-- name: GetMin3 :one
 SELECT min(1, 3, 2)
 `
 
-func (q *Queries) GetMin3(ctx context.Context) (interface{}, error) {
+func (q *Queries) GetMin3(ctx context.Context) (any, error) {
 	row := q.db.QueryRowContext(ctx, getMin3)
-	var min interface{}
+	var min any
 	err := row.Scan(&min)
 	return min, err
 }
@@ -256,9 +256,9 @@ const getNullif = `-- name: GetNullif :one
 SELECT nullif(1, 2)
 `
 
-func (q *Queries) GetNullif(ctx context.Context) (interface{}, error) {
+func (q *Queries) GetNullif(ctx context.Context) (any, error) {
 	row := q.db.QueryRowContext(ctx, getNullif)
-	var nullif interface{}
+	var nullif any
 	err := row.Scan(&nullif)
 	return nullif, err
 }
@@ -289,9 +289,9 @@ const getRandom = `-- name: GetRandom :one
 SELECT random()
 `
 
-func (q *Queries) GetRandom(ctx context.Context) (interface{}, error) {
+func (q *Queries) GetRandom(ctx context.Context) (any, error) {
 	row := q.db.QueryRowContext(ctx, getRandom)
-	var random interface{}
+	var random any
 	err := row.Scan(&random)
 	return random, err
 }
@@ -300,9 +300,9 @@ const getRandomBlob = `-- name: GetRandomBlob :one
 SELECT randomblob(16)
 `
 
-func (q *Queries) GetRandomBlob(ctx context.Context) (interface{}, error) {
+func (q *Queries) GetRandomBlob(ctx context.Context) (any, error) {
 	row := q.db.QueryRowContext(ctx, getRandomBlob)
-	var randomblob interface{}
+	var randomblob any
 	err := row.Scan(&randomblob)
 	return randomblob, err
 }
@@ -531,9 +531,9 @@ const getUnlikely = `-- name: GetUnlikely :one
 SELECT unlikely('12345')
 `
 
-func (q *Queries) GetUnlikely(ctx context.Context) (interface{}, error) {
+func (q *Queries) GetUnlikely(ctx context.Context) (any, error) {
 	row := q.db.QueryRowContext(ctx, getUnlikely)
-	var unlikely interface{}
+	var unlikely any
 	err := row.Scan(&unlikely)
 	return unlikely, err
 }

--- a/internal/endtoend/testdata/case_named_params/sqlite/go/db.go
+++ b/internal/endtoend/testdata/case_named_params/sqlite/go/db.go
@@ -10,10 +10,10 @@ import (
 )
 
 type DBTX interface {
-	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
 	PrepareContext(context.Context, string) (*sql.Stmt, error)
-	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
-	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/case_named_params/sqlite/go/models.go
+++ b/internal/endtoend/testdata/case_named_params/sqlite/go/models.go
@@ -10,8 +10,8 @@ import (
 
 type Author struct {
 	ID       int64
-	Username interface{}
-	Email    interface{}
+	Username any
+	Email    any
 	Name     string
 	Bio      sql.NullString
 }

--- a/internal/endtoend/testdata/case_named_params/sqlite/go/query.sql.go
+++ b/internal/endtoend/testdata/case_named_params/sqlite/go/query.sql.go
@@ -18,8 +18,8 @@ LIMIT   1
 `
 
 type ListAuthorsParams struct {
-	Email    interface{}
-	Username interface{}
+	Email    any
+	Username any
 }
 
 func (q *Queries) ListAuthors(ctx context.Context, arg ListAuthorsParams) (Author, error) {

--- a/internal/endtoend/testdata/case_sensitive/sqlite/go/db.go
+++ b/internal/endtoend/testdata/case_sensitive/sqlite/go/db.go
@@ -10,10 +10,10 @@ import (
 )
 
 type DBTX interface {
-	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
 	PrepareContext(context.Context, string) (*sql.Stmt, error)
-	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
-	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/cast_param/sqlite/go/db.go
+++ b/internal/endtoend/testdata/cast_param/sqlite/go/db.go
@@ -10,10 +10,10 @@ import (
 )
 
 type DBTX interface {
-	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
 	PrepareContext(context.Context, string) (*sql.Stmt, error)
-	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
-	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/coalesce/sqlite/go/db.go
+++ b/internal/endtoend/testdata/coalesce/sqlite/go/db.go
@@ -10,10 +10,10 @@ import (
 )
 
 type DBTX interface {
-	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
 	PrepareContext(context.Context, string) (*sql.Stmt, error)
-	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
-	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/coalesce_as/sqlite/go/db.go
+++ b/internal/endtoend/testdata/coalesce_as/sqlite/go/db.go
@@ -10,10 +10,10 @@ import (
 )
 
 type DBTX interface {
-	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
 	PrepareContext(context.Context, string) (*sql.Stmt, error)
-	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
-	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/coalesce_as/sqlite/go/query.sql.go
+++ b/internal/endtoend/testdata/coalesce_as/sqlite/go/query.sql.go
@@ -18,7 +18,7 @@ GROUP BY 1
 
 type SumBazRow struct {
 	Bar      sql.NullString
-	Quantity interface{}
+	Quantity any
 }
 
 func (q *Queries) SumBaz(ctx context.Context) ([]SumBazRow, error) {

--- a/internal/endtoend/testdata/column_as/sqlite/go/db.go
+++ b/internal/endtoend/testdata/column_as/sqlite/go/db.go
@@ -10,10 +10,10 @@ import (
 )
 
 type DBTX interface {
-	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
 	PrepareContext(context.Context, string) (*sql.Stmt, error)
-	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
-	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/comment_syntax/sqlite/go/db.go
+++ b/internal/endtoend/testdata/comment_syntax/sqlite/go/db.go
@@ -10,10 +10,10 @@ import (
 )
 
 type DBTX interface {
-	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
 	PrepareContext(context.Context, string) (*sql.Stmt, error)
-	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
-	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/comparisons/sqlite/go/db.go
+++ b/internal/endtoend/testdata/comparisons/sqlite/go/db.go
@@ -10,10 +10,10 @@ import (
 )
 
 type DBTX interface {
-	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
 	PrepareContext(context.Context, string) (*sql.Stmt, error)
-	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
-	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/count_star/sqlite/go/db.go
+++ b/internal/endtoend/testdata/count_star/sqlite/go/db.go
@@ -10,10 +10,10 @@ import (
 )
 
 type DBTX interface {
-	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
 	PrepareContext(context.Context, string) (*sql.Stmt, error)
-	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
-	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/create_view/sqlite/go/db.go
+++ b/internal/endtoend/testdata/create_view/sqlite/go/db.go
@@ -10,10 +10,10 @@ import (
 )
 
 type DBTX interface {
-	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
 	PrepareContext(context.Context, string) (*sql.Stmt, error)
-	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
-	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/data_type_boolean/sqlite/db/db.go
+++ b/internal/endtoend/testdata/data_type_boolean/sqlite/db/db.go
@@ -10,10 +10,10 @@ import (
 )
 
 type DBTX interface {
-	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
 	PrepareContext(context.Context, string) (*sql.Stmt, error)
-	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
-	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/datatype/sqlite/go/db.go
+++ b/internal/endtoend/testdata/datatype/sqlite/go/db.go
@@ -10,10 +10,10 @@ import (
 )
 
 type DBTX interface {
-	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
 	PrepareContext(context.Context, string) (*sql.Stmt, error)
-	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
-	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/ddl_alter_table_add_column/sqlite/go/db.go
+++ b/internal/endtoend/testdata/ddl_alter_table_add_column/sqlite/go/db.go
@@ -10,10 +10,10 @@ import (
 )
 
 type DBTX interface {
-	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
 	PrepareContext(context.Context, string) (*sql.Stmt, error)
-	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
-	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/ddl_alter_table_case_sensitivity/sqlite/go/db.go
+++ b/internal/endtoend/testdata/ddl_alter_table_case_sensitivity/sqlite/go/db.go
@@ -10,10 +10,10 @@ import (
 )
 
 type DBTX interface {
-	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
 	PrepareContext(context.Context, string) (*sql.Stmt, error)
-	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
-	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/ddl_alter_table_drop_column/sqlite/go/db.go
+++ b/internal/endtoend/testdata/ddl_alter_table_drop_column/sqlite/go/db.go
@@ -10,10 +10,10 @@ import (
 )
 
 type DBTX interface {
-	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
 	PrepareContext(context.Context, string) (*sql.Stmt, error)
-	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
-	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/ddl_alter_table_rename/sqlite/go/db.go
+++ b/internal/endtoend/testdata/ddl_alter_table_rename/sqlite/go/db.go
@@ -10,10 +10,10 @@ import (
 )
 
 type DBTX interface {
-	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
 	PrepareContext(context.Context, string) (*sql.Stmt, error)
-	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
-	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/ddl_alter_table_rename_column/sqlite/go/db.go
+++ b/internal/endtoend/testdata/ddl_alter_table_rename_column/sqlite/go/db.go
@@ -10,10 +10,10 @@ import (
 )
 
 type DBTX interface {
-	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
 	PrepareContext(context.Context, string) (*sql.Stmt, error)
-	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
-	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/ddl_create_table/sqlite/go/db.go
+++ b/internal/endtoend/testdata/ddl_create_table/sqlite/go/db.go
@@ -10,10 +10,10 @@ import (
 )
 
 type DBTX interface {
-	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
 	PrepareContext(context.Context, string) (*sql.Stmt, error)
-	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
-	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/ddl_create_table_strict/sqlite/go/db.go
+++ b/internal/endtoend/testdata/ddl_create_table_strict/sqlite/go/db.go
@@ -10,10 +10,10 @@ import (
 )
 
 type DBTX interface {
-	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
 	PrepareContext(context.Context, string) (*sql.Stmt, error)
-	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
-	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/ddl_create_table_without_rowid/sqlite/go/db.go
+++ b/internal/endtoend/testdata/ddl_create_table_without_rowid/sqlite/go/db.go
@@ -10,10 +10,10 @@ import (
 )
 
 type DBTX interface {
-	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
 	PrepareContext(context.Context, string) (*sql.Stmt, error)
-	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
-	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/ddl_create_trigger/sqlite/go/db.go
+++ b/internal/endtoend/testdata/ddl_create_trigger/sqlite/go/db.go
@@ -10,10 +10,10 @@ import (
 )
 
 type DBTX interface {
-	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
 	PrepareContext(context.Context, string) (*sql.Stmt, error)
-	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
-	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/ddl_drop_table/sqlite/go/db.go
+++ b/internal/endtoend/testdata/ddl_drop_table/sqlite/go/db.go
@@ -10,10 +10,10 @@ import (
 )
 
 type DBTX interface {
-	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
 	PrepareContext(context.Context, string) (*sql.Stmt, error)
-	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
-	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/ddl_drop_table_if_exists/sqlite/go/db.go
+++ b/internal/endtoend/testdata/ddl_drop_table_if_exists/sqlite/go/db.go
@@ -10,10 +10,10 @@ import (
 )
 
 type DBTX interface {
-	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
 	PrepareContext(context.Context, string) (*sql.Stmt, error)
-	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
-	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/delete_from/sqlite/go/db.go
+++ b/internal/endtoend/testdata/delete_from/sqlite/go/db.go
@@ -10,10 +10,10 @@ import (
 )
 
 type DBTX interface {
-	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
 	PrepareContext(context.Context, string) (*sql.Stmt, error)
-	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
-	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/emit_db_and_json_tags/sqlite/go/db.go
+++ b/internal/endtoend/testdata/emit_db_and_json_tags/sqlite/go/db.go
@@ -10,10 +10,10 @@ import (
 )
 
 type DBTX interface {
-	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
 	PrepareContext(context.Context, string) (*sql.Stmt, error)
-	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
-	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/emit_db_tags/sqlite/go/db.go
+++ b/internal/endtoend/testdata/emit_db_tags/sqlite/go/db.go
@@ -10,10 +10,10 @@ import (
 )
 
 type DBTX interface {
-	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
 	PrepareContext(context.Context, string) (*sql.Stmt, error)
-	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
-	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/emit_methods_with_db_argument/sqlite/go/db.go
+++ b/internal/endtoend/testdata/emit_methods_with_db_argument/sqlite/go/db.go
@@ -10,10 +10,10 @@ import (
 )
 
 type DBTX interface {
-	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
 	PrepareContext(context.Context, string) (*sql.Stmt, error)
-	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
-	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
 }
 
 func New() *Queries {

--- a/internal/endtoend/testdata/emit_pointers_for_null_types/sqlite/go/db.go
+++ b/internal/endtoend/testdata/emit_pointers_for_null_types/sqlite/go/db.go
@@ -10,10 +10,10 @@ import (
 )
 
 type DBTX interface {
-	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
 	PrepareContext(context.Context, string) (*sql.Stmt, error)
-	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
-	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/exec_create_table/sqlite/db/db.go
+++ b/internal/endtoend/testdata/exec_create_table/sqlite/db/db.go
@@ -10,10 +10,10 @@ import (
 )
 
 type DBTX interface {
-	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
 	PrepareContext(context.Context, string) (*sql.Stmt, error)
-	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
-	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/full_outer_join/sqlite/go/db.go
+++ b/internal/endtoend/testdata/full_outer_join/sqlite/go/db.go
@@ -10,10 +10,10 @@ import (
 )
 
 type DBTX interface {
-	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
 	PrepareContext(context.Context, string) (*sql.Stmt, error)
-	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
-	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/func_call_cast/sqlite/go/db.go
+++ b/internal/endtoend/testdata/func_call_cast/sqlite/go/db.go
@@ -10,10 +10,10 @@ import (
 )
 
 type DBTX interface {
-	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
 	PrepareContext(context.Context, string) (*sql.Stmt, error)
-	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
-	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/func_match_types/sqlite/go/db.go
+++ b/internal/endtoend/testdata/func_match_types/sqlite/go/db.go
@@ -10,10 +10,10 @@ import (
 )
 
 type DBTX interface {
-	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
 	PrepareContext(context.Context, string) (*sql.Stmt, error)
-	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
-	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/identical_tables/sqlite/go/db.go
+++ b/internal/endtoend/testdata/identical_tables/sqlite/go/db.go
@@ -10,10 +10,10 @@ import (
 )
 
 type DBTX interface {
-	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
 	PrepareContext(context.Context, string) (*sql.Stmt, error)
-	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
-	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/inflection/sqlite/go/db.go
+++ b/internal/endtoend/testdata/inflection/sqlite/go/db.go
@@ -10,10 +10,10 @@ import (
 )
 
 type DBTX interface {
-	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
 	PrepareContext(context.Context, string) (*sql.Stmt, error)
-	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
-	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/insert_default_values/sqlite/go/db.go
+++ b/internal/endtoend/testdata/insert_default_values/sqlite/go/db.go
@@ -10,10 +10,10 @@ import (
 )
 
 type DBTX interface {
-	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
 	PrepareContext(context.Context, string) (*sql.Stmt, error)
-	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
-	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/insert_select/sqlite/go/db.go
+++ b/internal/endtoend/testdata/insert_select/sqlite/go/db.go
@@ -10,10 +10,10 @@ import (
 )
 
 type DBTX interface {
-	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
 	PrepareContext(context.Context, string) (*sql.Stmt, error)
-	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
-	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/insert_values/sqlite/go/db.go
+++ b/internal/endtoend/testdata/insert_values/sqlite/go/db.go
@@ -10,10 +10,10 @@ import (
 )
 
 type DBTX interface {
-	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
 	PrepareContext(context.Context, string) (*sql.Stmt, error)
-	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
-	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/join_alias/sqlite/go/db.go
+++ b/internal/endtoend/testdata/join_alias/sqlite/go/db.go
@@ -10,10 +10,10 @@ import (
 )
 
 type DBTX interface {
-	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
 	PrepareContext(context.Context, string) (*sql.Stmt, error)
-	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
-	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/join_from/sqlite/go/db.go
+++ b/internal/endtoend/testdata/join_from/sqlite/go/db.go
@@ -10,10 +10,10 @@ import (
 )
 
 type DBTX interface {
-	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
 	PrepareContext(context.Context, string) (*sql.Stmt, error)
-	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
-	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/join_left/sqlite/go/db.go
+++ b/internal/endtoend/testdata/join_left/sqlite/go/db.go
@@ -10,10 +10,10 @@ import (
 )
 
 type DBTX interface {
-	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
 	PrepareContext(context.Context, string) (*sql.Stmt, error)
-	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
-	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/join_left_same_table/sqlite/go/db.go
+++ b/internal/endtoend/testdata/join_left_same_table/sqlite/go/db.go
@@ -10,10 +10,10 @@ import (
 )
 
 type DBTX interface {
-	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
 	PrepareContext(context.Context, string) (*sql.Stmt, error)
-	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
-	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/join_table_name/sqlite/go/db.go
+++ b/internal/endtoend/testdata/join_table_name/sqlite/go/db.go
@@ -10,10 +10,10 @@ import (
 )
 
 type DBTX interface {
-	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
 	PrepareContext(context.Context, string) (*sql.Stmt, error)
-	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
-	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/join_two_tables/sqlite/go/db.go
+++ b/internal/endtoend/testdata/join_two_tables/sqlite/go/db.go
@@ -10,10 +10,10 @@ import (
 )
 
 type DBTX interface {
-	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
 	PrepareContext(context.Context, string) (*sql.Stmt, error)
-	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
-	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/join_where_clause/sqlite/go/db.go
+++ b/internal/endtoend/testdata/join_where_clause/sqlite/go/db.go
@@ -10,10 +10,10 @@ import (
 )
 
 type DBTX interface {
-	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
 	PrepareContext(context.Context, string) (*sql.Stmt, error)
-	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
-	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/json_param_type/sqlite/go/db.go
+++ b/internal/endtoend/testdata/json_param_type/sqlite/go/db.go
@@ -10,10 +10,10 @@ import (
 )
 
 type DBTX interface {
-	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
 	PrepareContext(context.Context, string) (*sql.Stmt, error)
-	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
-	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/jsonb/sqlite/go/db.go
+++ b/internal/endtoend/testdata/jsonb/sqlite/go/db.go
@@ -10,10 +10,10 @@ import (
 )
 
 type DBTX interface {
-	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
 	PrepareContext(context.Context, string) (*sql.Stmt, error)
-	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
-	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/limit/sqlite/go/db.go
+++ b/internal/endtoend/testdata/limit/sqlite/go/db.go
@@ -10,10 +10,10 @@ import (
 )
 
 type DBTX interface {
-	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
 	PrepareContext(context.Context, string) (*sql.Stmt, error)
-	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
-	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/named_param/sqlite/go/db.go
+++ b/internal/endtoend/testdata/named_param/sqlite/go/db.go
@@ -10,10 +10,10 @@ import (
 )
 
 type DBTX interface {
-	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
 	PrepareContext(context.Context, string) (*sql.Stmt, error)
-	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
-	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/overrides/sqlite/go/db.go
+++ b/internal/endtoend/testdata/overrides/sqlite/go/db.go
@@ -10,10 +10,10 @@ import (
 )
 
 type DBTX interface {
-	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
 	PrepareContext(context.Context, string) (*sql.Stmt, error)
-	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
-	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/overrides_go_struct_tags/sqlite/go/db.go
+++ b/internal/endtoend/testdata/overrides_go_struct_tags/sqlite/go/db.go
@@ -10,10 +10,10 @@ import (
 )
 
 type DBTX interface {
-	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
 	PrepareContext(context.Context, string) (*sql.Stmt, error)
-	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
-	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/overrides_go_types/sqlite/go/db.go
+++ b/internal/endtoend/testdata/overrides_go_types/sqlite/go/db.go
@@ -10,10 +10,10 @@ import (
 )
 
 type DBTX interface {
-	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
 	PrepareContext(context.Context, string) (*sql.Stmt, error)
-	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
-	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/quoted_colname/sqlite/go/db.go
+++ b/internal/endtoend/testdata/quoted_colname/sqlite/go/db.go
@@ -10,10 +10,10 @@ import (
 )
 
 type DBTX interface {
-	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
 	PrepareContext(context.Context, string) (*sql.Stmt, error)
-	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
-	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/quoted_names_complex/sqlite/go/db.go
+++ b/internal/endtoend/testdata/quoted_names_complex/sqlite/go/db.go
@@ -10,10 +10,10 @@ import (
 )
 
 type DBTX interface {
-	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
 	PrepareContext(context.Context, string) (*sql.Stmt, error)
-	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
-	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/quoted_tablename/sqlite/go/db.go
+++ b/internal/endtoend/testdata/quoted_tablename/sqlite/go/db.go
@@ -10,10 +10,10 @@ import (
 )
 
 type DBTX interface {
-	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
 	PrepareContext(context.Context, string) (*sql.Stmt, error)
-	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
-	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/returning/sqlite/go/db.go
+++ b/internal/endtoend/testdata/returning/sqlite/go/db.go
@@ -10,10 +10,10 @@ import (
 )
 
 type DBTX interface {
-	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
 	PrepareContext(context.Context, string) (*sql.Stmt, error)
-	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
-	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/select_column_cast/sqlite/go/db.go
+++ b/internal/endtoend/testdata/select_column_cast/sqlite/go/db.go
@@ -10,10 +10,10 @@ import (
 )
 
 type DBTX interface {
-	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
 	PrepareContext(context.Context, string) (*sql.Stmt, error)
-	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
-	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/select_cte/sqlite/go/db.go
+++ b/internal/endtoend/testdata/select_cte/sqlite/go/db.go
@@ -10,10 +10,10 @@ import (
 )
 
 type DBTX interface {
-	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
 	PrepareContext(context.Context, string) (*sql.Stmt, error)
-	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
-	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/select_exists/sqlite/go/db.go
+++ b/internal/endtoend/testdata/select_exists/sqlite/go/db.go
@@ -10,10 +10,10 @@ import (
 )
 
 type DBTX interface {
-	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
 	PrepareContext(context.Context, string) (*sql.Stmt, error)
-	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
-	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/select_in_and/sqlite/go/db.go
+++ b/internal/endtoend/testdata/select_in_and/sqlite/go/db.go
@@ -10,10 +10,10 @@ import (
 )
 
 type DBTX interface {
-	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
 	PrepareContext(context.Context, string) (*sql.Stmt, error)
-	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
-	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/select_limit/sqlite/go/db.go
+++ b/internal/endtoend/testdata/select_limit/sqlite/go/db.go
@@ -10,10 +10,10 @@ import (
 )
 
 type DBTX interface {
-	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
 	PrepareContext(context.Context, string) (*sql.Stmt, error)
-	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
-	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/select_nested_count/sqlite/go/db.go
+++ b/internal/endtoend/testdata/select_nested_count/sqlite/go/db.go
@@ -10,10 +10,10 @@ import (
 )
 
 type DBTX interface {
-	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
 	PrepareContext(context.Context, string) (*sql.Stmt, error)
-	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
-	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/select_not_exists/sqlite/go/db.go
+++ b/internal/endtoend/testdata/select_not_exists/sqlite/go/db.go
@@ -10,10 +10,10 @@ import (
 )
 
 type DBTX interface {
-	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
 	PrepareContext(context.Context, string) (*sql.Stmt, error)
-	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
-	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/select_star/sqlite/go/db.go
+++ b/internal/endtoend/testdata/select_star/sqlite/go/db.go
@@ -10,10 +10,10 @@ import (
 )
 
 type DBTX interface {
-	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
 	PrepareContext(context.Context, string) (*sql.Stmt, error)
-	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
-	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/select_subquery_no_alias/sqlite/go/db.go
+++ b/internal/endtoend/testdata/select_subquery_no_alias/sqlite/go/db.go
@@ -10,10 +10,10 @@ import (
 )
 
 type DBTX interface {
-	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
 	PrepareContext(context.Context, string) (*sql.Stmt, error)
-	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
-	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/select_union/sqlite/go/db.go
+++ b/internal/endtoend/testdata/select_union/sqlite/go/db.go
@@ -10,10 +10,10 @@ import (
 )
 
 type DBTX interface {
-	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
 	PrepareContext(context.Context, string) (*sql.Stmt, error)
-	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
-	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/single_param_conflict/sqlite/go/db.go
+++ b/internal/endtoend/testdata/single_param_conflict/sqlite/go/db.go
@@ -10,10 +10,10 @@ import (
 )
 
 type DBTX interface {
-	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
 	PrepareContext(context.Context, string) (*sql.Stmt, error)
-	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
-	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/sqlc_arg/sqlite/go/db.go
+++ b/internal/endtoend/testdata/sqlc_arg/sqlite/go/db.go
@@ -10,10 +10,10 @@ import (
 )
 
 type DBTX interface {
-	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
 	PrepareContext(context.Context, string) (*sql.Stmt, error)
-	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
-	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/sqlc_embed/sqlite/go/db.go
+++ b/internal/endtoend/testdata/sqlc_embed/sqlite/go/db.go
@@ -10,10 +10,10 @@ import (
 )
 
 type DBTX interface {
-	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
 	PrepareContext(context.Context, string) (*sql.Stmt, error)
-	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
-	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/sqlc_narg/sqlite/go/db.go
+++ b/internal/endtoend/testdata/sqlc_narg/sqlite/go/db.go
@@ -10,10 +10,10 @@ import (
 )
 
 type DBTX interface {
-	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
 	PrepareContext(context.Context, string) (*sql.Stmt, error)
-	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
-	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/sqlc_slice/sqlite/go/db.go
+++ b/internal/endtoend/testdata/sqlc_slice/sqlite/go/db.go
@@ -10,10 +10,10 @@ import (
 )
 
 type DBTX interface {
-	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
 	PrepareContext(context.Context, string) (*sql.Stmt, error)
-	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
-	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/sqlc_slice/sqlite/go/query.sql.go
+++ b/internal/endtoend/testdata/sqlc_slice/sqlite/go/query.sql.go
@@ -18,7 +18,7 @@ WHERE id IN (/*SLICE:favourites*/?)
 
 func (q *Queries) FuncNullable(ctx context.Context, favourites []int64) ([]sql.NullString, error) {
 	query := funcNullable
-	var queryParams []interface{}
+	var queryParams []any
 	if len(favourites) > 0 {
 		for _, v := range favourites {
 			queryParams = append(queryParams, v)
@@ -56,7 +56,7 @@ WHERE id NOT IN (/*SLICE:favourites*/?)
 
 func (q *Queries) FuncNullableNot(ctx context.Context, favourites []int64) ([]sql.NullString, error) {
 	query := funcNullableNot
-	var queryParams []interface{}
+	var queryParams []any
 	if len(favourites) > 0 {
 		for _, v := range favourites {
 			queryParams = append(queryParams, v)
@@ -100,7 +100,7 @@ type FuncParamIdentParams struct {
 
 func (q *Queries) FuncParamIdent(ctx context.Context, arg FuncParamIdentParams) ([]string, error) {
 	query := funcParamIdent
-	var queryParams []interface{}
+	var queryParams []any
 	queryParams = append(queryParams, arg.Slug)
 	if len(arg.Favourites) > 0 {
 		for _, v := range arg.Favourites {
@@ -139,7 +139,7 @@ WHERE id IN (/*SLICE:favourites*/?)
 
 func (q *Queries) FuncParamSoloArg(ctx context.Context, favourites []int64) ([]string, error) {
 	query := funcParamSoloArg
-	var queryParams []interface{}
+	var queryParams []any
 	if len(favourites) > 0 {
 		for _, v := range favourites {
 			queryParams = append(queryParams, v)
@@ -183,7 +183,7 @@ type FuncParamStringParams struct {
 
 func (q *Queries) FuncParamString(ctx context.Context, arg FuncParamStringParams) ([]string, error) {
 	query := funcParamString
-	var queryParams []interface{}
+	var queryParams []any
 	queryParams = append(queryParams, arg.Slug)
 	if len(arg.Favourites) > 0 {
 		for _, v := range arg.Favourites {
@@ -227,7 +227,7 @@ type SliceExecParams struct {
 
 func (q *Queries) SliceExec(ctx context.Context, arg SliceExecParams) error {
 	query := sliceExec
-	var queryParams []interface{}
+	var queryParams []any
 	queryParams = append(queryParams, arg.Slug)
 	if len(arg.Favourites) > 0 {
 		for _, v := range arg.Favourites {

--- a/internal/endtoend/testdata/sqlc_slice_prepared/sqlite/go/db.go
+++ b/internal/endtoend/testdata/sqlc_slice_prepared/sqlite/go/db.go
@@ -11,10 +11,10 @@ import (
 )
 
 type DBTX interface {
-	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
 	PrepareContext(context.Context, string) (*sql.Stmt, error)
-	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
-	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
 }
 
 func New(db DBTX) *Queries {
@@ -40,7 +40,7 @@ func (q *Queries) Close() error {
 	return err
 }
 
-func (q *Queries) exec(ctx context.Context, stmt *sql.Stmt, query string, args ...interface{}) (sql.Result, error) {
+func (q *Queries) exec(ctx context.Context, stmt *sql.Stmt, query string, args ...any) (sql.Result, error) {
 	switch {
 	case stmt != nil && q.tx != nil:
 		return q.tx.StmtContext(ctx, stmt).ExecContext(ctx, args...)
@@ -51,7 +51,7 @@ func (q *Queries) exec(ctx context.Context, stmt *sql.Stmt, query string, args .
 	}
 }
 
-func (q *Queries) query(ctx context.Context, stmt *sql.Stmt, query string, args ...interface{}) (*sql.Rows, error) {
+func (q *Queries) query(ctx context.Context, stmt *sql.Stmt, query string, args ...any) (*sql.Rows, error) {
 	switch {
 	case stmt != nil && q.tx != nil:
 		return q.tx.StmtContext(ctx, stmt).QueryContext(ctx, args...)
@@ -62,7 +62,7 @@ func (q *Queries) query(ctx context.Context, stmt *sql.Stmt, query string, args 
 	}
 }
 
-func (q *Queries) queryRow(ctx context.Context, stmt *sql.Stmt, query string, args ...interface{}) *sql.Row {
+func (q *Queries) queryRow(ctx context.Context, stmt *sql.Stmt, query string, args ...any) *sql.Row {
 	switch {
 	case stmt != nil && q.tx != nil:
 		return q.tx.StmtContext(ctx, stmt).QueryRowContext(ctx, args...)

--- a/internal/endtoend/testdata/sqlc_slice_prepared/sqlite/go/query.sql.go
+++ b/internal/endtoend/testdata/sqlc_slice_prepared/sqlite/go/query.sql.go
@@ -23,7 +23,7 @@ type FuncParamIdentParams struct {
 
 func (q *Queries) FuncParamIdent(ctx context.Context, arg FuncParamIdentParams) ([]string, error) {
 	query := funcParamIdent
-	var queryParams []interface{}
+	var queryParams []any
 	queryParams = append(queryParams, arg.Slug)
 	if len(arg.Favourites) > 0 {
 		for _, v := range arg.Favourites {

--- a/internal/endtoend/testdata/sqlite_table_options/sqlite/go/db.go
+++ b/internal/endtoend/testdata/sqlite_table_options/sqlite/go/db.go
@@ -10,10 +10,10 @@ import (
 )
 
 type DBTX interface {
-	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
 	PrepareContext(context.Context, string) (*sql.Stmt, error)
-	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
-	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/star_expansion/sqlite/go/db.go
+++ b/internal/endtoend/testdata/star_expansion/sqlite/go/db.go
@@ -10,10 +10,10 @@ import (
 )
 
 type DBTX interface {
-	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
 	PrepareContext(context.Context, string) (*sql.Stmt, error)
-	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
-	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/subquery_calculated_column/sqlite/go/db.go
+++ b/internal/endtoend/testdata/subquery_calculated_column/sqlite/go/db.go
@@ -10,10 +10,10 @@ import (
 )
 
 type DBTX interface {
-	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
 	PrepareContext(context.Context, string) (*sql.Stmt, error)
-	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
-	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/table_function/sqlite/go/db.go
+++ b/internal/endtoend/testdata/table_function/sqlite/go/db.go
@@ -10,10 +10,10 @@ import (
 )
 
 type DBTX interface {
-	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
 	PrepareContext(context.Context, string) (*sql.Stmt, error)
-	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
-	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/table_function/sqlite/go/query.sql.go
+++ b/internal/endtoend/testdata/table_function/sqlite/go/query.sql.go
@@ -31,8 +31,8 @@ type GetTransactionParams struct {
 }
 
 type GetTransactionRow struct {
-	JsonExtract    interface{}
-	JsonGroupArray interface{}
+	JsonExtract    any
+	JsonGroupArray any
 }
 
 func (q *Queries) GetTransaction(ctx context.Context, arg GetTransactionParams) ([]GetTransactionRow, error) {

--- a/internal/endtoend/testdata/table_name_case_sensitivity/sqlite/go/db.go
+++ b/internal/endtoend/testdata/table_name_case_sensitivity/sqlite/go/db.go
@@ -10,10 +10,10 @@ import (
 )
 
 type DBTX interface {
-	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
 	PrepareContext(context.Context, string) (*sql.Stmt, error)
-	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
-	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/untyped_columns/sqlite/stdlib/db/db.go
+++ b/internal/endtoend/testdata/untyped_columns/sqlite/stdlib/db/db.go
@@ -10,10 +10,10 @@ import (
 )
 
 type DBTX interface {
-	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
 	PrepareContext(context.Context, string) (*sql.Stmt, error)
-	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
-	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/untyped_columns/sqlite/stdlib/db/models.go
+++ b/internal/endtoend/testdata/untyped_columns/sqlite/stdlib/db/models.go
@@ -5,7 +5,7 @@
 package db
 
 type Repro struct {
-	ID   interface{}
-	Name interface{}
-	Seq  interface{}
+	ID   any
+	Name any
+	Seq  any
 }

--- a/internal/endtoend/testdata/untyped_columns/sqlite/stdlib/db/query.sql.go
+++ b/internal/endtoend/testdata/untyped_columns/sqlite/stdlib/db/query.sql.go
@@ -13,7 +13,7 @@ const getRepro = `-- name: GetRepro :one
 select id, name, seq from repro where id = ? limit 1
 `
 
-func (q *Queries) GetRepro(ctx context.Context, id interface{}) (Repro, error) {
+func (q *Queries) GetRepro(ctx context.Context, id any) (Repro, error) {
 	row := q.db.QueryRowContext(ctx, getRepro, id)
 	var i Repro
 	err := row.Scan(&i.ID, &i.Name, &i.Seq)

--- a/internal/endtoend/testdata/update_set/sqlite/go/db.go
+++ b/internal/endtoend/testdata/update_set/sqlite/go/db.go
@@ -10,10 +10,10 @@ import (
 )
 
 type DBTX interface {
-	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
 	PrepareContext(context.Context, string) (*sql.Stmt, error)
-	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
-	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/update_set_multiple/sqlite/go/db.go
+++ b/internal/endtoend/testdata/update_set_multiple/sqlite/go/db.go
@@ -10,10 +10,10 @@ import (
 )
 
 type DBTX interface {
-	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
 	PrepareContext(context.Context, string) (*sql.Stmt, error)
-	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
-	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/upsert/sqlite/go/db.go
+++ b/internal/endtoend/testdata/upsert/sqlite/go/db.go
@@ -10,10 +10,10 @@ import (
 )
 
 type DBTX interface {
-	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
 	PrepareContext(context.Context, string) (*sql.Stmt, error)
-	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
-	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/virtual_table/sqlite/go/db.go
+++ b/internal/endtoend/testdata/virtual_table/sqlite/go/db.go
@@ -10,10 +10,10 @@ import (
 )
 
 type DBTX interface {
-	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
 	PrepareContext(context.Context, string) (*sql.Stmt, error)
-	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
-	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/where_collate/sqlite/go/db.go
+++ b/internal/endtoend/testdata/where_collate/sqlite/go/db.go
@@ -10,10 +10,10 @@ import (
 )
 
 type DBTX interface {
-	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
 	PrepareContext(context.Context, string) (*sql.Stmt, error)
-	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
-	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/wrap_errors/sqlite/db/db.go
+++ b/internal/endtoend/testdata/wrap_errors/sqlite/db/db.go
@@ -10,10 +10,10 @@ import (
 )
 
 type DBTX interface {
-	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
 	PrepareContext(context.Context, string) (*sql.Stmt, error)
-	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
-	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
 }
 
 func New(db DBTX) *Queries {


### PR DESCRIPTION
Replaces all auto-generated `interface{}` with `any` in Go/SQLite code generation templates and type mapping functions. This is the modern Go idiom since Go 1.18 (`any` is a built-in alias for `interface{}`).

### Changes:
- `sqlite_type.go`: return `any` instead of `interface{}` for SQLite `any` type and unknown type default case
- `go_type.go`: return `any` instead of `interface{}` for unknown engine default case
- `result.go`: update type comparison from `interface{}` to `any`
- `template.tmpl`: Scan() methods use `any` parameter type
- `stdlib/queryCode.tmpl`: use `[]any` instead of `[]interface{}`
- `stdlib/dbCode.tmpl`: DBTX interface and helpers use `...any`
- Update all SQLite endtoend test golden files

Closes #4470