### PR TITLE
fix(sqlite): translate antlr rune offsets to byte offsets

### DIFF
--- a/internal/engine/sqlite/convert.go
+++ b/internal/engine/sqlite/convert.go
@@ -14,6 +14,25 @@ import (
 
 type cc struct {
 	paramCount int
+
+	// convertPos maps a rune index (as reported by antlr) to a byte offset in
+	// the original source. The compiler treats all node locations as byte
+	// offsets, so every Location must be routed through pos. May be nil in
+	// tests, in which case offsets are passed through unchanged.
+	convertPos func(int) int
+}
+
+// pos translates an antlr rune offset into the byte offset the rest of sqlc
+// expects when slicing the source SQL (see source.Pluck / source.Mutate).
+func (c *cc) pos(tok antlr.Token) int {
+	if tok == nil {
+		return 0
+	}
+	start := tok.GetStart()
+	if c.convertPos == nil {
+		return start
+	}
+	return c.convertPos(start)
 }
 
 type node interface {
@@ -286,7 +305,7 @@ func (c *cc) convertFuncContext(n *parser.Expr_functionContext) ast.Node {
 		if funcName == "coalesce" {
 			return &ast.CoalesceExpr{
 				Args:     args,
-				Location: name.GetStart().GetStart(),
+				Location: c.pos(name.GetStart()),
 			}
 		} else {
 			return &ast.FuncCall{
@@ -303,7 +322,7 @@ func (c *cc) convertFuncContext(n *parser.Expr_functionContext) ast.Node {
 				Args:        args,
 				AggOrder:    &ast.List{},
 				AggDistinct: n.DISTINCT_() != nil,
-				Location:    name.GetStart().GetStart(),
+				Location:    c.pos(name.GetStart()),
 			}
 		}
 	}
@@ -334,7 +353,7 @@ func (c *cc) convertColumnNameExpr(n *parser.Expr_qualified_column_nameContext) 
 		Fields: &ast.List{
 			Items: items,
 		},
-		Location: n.GetStart().GetStart(),
+		Location: c.pos(n.GetStart()),
 	}
 }
 
@@ -358,7 +377,7 @@ func (c *cc) convertComparison(n *parser.Expr_comparisonContext) ast.Node {
 			List:     rexprs,
 			Not:      false,
 			Sel:      nil,
-			Location: n.GetStart().GetStart(),
+			Location: c.pos(n.GetStart()),
 		}
 	}
 
@@ -386,7 +405,7 @@ func (c *cc) convertMultiSelect_stmtContext(n *parser.Select_stmtContext) ast.No
 			ctes.Items = append(ctes.Items, &ast.CommonTableExpr{
 				Ctename:      &tableName,
 				Ctequery:     c.convert(cte.Select_stmt()),
-				Location:     cte.GetStart().GetStart(),
+				Location:     c.pos(cte.GetStart()),
 				Cterecursive: recursive,
 				Ctecolnames:  &cteCols,
 			})
@@ -472,7 +491,7 @@ func (c *cc) convertMultiSelect_stmtContext(n *parser.Select_stmtContext) ast.No
 					FrameOptions:    0, // todo
 					StartOffset:     &ast.TODO{},
 					EndOffset:       &ast.TODO{},
-					Location:        windowNameCtx.GetStart().GetStart(),
+					Location:        c.pos(windowNameCtx.GetStart()),
 				})
 			}
 		}
@@ -580,7 +599,7 @@ func (c *cc) getCols(core *parser.Select_coreContext) []ast.Node {
 			continue
 		}
 		target := &ast.ResTarget{
-			Location: col.GetStart().GetStart(),
+			Location: c.pos(col.GetStart()),
 		}
 		var val ast.Node
 		iexpr := col.Expr()
@@ -617,7 +636,7 @@ func (c *cc) convertWildCardField(n *parser.Result_columnContext) *ast.ColumnRef
 		Fields: &ast.List{
 			Items: items,
 		},
-		Location: n.GetStart().GetStart(),
+		Location: c.pos(n.GetStart()),
 	}
 }
 
