### PR TITLE
Missing sqlc.arg in SQL UPDATE query with EXISTS subquery

### DIFF
--- a/internal/engine/dolphin/convert.go
+++ b/internal/engine/dolphin/convert.go
@@ -1556,6 +1556,12 @@ func (c *cc) convertTruncateTableStmt(n *pcast.TruncateTableStmt) *ast.TruncateS
 }
 
 func (c *cc) convertUnaryOperationExpr(n *pcast.UnaryOperationExpr) ast.Node {
+	if n.Op == opcode.Not || n.Op == opcode.Not2 {
+		return &ast.BoolExpr{
+			Boolop: ast.BoolExprTypeNot,
+			Args:   &ast.List{Items: []ast.Node{c.convert(n.V)}},
+		}
+	}
 	return todo(n)
 }
 


### PR DESCRIPTION
Handle `NOT (EXISTS (...))` in MySQL by converting `UnaryOperationExpr{Not}` to `BoolExpr{BoolExprTypeNot}` instead of discarding it as `ast.TODO`

Found via automated repo scanning, fix written and reviewed before opening.
