### PR TITLE
fix: correct typos in sqlite catalog function names and comments

### DIFF
--- a/internal/codegen/golang/opts/override.go
+++ b/internal/codegen/golang/opts/override.go
@@ -28,7 +28,7 @@ type Override struct {
 	// True if the GoType should override if the matching type is nullable
 	Nullable bool `json:"nullable" yaml:"nullable"`
 
-	// True if the GoType should override if the matching type is unsiged.
+	// True if the GoType should override if the matching type is unsigned.
 	Unsigned bool `json:"unsigned" yaml:"unsigned"`
 
 	// Deprecated. Use the `nullable` property instead

--- a/internal/codegen/golang/struct.go
+++ b/internal/codegen/golang/struct.go
@@ -43,7 +43,7 @@ func StructName(name string, options *opts.Options) string {
 		}
 	}
 
-	// If a name has a digit as its first char, prepand an underscore to make it a valid Go name.
+	// If a name has a digit as its first char, prepend an underscore to make it a valid Go name.
 	r, _ := utf8.DecodeRuneInString(out.String())
 	if unicode.IsDigit(r) {
 		return "_" + out.String()

--- a/internal/compiler/selector.go
+++ b/internal/compiler/selector.go
@@ -14,7 +14,7 @@ type selector interface {
 	ColumnExpr(name string, column *Column) string
 }
 
-// defaultSelector is a selector implementation that does the simpliest possible
+// defaultSelector is a selector implementation that does the simplest possible
 // pass through when generating column expressions. Its use is suitable for all
 // database engines not requiring additional customization.
 type defaultSelector struct{}

--- a/internal/engine/sqlite/stdlib.go
+++ b/internal/engine/sqlite/stdlib.go
@@ -670,12 +670,12 @@ func defaultSchema(name string) *catalog.Schema {
 			ReturnType: &ast.TypeName{Name: "text"},
 		},
 		{
-			Name:       "RAMDOM",
+			Name:       "RANDOM",
 			Args:       []*catalog.Argument{},
 			ReturnType: &ast.TypeName{Name: "integer"},
 		},
 		{
-			Name: "RAMDOMBLOB",
+			Name: "RANDOMBLOB",
 			Args: []*catalog.Argument{
 				{
 					Type: &ast.TypeName{Name: "integer"},

--- a/protos/plugin/codegen.proto
+++ b/protos/plugin/codegen.proto
@@ -13,7 +13,7 @@ message File {
 
 message Settings {
   // Rename message was field 5
-  // Overides message was field 6
+  // Overrides message was field 6
   // PythonCode message was field 8
   // KotlinCode message was field 9
   // GoCode message was field 10;


### PR DESCRIPTION
## Summary

Fix several typos found across the codebase:

- **`internal/engine/sqlite/stdlib.go`** (functional bug): `RAMDOM` → `RANDOM` and `RAMDOMBLOB` → `RANDOMBLOB`. These misspellings in the SQLite built-in function catalog mean sqlc fails to recognize `RANDOM()` and `RANDOMBLOB()` in queries.
- **`internal/codegen/golang/struct.go`**: `prepand` → `prepend` in comment
- **`internal/codegen/golang/opts/override.go`**: `unsiged` → `unsigned` in comment
- **`internal/compiler/selector.go`**: `simpliest` → `simplest` in comment
- **`protos/plugin/codegen.proto`**: `Overides` → `Overrides` in comment

The `RANDOM`/`RANDOMBLOB` fix is the most impactful — it's a functional issue where queries using SQLite's built-in random number functions won't be recognized by sqlc.