@@ -631,7 +650,7 @@ func (c *cc) convertOrderby_stmtContext(n parser.IOrder_by_stmtContext) ast.Node
 			}
 			list.Items = append(list.Items, &ast.CaseExpr{
 				Xpr:      c.convert(term.Expr()),
-				Location: term.Expr().GetStart().GetStart(),
+				Location: c.pos(term.Expr().GetStart()),
 			})
 		}
 		return list
@@ -738,7 +757,7 @@ func (c *cc) convertLiteral(n *parser.Expr_literalContext) ast.Node {
 			i, _ := strconv.ParseInt(literal.GetText(), 10, 64)
 			return &ast.A_Const{
 				Val:      &ast.Integer{Ival: i},
-				Location: n.GetStart().GetStart(),
+				Location: c.pos(n.GetStart()),
 			}
 		}
 
@@ -747,7 +766,7 @@ func (c *cc) convertLiteral(n *parser.Expr_literalContext) ast.Node {
 			text := literal.GetText()
 			return &ast.A_Const{
 				Val:      &ast.String{Str: text[1 : len(text)-1]},
-				Location: n.GetStart().GetStart(),
+				Location: c.pos(n.GetStart()),
 			}
 		}
 
@@ -759,14 +778,14 @@ func (c *cc) convertLiteral(n *parser.Expr_literalContext) ast.Node {
 
 			return &ast.A_Const{
 				Val:      &ast.Integer{Ival: i},
-				Location: n.GetStart().GetStart(),
+				Location: c.pos(n.GetStart()),
 			}
 		}
 
 		if literal.NULL_() != nil {
 			return &ast.A_Const{
 				Val:      &ast.Null{},
-				Location: n.GetStart().GetStart(),
+				Location: c.pos(n.GetStart()),
 			}
 		}
 	}
@@ -858,7 +877,7 @@ func (c *cc) convertParam(n *parser.Expr_bindContext) ast.Node {
 		}
 		return &ast.ParamRef{
 			Number:   number,
-			Location: n.GetStart().GetStart(),
+			Location: c.pos(n.GetStart()),
 			Dollar:   len(text) > 1,
 		}
 	}
@@ -867,7 +886,7 @@ func (c *cc) convertParam(n *parser.Expr_bindContext) ast.Node {
 		return &ast.A_Expr{
 			Name:     &ast.List{Items: []ast.Node{&ast.String{Str: "@"}}},
 			Rexpr:    &ast.String{Str: n.GetText()[1:]},
-			Location: n.GetStart().GetStart(),
+			Location: c.pos(n.GetStart()),
 		}
 	}
 
@@ -948,9 +967,9 @@ func (c *cc) convertReturning_caluseContext(n parser.IReturning_clauseContext) *
 				Fields: &ast.List{
 					Items: []ast.Node{&ast.A_Star{}},
 				},
-				Location: star.GetSymbol().GetStart(),
+				Location: c.pos(star.GetSymbol()),
 			},
-			Location: star.GetSymbol().GetStart(),
+			Location: c.pos(star.GetSymbol()),
 		})
 	}
 
@@ -1057,7 +1076,7 @@ func (c *cc) convertTablesOrSubquery(n []parser.ITable_or_subqueryContext) []ast
 			rel := identifier(from.Table_name().GetText())
 			rv := &ast.RangeVar{
 				Relname:  &rel,
-				Location: from.GetStart().GetStart(),
+				Location: c.pos(from.GetStart()),
 			}
 
 			if from.Schema_name() != nil {
@@ -1096,7 +1115,7 @@ func (c *cc) convertTablesOrSubquery(n []parser.ITable_or_subqueryContext) []ast
 							Args: &ast.List{
 								Items: args,
 							},
-							Location: from.GetStart().GetStart(),
+							Location: c.pos(from.GetStart()),
 						},
 					},
 				},
