### PR TITLE
Add NOTICE file for Apache-2.0 dependencies

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -1,0 +1,48 @@
+This distribution of sqlc includes software licensed under the Apache
+License, Version 2.0, from projects that ship a NOTICE file. As required
+by section 4(d) of that license, their attribution notices are reproduced
+below.
+
+================================================================================
+github.com/tetratelabs/wazero
+================================================================================
+
+wazero
+Copyright 2020-2023 wazero authors
+
+================================================================================
+google.golang.org/grpc
+================================================================================
+
+Copyright 2014 gRPC authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+================================================================================
+gopkg.in/yaml.v3
+go.yaml.in/yaml/v3
+================================================================================
+
+Copyright 2011-2016 Canonical Ltd.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.


### PR DESCRIPTION
Adds a top-level `NOTICE` file aggregating the attribution notices from the Apache-2.0 dependencies compiled into the sqlc binary that ship one, as required by section 4(d) of the Apache License. Refs #4443.

Auditing the current module graph (`go mod download -json all` cross-checked against `go list -deps ./cmd/sqlc`), four linked modules ship a NOTICE:

- `github.com/tetratelabs/wazero`
- `google.golang.org/grpc`
- `gopkg.in/yaml.v3`
- `go.yaml.in/yaml/v3` (same Canonical notice as `gopkg.in/yaml.v3`, listed under one heading)

The `coreos/go-semver` dependency called out in #4443 is not included: it arrived via `pingcap/tidb/pkg/parser` in v1.31.x and is already gone from `main` since the parser was replaced with `github.com/sqlc-dev/marino`.

No tooling is added to keep the file in sync — if the dependency set changes, this PR is the reference for how to regenerate it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Tb9pkPZxJefgFP3vcQ4wrD

---
_Generated by [Claude Code](https://claude.ai/code/session_01Tb9pkPZxJefgFP3vcQ4wrD)_