### PR TITLE
docs: use 'go build .' in getting-started tutorials

### DIFF
--- a/docs/tutorials/getting-started-mysql.md
+++ b/docs/tutorials/getting-started-mysql.md
@@ -169,7 +169,7 @@ Before this code will compile you'll need to fetch the relevant MySQL driver:
 
 ```shell
 go get github.com/go-sql-driver/mysql
-go build ./...
+go build .
 ```
 
 The program should compile without errors. To make that possible, sqlc generates

--- a/docs/tutorials/getting-started-postgresql.md
+++ b/docs/tutorials/getting-started-postgresql.md
@@ -188,7 +188,7 @@ package, but in this tutorial we've used `pgx/v5`:
 
 ```shell
 go get github.com/jackc/pgx/v5
-go build ./...
+go build .
 ```
 
 The program should compile without errors. To make that possible, sqlc generates

--- a/docs/tutorials/getting-started-sqlite.md
+++ b/docs/tutorials/getting-started-sqlite.md
@@ -190,7 +190,7 @@ Before this code will compile you'll need to fetch the relevant SQLite driver:
 
 ```shell
 go get modernc.org/sqlite
-go build ./...
+go build .
 ```
 
 The program should compile without errors, and run successfully. To make that


### PR DESCRIPTION
Fixes #4554

The getting-started tutorials tell readers to run `go build ./...` after fetching the database driver. In the tutorial layout the pattern matches two packages — the root `main` package and the generated `tutorial` package — and when `go build` is given more than one package it compiles them as a check but discards the resulting binaries, so no executable is produced.

Switching to `go build .` builds just the main package and writes the binary, which is what the tutorials intend ("The program should compile without errors, and run successfully").

The issue reports the SQLite tutorial, but the MySQL and PostgreSQL tutorials share the same layout and instruction, so all three are updated:

- `docs/tutorials/getting-started-sqlite.md`
- `docs/tutorials/getting-started-mysql.md`
- `docs/tutorials/getting-started-postgresql.md`

Verified by reproducing the behavior in a minimal module with the same layout: `go build ./...` leaves no binary; `go build .` writes it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FdtZb2F2AHRqAypxKhbTHn

---
_Generated by [Claude Code](https://claude.ai/code/session_01FdtZb2F2AHRqAypxKhbTHn)_