### PR TITLE
endtoend: run the corpus through the analysis core with an opt-in context

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -124,6 +124,25 @@ stdout against `stdout.txt`. A case that is expected to fail commits its
 `stderr.txt`. Regenerate a golden by running the command in its directory and
 writing the output back over the committed file.
 
+`TestReplay` runs the whole corpus once per *context*. `base` runs each case as
+committed and `managed-db` reruns it against a live database, so a context can
+change the config a case is generated with and the experiments it is generated
+under. A case restricts itself to some of them with `"contexts": [...]` in its
+`exec.json`, and commits per-context expected errors as `stderr/<context>.txt`.
+There is only one set of committed golden files, so every context is expected
+to generate identical code.
+
+The `core` context generates every case through the analysis core
+(`SQLCEXPERIMENT=coreanalyzer`). The two paths still disagree, so it is opt-in
+and needs no database:
+
+```bash
+SQLC_TEST_CORE=1 go test ./internal/endtoend -run 'TestReplay/core'
+```
+
+Go aborts a test binary on panic, so a case that panics the core analyzer ends
+the run early. Run a subset to get past one (`-run 'TestReplay/core/^select'`).
+
 ### Example Tests
 
 - **Location:** `/examples/` directory

--- a/internal/core/analyzer/dml.go
+++ b/internal/core/analyzer/dml.go
@@ -83,6 +83,7 @@ func (a *analyzer) analyzeDelete(s *ast.DeleteStmt) error {
 // report a multi-table DELETE that way — a single FROM node.
 func (a *analyzer) relationScope(relations, extra *ast.List, from ast.Node) (*scope, error) {
 	sc := &scope{}
+	defer a.binding(sc)()
 	for _, item := range listItems(relations) {
 		if err := a.appendFromItem(sc, item); err != nil {
 			return nil, err

--- a/internal/core/analyzer/scope.go
+++ b/internal/core/analyzer/scope.go
@@ -22,12 +22,24 @@ type scopeRel struct {
 func (a *analyzer) buildScope(from *ast.List) (*scope, error) {
 	items := listItems(from)
 	sc := &scope{rels: make([]scopeRel, 0, len(items))}
+	defer a.binding(sc)()
 	for _, item := range items {
 		if err := a.appendFromItem(sc, item); err != nil {
 			return nil, err
 		}
 	}
 	return sc, nil
+}
+
+// binding makes the scope under construction the one the analyzer resolves
+// against, and returns the func that puts back the scope it replaced. A FROM
+// item can refer to the ones before it — a set-returning function takes its
+// arguments from them — so binding an item has to see what is bound so far
+// rather than no scope at all.
+func (a *analyzer) binding(sc *scope) func() {
+	prev := a.scope
+	a.scope = sc
+	return func() { a.scope = prev }
 }
 
 func (a *analyzer) appendFromItem(sc *scope, item ast.Node) error {
@@ -202,6 +214,12 @@ func (a *analyzer) resolveColumn(relation, column string) (scopeRel, core.ClassC
 // relation. It reports an error when more than one relation in scope offers
 // that name.
 func (s *scope) resolveColumn(relation, column string) (rel scopeRel, col core.ClassColumn, ok bool, err error) {
+	// A statement whose scope is not built yet offers no columns. Report the
+	// column as unresolved and let the caller say so, rather than crashing on
+	// the way to the same answer.
+	if s == nil {
+		return rel, col, false, nil
+	}
 	found := 0
 	for _, r := range s.rels {
 		if relation != "" && r.alias != relation {

--- a/internal/endtoend/endtoend_test.go
+++ b/internal/endtoend/endtoend_test.go
@@ -120,6 +120,10 @@ func BenchmarkExamples(b *testing.B) {
 type textContext struct {
 	Mutate  func(*testing.T, string) func(*config.Config)
 	Enabled func() bool
+	// Experiments names the experiments every case in this context runs
+	// with. A case's own SQLCEXPERIMENT is appended to these, so a case can
+	// still turn one back off with the "no" prefix.
+	Experiments func() []string
 }
 
 func TestReplay(t *testing.T) {
@@ -235,6 +239,16 @@ func TestReplay(t *testing.T) {
 				return postgresURI != "" || mysqlURI != ""
 			},
 		},
+		"core": {
+			Mutate:      func(t *testing.T, path string) func(*config.Config) { return func(c *config.Config) {} },
+			Experiments: func() []string { return []string{"coreanalyzer"} },
+			Enabled: func() bool {
+				// Running the whole corpus through the analysis core is opt-in
+				// while the two paths still disagree. The core needs no
+				// database, so nothing else gates this.
+				return os.Getenv("SQLC_TEST_CORE") != ""
+			},
+		},
 	}
 
 	for name, testctx := range contexts {
@@ -276,9 +290,14 @@ func TestReplay(t *testing.T) {
 					}
 				}
 
+				experiments := args.Env["SQLCEXPERIMENT"]
+				if testctx.Experiments != nil {
+					experiments = strings.Join(append(testctx.Experiments(), experiments), ",")
+				}
+
 				opts := cmd.Options{
 					Env: cmd.Env{
-						Experiment: opts.ExperimentFromString(args.Env["SQLCEXPERIMENT"]),
+						Experiment: opts.ExperimentFromString(experiments),
 					},
 					Stderr:       &stderr,
 					MutateConfig: testctx.Mutate(t, path),


### PR DESCRIPTION
`TestReplay` runs the whole testdata corpus once per context: `base` as
committed, `managed-db` against a live database. This adds a third, `core`,
which generates every case through the analysis core, so the two paths can be
compared case by case rather than one case at a time.

## The context

Contexts could only mutate `config.Config`, so the `coreanalyzer` experiment
could reach a case only through its own `exec.json`. `textContext` now also
names the experiments every case in it runs with:

```go
type textContext struct {
	Mutate      func(*testing.T, string) func(*config.Config)
	Enabled     func() bool
	Experiments func() []string
}
```

A case's own `SQLCEXPERIMENT` is appended to the context's, so a case can still
turn one back off with the `no` prefix.

The two paths still disagree, so the context is opt-in, and needs no database:

```bash
SQLC_TEST_CORE=1 go test ./internal/endtoend -run 'TestReplay/core'
```

The gate is an environment variable rather than a test flag because the
documented workflow runs the whole module, and a flag defined in one test
binary fails every package that does not define it:

```
$ go test -run TestNothingMatches -update=true ./internal/sql/preprocess ./internal/opts
flag provided but not defined: -update
```

It also matches how the rest of this suite is configured — `POSTGRESQL_SERVER_URI`,
`MYSQL_SERVER_URI`, `SQLC_DUMMY_VALUE`.

## The panic it found

Two cases took the test binary down, which ended the run partway through and
took the rest of the corpus with it. A set-returning function in `FROM` takes
its arguments from the items before it, so `bindRangeFunction` types the call
while the scope is still being assembled — but the scope under construction was
never installed on the analyzer, so `a.scope` was nil and resolving one of those
arguments dereferenced it:

```sql
FROM transactions,
     jsonb_each(jsonb_extract_path(transactions.data, '...')) AS instructions
```

`buildScope` and `relationScope` now install the scope they are filling for as
long as they fill it, and put back the one they replaced on the way out.
Resolving against a nil scope also reports the column as unresolved rather than
crashing, so no other half-built statement can panic on the way to the error it
was going to report anyway.

Both queries now analyze to an ordinary error, and the core context runs to
completion in a single process.

Worth a look on review: installing the partial scope also means a `FROM` item
can now resolve columns from the items before it, which is what
`bindRangeFunction`'s comment always claimed it did. That is a small
permissiveness increase for subqueries in `FROM` — a non-LATERAL subquery can
now see an earlier `FROM` item. Nothing in the suite depends on the stricter
behavior, but it is a semantic change rather than a purely defensive one.

## Where the paths differ today

838 cases run under `core`, 311 pass, 527 fail. Ranked:

| Count | Divergence |
| --- | --- |
| 224 | `*` not expanded in the emitted SQL |
| 121 | other generated-code differences |
| 99 | hard errors, `sqlc generate` exits non-zero |
| 22 | nullability (`sql.Null*` / pgtype wrappers) |
| 15 | column or param typed `interface{}` |
| 10 | enum scaffolding missing from `models.go` |
| 7 | stderr differs — both paths error, different message |
| 6 | integer signedness (MySQL `uint` vs `int`) |
| 4 | array/slice-ness |

Star expansion is one behavior and 43% of the failures. Of the hard errors, 47
are `illegal character U+003F '?'` — parameters get dropped, so the emitted Go
does not compile — then catalog `sql: no rows in result set` on CTEs and
schema-qualified relations, unsupported AST nodes (`*ast.NamedArgExpr`,
`*ast.MultiAssignRef`), and `unknown column` on `unnest`.

No goldens were regenerated and no divergence was papered over. The failures are
the report.

## Testing

- `go test --tags=examples -timeout 20m ./...` passes with PostgreSQL and MySQL
  live — 31 packages, no failures. Covers `base`, `managed-db`, and the
  live-database example tests.
- `SQLC_TEST_CORE=1 go test ./internal/endtoend -run 'TestReplay/core'` completes
  in one process with zero panics.
- Nothing changes for anyone who does not set `SQLC_TEST_CORE`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0161e7oMkzNW9DZMUPtyQibH

---
_Generated by [Claude Code](https://claude.ai/code/session_0161e7oMkzNW9DZMUPtyQibH)_