### PR TITLE
Escape constant names in queries

### DIFF
--- a/internal/codegen/golang/reserved.go
+++ b/internal/codegen/golang/reserved.go
@@ -9,6 +9,8 @@ func escape(s string) string {
 
 func IsReserved(s string) bool {
 	switch s {
+	case "any":
+		return true
 	case "break":
 		return true
 	case "default":

--- a/internal/codegen/golang/result.go
+++ b/internal/codegen/golang/result.go
@@ -219,7 +219,7 @@ func buildQueries(req *plugin.GenerateRequest, options *opts.Options, enums []En
 
 		gq := Query{
 			Cmd:          query.Cmd,
-			ConstantName: constantName,
+			ConstantName: escape(constantName),
 			FieldName:    sdk.LowerTitle(query.Name) + "Stmt",
 			MethodName:   query.Name,
 			SourceName:   query.Filename,

--- a/internal/endtoend/testdata/any/pgx/v4/go/query.sql.go
+++ b/internal/endtoend/testdata/any/pgx/v4/go/query.sql.go
@@ -9,14 +9,14 @@ import (
 	"context"
 )
 
-const any = `-- name: Any :many
+const any_ = `-- name: Any :many
 SELECT id
 FROM bar
 WHERE id = ANY($1::bigint[])
 `
 
 func (q *Queries) Any(ctx context.Context, dollar_1 []int64) ([]int64, error) {
-	rows, err := q.db.Query(ctx, any, dollar_1)
+	rows, err := q.db.Query(ctx, any_, dollar_1)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/endtoend/testdata/any/pgx/v5/go/query.sql.go
+++ b/internal/endtoend/testdata/any/pgx/v5/go/query.sql.go
@@ -9,14 +9,14 @@ import (
 	"context"
 )
 
-const any = `-- name: Any :many
+const any_ = `-- name: Any :many
 SELECT id
 FROM bar
 WHERE id = ANY($1::bigint[])
 `
 
 func (q *Queries) Any(ctx context.Context, dollar_1 []int64) ([]int64, error) {
-	rows, err := q.db.Query(ctx, any, dollar_1)
+	rows, err := q.db.Query(ctx, any_, dollar_1)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/endtoend/testdata/any/stdlib/go/query.sql.go
+++ b/internal/endtoend/testdata/any/stdlib/go/query.sql.go
@@ -11,14 +11,14 @@ import (
 	"github.com/lib/pq"
 )
 
-const any = `-- name: Any :many
+const any_ = `-- name: Any :many
 SELECT id
 FROM bar
 WHERE id = ANY($1::bigint[])
 `
 
 func (q *Queries) Any(ctx context.Context, dollar_1 []int64) ([]int64, error) {
-	rows, err := q.db.QueryContext(ctx, any, pq.Array(dollar_1))
+	rows, err := q.db.QueryContext(ctx, any_, pq.Array(dollar_1))
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
The `any` keyword was introduced in Go 1.18, and can be used in place of `interface{}`. This was not in the list of reserved keywords, leading to identifiers using this term in generated code.

Update the logic to escape constant names, and also add `any` to the list of reserved keywords.

This is a minimal rebased version of #3961, which I'm unable to reopen. It only contains the changes that fix invalid code generation.