@@ -1143,7 +1162,7 @@ func (c *cc) convertUpdate_stmtContext(n Update_stmt) ast.Node {
 	tableName := identifier(n.Qualified_table_name().GetText())
 	rel := ast.RangeVar{
 		Relname:  &tableName,
-		Location: n.GetStart().GetStart(),
+		Location: c.pos(n.GetStart()),
 	}
 	relations.Items = append(relations.Items, &rel)
 
@@ -1190,7 +1209,7 @@ func (c *cc) convertBetweenExpr(n *parser.Expr_betweenContext) ast.Node {
 		Expr:     c.convert(n.Expr(0)),
 		Left:     c.convert(n.Expr(1)),
 		Right:    c.convert(n.Expr(2)),
-		Location: n.GetStart().GetStart(),
+		Location: c.pos(n.GetStart()),
 		Not:      n.NOT_() != nil,
 	}
 }
@@ -1206,7 +1225,7 @@ func (c *cc) convertCastExpr(n *parser.Expr_castContext) ast.Node {
 			}},
 			ArrayBounds: &ast.List{},
 		},
-		Location: n.GetStart().GetStart(),
+		Location: c.pos(n.GetStart()),
 	}
 }
 
@@ -1214,7 +1233,7 @@ func (c *cc) convertCollateExpr(n *parser.Expr_collateContext) ast.Node {
 	return &ast.CollateExpr{
 		Xpr:      c.convert(n.Expr()),
 		Arg:      NewIdentifier(n.Collation_name().GetText()),
-		Location: n.GetStart().GetStart(),
+		Location: c.pos(n.GetStart()),
 	}
 }
 

--- a/internal/engine/sqlite/parse.go
+++ b/internal/engine/sqlite/parse.go
@@ -42,7 +42,15 @@ func (p *Parser) Parse(r io.Reader) ([]ast.Statement, error) {
 	if err != nil {
 		return nil, err
 	}
-	input := antlr.NewInputStream(string(blob))
+	// antlr reads the input as a slice of runes and reports all token
+	// positions as rune indices. The rest of sqlc treats query offsets as byte
+	// offsets into the original source (see source.Pluck / source.Mutate), so
+	// any multi-byte rune in the source would otherwise shift every later
+	// offset and corrupt the generated SQL. Build a rune-index -> byte-offset
+	// table so we can translate antlr's positions back to byte offsets.
+	src := string(blob)
+	runeToByte := runeOffsets(src)
+	input := antlr.NewInputStream(src)
 	lexer := parser.NewSQLiteLexer(input)
 	stream := antlr.NewCommonTokenStream(lexer, 0)
 	pp := parser.NewSQLiteParser(stream)
@@ -66,24 +74,49 @@ func (p *Parser) Parse(r io.Reader) ([]ast.Statement, error) {
 		loc := 0
 
 		for _, stmt := range list.AllSql_stmt() {
-			converter := &cc{}
+			converter := &cc{convertPos: runeToByte}
 			out := converter.convert(stmt)
 			if _, ok := out.(*ast.TODO); ok {
 				loc = stmt.GetStop().GetStop() + 2
 				continue
 			}
-			len := (stmt.GetStop().GetStop() + 1) - loc
+			end := stmt.GetStop().GetStop() + 1
+			// antlr reports rune-based offsets; translate them to byte offsets
+			// before they reach the byte-oriented compiler.
+			byteLoc := runeToByte(loc)
+			byteLen := runeToByte(end) - byteLoc
 			stmts = append(stmts, ast.Statement{
 				Raw: &ast.RawStmt{
 					Stmt:         out,
-					StmtLocation: loc,
-					StmtLen:      len,
+					StmtLocation: byteLoc,
+					StmtLen:      byteLen,
 				},
 			})
 			loc = stmt.GetStop().GetStop() + 2
 		}
 	}
 	return stmts, nil
+}
+
+// runeOffsets returns a function that maps a rune index in src (as reported by
+// antlr) to the corresponding byte offset. Indices at or past the end of the
+// input map to len(src) so that end-exclusive bounds keep working.
+func runeOffsets(src string) func(int) int {
+	// table[i] is the byte offset of the i-th rune; the final entry is len(src).
+	table := make([]int, 0, len(src)+1)
+	for i := range src {
+		table = append(table, i)
+	}
+	table = append(table, len(src))
+	return func(runeIdx int) int {
+		if runeIdx < 0 {
+			return runeIdx
+		}
+		if runeIdx >= len(table) {
+			return len(src)
+		}
+		return table[runeIdx]
+	}
 }
 
 func (p *Parser) CommentSyntax() source.CommentSyntax {

--- a/internal/engine/sqlite/parse_test.go
+++ b/internal/engine/sqlite/parse_test.go
@@ -1,0 +1,39 @@
+package sqlite
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/sqlc-dev/sqlc/internal/source"
+)
+
+// Regression test for a bug where non-ASCII characters in the source SQL
+// (e.g. an em-dash in a comment) caused the generated query text to be
+// truncated. antlr reports token offsets as rune indices, but sqlc slices the
+// query text using byte offsets; the two diverge after any multi-byte rune.
+func TestParseNonASCIIOffsets(t *testing.T) {
+	const query = "-- name: GetItem :one\n" +
+		"-- Returns an item — looks up by id\n" +
+		"SELECT id, name FROM items WHERE id = ?;\n"
+
+	p := NewParser()
+	stmts, err := p.Parse(strings.NewReader(query))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(stmts) != 1 {
+		t.Fatalf("expected 1 statement, got %d", len(stmts))
+	}
+
+	raw := stmts[0].Raw
+	plucked, err := source.Pluck(query, raw.StmtLocation, raw.StmtLen)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// The plucked text must include the trailing "?" placeholder. Before the
+	// fix the byte/rune mismatch dropped the last few bytes of the statement.
+	if !strings.Contains(plucked, "WHERE id = ?") {
+		t.Errorf("plucked query was truncated:\n%q", plucked)
+	}
+}


