### PR TITLE
docs: add uv/pip installation instructions

### DIFF
--- a/docs/overview/install.md
+++ b/docs/overview/install.md
@@ -22,6 +22,18 @@ Installing recent versions of sqlc requires Go 1.21+.
 go install github.com/sqlc-dev/sqlc/cmd/sqlc@latest
 ```
 
+## uv / pip
+
+sqlc is available on PyPI as [sqlc-bin](https://pypi.org/project/sqlc-bin/), which packages the official release binaries. No Go toolchain is required.
+
+```
+uv tool install sqlc-bin
+```
+
+```
+pip install sqlc-bin
+```
+
 ## Docker
 
 ```


### PR DESCRIPTION
Adds a short section to the install docs for installing sqlc from PyPI via [sqlc-bin](https://pypi.org/project/sqlc-bin/). The package ships the unmodified official release binaries, so Python projects can pin sqlc as a dev dependency without needing a Go toolchain. I maintain the sqlc-bin package.