### PR TITLE
fix: correct typos in comments and proto annotations

### DIFF
--- a/internal/codegen/golang/opts/override.go
+++ b/internal/codegen/golang/opts/override.go
@@ -28,7 +28,7 @@ type Override struct {
 	// True if the GoType should override if the matching type is nullable
 	Nullable bool `json:"nullable" yaml:"nullable"`
 
-	// True if the GoType should override if the matching type is unsiged.
+	// True if the GoType should override if the matching type is unsigned.
 	Unsigned bool `json:"unsigned" yaml:"unsigned"`
 
 	// Deprecated. Use the `nullable` property instead

--- a/internal/codegen/golang/struct.go
+++ b/internal/codegen/golang/struct.go
@@ -43,7 +43,7 @@ func StructName(name string, options *opts.Options) string {
 		}
 	}
 
-	// If a name has a digit as its first char, prepand an underscore to make it a valid Go name.
+	// If a name has a digit as its first char, prepend an underscore to make it a valid Go name.
 	r, _ := utf8.DecodeRuneInString(out.String())
 	if unicode.IsDigit(r) {
 		return "_" + out.String()

--- a/internal/tools/sqlc-pg-gen/main.go
+++ b/internal/tools/sqlc-pg-gen/main.go
@@ -370,7 +370,7 @@ func run(ctx context.Context) error {
 type schemaToLoad struct {
 	// name is the name of a schema to load
 	Name string
-	// DestPath is the desination for the generate file
+	// DestPath is the destination for the generate file
 	DestPath string
 	// The name of the function to generate for loading this schema
 	GenFnName string

--- a/internal/tools/sqlc-pg-gen/proc.go
+++ b/internal/tools/sqlc-pg-gen/proc.go
@@ -62,7 +62,7 @@ func (p *Proc) Args() []Arg {
 	}
 
 	// Some manual changes until https://github.com/sqlc-dev/sqlc/pull/1748
-	// can be completely implmented
+	// can be completely implemented
 	if p.Name == "mode" {
 		return nil
 	}

--- a/protos/plugin/codegen.proto
+++ b/protos/plugin/codegen.proto
@@ -13,7 +13,7 @@ message File {
 
 message Settings {
   // Rename message was field 5
-  // Overides message was field 6
+  // Overrides message was field 6
   // PythonCode message was field 8
   // KotlinCode message was field 9
   // GoCode message was field 10;


### PR DESCRIPTION
Fix several spelling mistakes in Go code comments and a proto annotation comment. No logic or behavior is changed.

Changes:
- `prepand` -> `prepend` in `internal/codegen/golang/struct.go`
- `unsiged` -> `unsigned` in `internal/codegen/golang/opts/override.go`
- `desination` -> `destination` in `internal/tools/sqlc-pg-gen/main.go`
- `implmented` -> `implemented` in `internal/tools/sqlc-pg-gen/proc.go`
- `Overides` -> `Overrides` in `protos/plugin/codegen.proto`