### PR DESCRIPTION
## Summary

Fixes a bug where SQLite code generation produced truncated or corrupt
output whenever the source `.sql` file contained a non-ASCII character
(em-dash, accented letters, etc.).

## The bug

Given a query with a multi-byte character in a comment (here the `é` in
"café", which is 2 bytes in UTF-8):

```sql
-- name: GetItem :one
-- Lookup used by the café menu screen
SELECT id, name FROM items WHERE id = ?;
```

sqlc generated a truncated SQL constant, dropping the trailing `?`:

```go
const getItem = `-- name: GetItem :one
SELECT id, name FROM items WHERE id =
`
```

In queries that use `sqlc.arg()` or `SELECT *`, the misaligned offsets
caused edits to land at the wrong byte positions and produced SQL that
fails to parse (e.g. `SEid ...`). There was no error at generate time —
the corruption was silent.

## Root cause

antlr's `InputStream` stores the input as a `[]rune` and reports all
token positions as **rune indices**. The rest of sqlc, shared with the
Postgres and MySQL engines, treats query offsets as **byte offsets**
into the original source:

- `source.Pluck` slices the raw SQL for each statement
- `source.Mutate` applies parameter / star-expansion edits

For ASCII, rune index == byte offset, so the bug never surfaced. A
multi-byte rune (em-dash = 3 bytes, 1 rune) makes every later rune
index lag its true byte offset, truncating the statement slice and
shifting every edit. Postgres and MySQL are unaffected because they get
byte offsets from libpg_query and TiDB.

## The fix

Confined to the SQLite engine. We build a rune-index → byte-offset table
for the source and translate offsets at the point they are produced, so
a rune-based offset never escapes the parser:

- `parse.go` converts the statement's `StmtLocation` / `StmtLen` and
  threads the table into the converter (`cc.convertPos`).
- `convert.go` routes every node `Location` through a single `cc.pos`
  helper instead of using the raw antlr token offset.

By the time the AST leaves the parser, all offsets are byte offsets,
matching the invariant the other engines already satisfy. The
translation lives where the offsets originate, so there is no separate
post-processing pass and no reflection.

## Testing

- New regression test `internal/engine/sqlite/parse_test.go` (fails
  before the fix, passes after).
- Verified `sqlc generate` end-to-end on the query above and on a harder
  case (multi-byte string literal before `sqlc.arg()` params +
  `SELECT *`); both are correct after the fix, and the latter produced
  corrupt SQL before it.

