### PR TITLE
Give buf-setup-action a token so setup stops hitting the rate limit

### DIFF
--- a/.github/workflows/buf.yml
+++ b/.github/workflows/buf.yml
@@ -10,4 +10,10 @@ jobs:
     steps:
       - uses: actions/checkout@v7
       - uses: bufbuild/buf-setup-action@v1
+        with:
+          # buf-setup-action resolves the release download URL through the
+          # GitHub API. Without a token that request is anonymous and shares
+          # a rate limit with every other job on the runner's IP, so setup
+          # intermittently fails with "API rate limit exceeded".
+          github_token: ${{ github.token }}
       - uses: bufbuild/buf-lint-action@v1


### PR DESCRIPTION
## Summary

`bufbuild/buf-setup-action` resolves the buf release download URL through the GitHub API. The step in `.github/workflows/buf.yml` passed no token, so that request went out anonymous and drew on the rate limit shared by every other job on the runner's IP. When the limit was already spent, the job failed during setup, before buf ever ran:

```
Setting up buf version "1.50.0"
Resolving the download URL for the current platform...
##[error]API rate limit exceeded for 172.183.131.23.
```

The action warns about this itself in the same log — `No github_token supplied, API requests will be subject to stricter rate limiting`. Passing the workflow's own `github.token` moves the request to the authenticated limit, which is per-installation rather than per-IP.

This was hit on #4544, where the `buf / build` check went red on a branch that touches no `.proto` or buf files. It's intermittent rather than constant: that was the only buf failure in the surrounding ten runs, and an earlier run on the same branch passed.

`github.token` is the token GitHub already mints for the run, so there's no new secret to configure. It only needs read access to resolve a public release, which is within the default `pull_request` permissions — including for forks, where the token is read-only.

## Testing

Workflow changes only; nothing to exercise locally. Verified the file still parses and the step is well-formed:

```
$ python3 -c "import yaml; d=yaml.safe_load(open('.github/workflows/buf.yml')); print(d['jobs']['build']['steps'][1])"
{'uses': 'bufbuild/buf-setup-action@v1', 'with': {'github_token': '${{ github.token }}'}}
```

The buf workflow runs on this PR, which exercises the changed step directly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ANVHEs41RJbybS3ja9N1SA

---
_Generated by [Claude Code](https://claude.ai/code/session_01ANVHEs41RJbybS3ja9N1SA)_