### PR TITLE
docs: fix SQLite tutorial CreateAuthor usage with RETURNING *

### DIFF
--- a/docs/tutorials/getting-started-sqlite.md
+++ b/docs/tutorials/getting-started-sqlite.md
@@ -159,28 +159,23 @@ func run() error {
 	log.Println(authors)
 
 	// create an author
-	result, err := queries.CreateAuthor(ctx, tutorial.CreateAuthorParams{
+	insertedAuthor, err := queries.CreateAuthor(ctx, tutorial.CreateAuthorParams{
 		Name: "Brian Kernighan",
 		Bio:  sql.NullString{String: "Co-author of The C Programming Language and The Go Programming Language", Valid: true},
 	})
 	if err != nil {
 		return err
 	}
-
-	insertedAuthorID, err := result.LastInsertId()
-	if err != nil {
-		return err
-	}
-	log.Println(insertedAuthorID)
+	log.Println(insertedAuthor)
 
 	// get the author we just inserted
-	fetchedAuthor, err := queries.GetAuthor(ctx, insertedAuthorID)
+	fetchedAuthor, err := queries.GetAuthor(ctx, insertedAuthor.ID)
 	if err != nil {
 		return err
 	}
 
 	// prints true
-	log.Println(reflect.DeepEqual(insertedAuthorID, fetchedAuthor.ID))
+	log.Println(reflect.DeepEqual(insertedAuthor, fetchedAuthor))
 	return nil
 }
 


### PR DESCRIPTION
## Summary

- The SQLite getting-started tutorial defines `CreateAuthor` as `:one` with `RETURNING *`, so sqlc generates `(Author, error)`, not `sql.Result`.
- The Go example incorrectly treated the return value as `sql.Result` and called `LastInsertId()`, which does not compile.
- Update the example to use the returned `Author` (same pattern as the PostgreSQL tutorial) and compare full structs after `GetAuthor`.

Fixes #4468

## Verification

1. Generated code from the tutorial `schema.sql` / `query.sql` with a local `sqlc` build:
   - `CreateAuthor(ctx, CreateAuthorParams) (Author, error)`
   - `GetAuthor(ctx, id int64) (Author, error)`
   - `Author{ID int64; Name string; Bio sql.NullString}`
2. Compiled and ran the fixed `tutorial.go` end-to-end with `modernc.org/sqlite` and an in-memory DB.
3. Program output included `true` from `reflect.DeepEqual(insertedAuthor, fetchedAuthor)`.

## Test plan

- [x] Confirmed generated signatures match the fixed example
- [x] `go build` and run of the full tutorial program succeeds
- [ ] Docs render as expected after merge