### PR TITLE
docs: fix broken managed databases link in migration guide

### DIFF
--- a/docs/guides/migrating-off-hosted-managed-databases.md
+++ b/docs/guides/migrating-off-hosted-managed-databases.md
@@ -1,6 +1,6 @@
 # Migrating off hosted managed databases
  
-Starting in sqlc 1.27.0, [managed databases](../docs/managed-databases.md) will require a database server URI in the configuration file.
+Starting in sqlc 1.27.0, [managed databases](../howto/managed-databases.md) will require a database server URI in the configuration file.
 
 This guide walks you through migrating to a locally running database server.
 


### PR DESCRIPTION
While reading the "Migrating off hosted managed databases" guide, I noticed the link to the managed databases page points to `../docs/managed-databases.md`. From `docs/guides/`, that path resolves to `docs/docs/managed-databases.md`, which does not exist, so the link is broken in the rendered docs.

The page itself lives at `docs/howto/managed-databases.md`. This updates the link to `../howto/managed-databases.md`, which matches the form already used everywhere else the page is referenced (for example throughout `docs/reference/changelog.md`).

This is a single-line docs change with nothing else touched. Thanks for maintaining sqlc.