### PR TITLE
codegen/golang: emit any instead of interface{}

### DIFF
--- a/docs/howto/delete.md
+++ b/docs/howto/delete.md
@@ -30,7 +30,7 @@ import (
 )
 
 type DBTX interface {
-	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
 }
 
 func New(db DBTX) *Queries {

--- a/docs/howto/insert.md
+++ b/docs/howto/insert.md
@@ -30,7 +30,7 @@ import (
 )
 
 type DBTX interface {
-	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
 }
 
 func New(db DBTX) *Queries {

--- a/docs/howto/prepared_query.md
+++ b/docs/howto/prepared_query.md
@@ -35,7 +35,7 @@ type Record struct {
 
 type DBTX interface {
 	PrepareContext(context.Context, string) (*sql.Stmt, error)
-	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
+	QueryRowContext(context.Context, string, ...any) *sql.Row
 }
 
 func New(db DBTX) *Queries {
@@ -51,7 +51,7 @@ func Prepare(ctx context.Context, db DBTX) (*Queries, error) {
 	return &q, nil
 }
 
-func (q *Queries) queryRow(ctx context.Context, stmt *sql.Stmt, query string, args ...interface{}) *sql.Row {
+func (q *Queries) queryRow(ctx context.Context, stmt *sql.Stmt, query string, args ...any) *sql.Row {
 	switch {
 	case stmt != nil && q.tx != nil:
 		return q.tx.StmtContext(ctx, stmt).QueryRowContext(ctx, args...)

--- a/docs/howto/query_count.md
+++ b/docs/howto/query_count.md
@@ -24,8 +24,8 @@ import (
 )
 
 type DBTX interface {
-	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
-	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
 }
 
 func New(db DBTX) *Queries {

--- a/docs/howto/select.md
+++ b/docs/howto/select.md
@@ -69,8 +69,8 @@ type Author struct {
 }
 
 type DBTX interface {
-	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
-	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
 }
 
 func New(db DBTX) *Queries {
@@ -161,7 +161,7 @@ import (
 )
 
 type DBTX interface {
-	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
+	QueryRowContext(context.Context, string, ...any) *sql.Row
 }
 
 func New(db DBTX) *Queries {
@@ -243,8 +243,8 @@ type Author struct {
 }
 
 type DBTX interface {
-	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
-	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
 }
 
 func New(db DBTX) *Queries {
@@ -334,10 +334,10 @@ type Author struct {
 }
 
 type DBTX interface {
-	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
 	PrepareContext(context.Context, string) (*sql.Stmt, error)
-	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
-	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
 }
 
 func New(db DBTX) *Queries {
@@ -361,7 +361,7 @@ WHERE id IN (/*SLICE:ids*/?)
 
 func (q *Queries) ListAuthorsByIDs(ctx context.Context, ids []int64) ([]Author, error) {
 	sql := listAuthorsByIDs
-	var queryParams []interface{}
+	var queryParams []any
 	if len(ids) == 0 {
 		return nil, fmt.Errorf("slice ids must have at least one element")
 	}

--- a/docs/howto/transactions.md
+++ b/docs/howto/transactions.md
@@ -32,10 +32,10 @@ import (
 )
 
 type DBTX interface {
-	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
 	PrepareContext(context.Context, string) (*sql.Stmt, error)
-	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
-	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
 }
 
 func New(db DBTX) *Queries {

--- a/docs/howto/update.md
+++ b/docs/howto/update.md
@@ -35,7 +35,7 @@ import (
 )
 
 type DBTX interface {
-	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
 }
 
 func New(db DBTX) *Queries {
@@ -86,7 +86,7 @@ import (
 )
 
 type DBTX interface {
-	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
 }
 
 func New(db DBTX) *Queries {

--- a/examples/authors/mysql/db.go
+++ b/examples/authors/mysql/db.go
@@ -10,10 +10,10 @@ import (
 )
 
 type DBTX interface {
-	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
 	PrepareContext(context.Context, string) (*sql.Stmt, error)
-	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
-	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
 }
 
 func New(db DBTX) *Queries {

--- a/examples/authors/postgresql/db.go
+++ b/examples/authors/postgresql/db.go
@@ -12,9 +12,9 @@ import (
 )
 
 type DBTX interface {
-	Exec(context.Context, string, ...interface{}) (pgconn.CommandTag, error)
-	Query(context.Context, string, ...interface{}) (pgx.Rows, error)
-	QueryRow(context.Context, string, ...interface{}) pgx.Row
+	Exec(context.Context, string, ...any) (pgconn.CommandTag, error)
+	Query(context.Context, string, ...any) (pgx.Rows, error)
+	QueryRow(context.Context, string, ...any) pgx.Row
 }
 
 func New(db DBTX) *Queries {

--- a/examples/authors/sqlite/db.go
+++ b/examples/authors/sqlite/db.go
@@ -10,10 +10,10 @@ import (
 )
 
 type DBTX interface {
-	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
 	PrepareContext(context.Context, string) (*sql.Stmt, error)
-	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
-	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
 }
 
 func New(db DBTX) *Queries {

--- a/examples/batch/postgresql/batch.go
+++ b/examples/batch/postgresql/batch.go
@@ -31,7 +31,7 @@ type BooksByYearBatchResults struct {
 func (q *Queries) BooksByYear(ctx context.Context, year []int32) *BooksByYearBatchResults {
 	batch := &pgx.Batch{}
 	for _, a := range year {
-		vals := []interface{}{
+		vals := []any{
 			a,
 		}
 		batch.Queue(booksByYear, vals...)
@@ -125,7 +125,7 @@ type CreateBookParams struct {
 func (q *Queries) CreateBook(ctx context.Context, arg []CreateBookParams) *CreateBookBatchResults {
 	batch := &pgx.Batch{}
 	for _, a := range arg {
-		vals := []interface{}{
+		vals := []any{
 			a.AuthorID,
 			a.Isbn,
 			a.BookType,
@@ -186,7 +186,7 @@ type DeleteBookBatchResults struct {
 func (q *Queries) DeleteBook(ctx context.Context, bookID []int32) *DeleteBookBatchResults {
 	batch := &pgx.Batch{}
 	for _, a := range bookID {
-		vals := []interface{}{
+		vals := []any{
 			a,
 		}
 		batch.Queue(deleteBook, vals...)
@@ -230,7 +230,7 @@ type DeleteBookNamedFuncBatchResults struct {
 func (q *Queries) DeleteBookNamedFunc(ctx context.Context, bookID []int32) *DeleteBookNamedFuncBatchResults {
 	batch := &pgx.Batch{}
 	for _, a := range bookID {
-		vals := []interface{}{
+		vals := []any{
 			a,
 		}
 		batch.Queue(deleteBookNamedFunc, vals...)
@@ -274,7 +274,7 @@ type DeleteBookNamedSignBatchResults struct {
 func (q *Queries) DeleteBookNamedSign(ctx context.Context, bookID []int32) *DeleteBookNamedSignBatchResults {
 	batch := &pgx.Batch{}
 	for _, a := range bookID {
-		vals := []interface{}{
+		vals := []any{
 			a,
 		}
 		batch.Queue(deleteBookNamedSign, vals...)
@@ -318,7 +318,7 @@ type GetBiographyBatchResults struct {
 func (q *Queries) GetBiography(ctx context.Context, authorID []int32) *GetBiographyBatchResults {
 	batch := &pgx.Batch{}
 	for _, a := range authorID {
-		vals := []interface{}{
+		vals := []any{
 			a,
 		}
 		batch.Queue(getBiography, vals...)
@@ -371,7 +371,7 @@ type UpdateBookParams struct {
 func (q *Queries) UpdateBook(ctx context.Context, arg []UpdateBookParams) *UpdateBookBatchResults {
 	batch := &pgx.Batch{}
 	for _, a := range arg {
-		vals := []interface{}{
+		vals := []any{
 			a.Title,
 			a.Tags,
 			a.BookID,

--- a/examples/batch/postgresql/db.go
+++ b/examples/batch/postgresql/db.go
@@ -12,9 +12,9 @@ import (
 )
 
 type DBTX interface {
-	Exec(context.Context, string, ...interface{}) (pgconn.CommandTag, error)
-	Query(context.Context, string, ...interface{}) (pgx.Rows, error)
-	QueryRow(context.Context, string, ...interface{}) pgx.Row
+	Exec(context.Context, string, ...any) (pgconn.CommandTag, error)
+	Query(context.Context, string, ...any) (pgx.Rows, error)
+	QueryRow(context.Context, string, ...any) pgx.Row
 	SendBatch(context.Context, *pgx.Batch) pgx.BatchResults
 }
 

--- a/examples/batch/postgresql/models.go
+++ b/examples/batch/postgresql/models.go
@@ -18,7 +18,7 @@ const (
 	BookTypeNONFICTION BookType = "NONFICTION"
 )
 
-func (e *BookType) Scan(src interface{}) error {
+func (e *BookType) Scan(src any) error {
 	switch s := src.(type) {
 	case []byte:
 		*e = BookType(s)
@@ -36,7 +36,7 @@ type NullBookType struct {
 }
 
 // Scan implements the Scanner interface.
-func (ns *NullBookType) Scan(value interface{}) error {
+func (ns *NullBookType) Scan(value any) error {
 	if value == nil {
 		ns.BookType, ns.Valid = "", false
 		return nil

--- a/examples/booktest/mysql/db.go
+++ b/examples/booktest/mysql/db.go
@@ -10,10 +10,10 @@ import (
 )
 
 type DBTX interface {
-	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
 	PrepareContext(context.Context, string) (*sql.Stmt, error)
-	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
-	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
 }
 
 func New(db DBTX) *Queries {

--- a/examples/booktest/mysql/models.go
+++ b/examples/booktest/mysql/models.go
@@ -17,7 +17,7 @@ const (
 	BooksBookTypeNONFICTION BooksBookType = "NONFICTION"
 )
 
-func (e *BooksBookType) Scan(src interface{}) error {
+func (e *BooksBookType) Scan(src any) error {
 	switch s := src.(type) {
 	case []byte:
 		*e = BooksBookType(s)
@@ -35,7 +35,7 @@ type NullBooksBookType struct {
 }
 
 // Scan implements the Scanner interface.
-func (ns *NullBooksBookType) Scan(value interface{}) error {
+func (ns *NullBooksBookType) Scan(value any) error {
 	if value == nil {
 		ns.BooksBookType, ns.Valid = "", false
 		return nil

--- a/examples/booktest/postgresql/db.go
+++ b/examples/booktest/postgresql/db.go
@@ -12,9 +12,9 @@ import (
 )
 
 type DBTX interface {
-	Exec(context.Context, string, ...interface{}) (pgconn.CommandTag, error)
-	Query(context.Context, string, ...interface{}) (pgx.Rows, error)
-	QueryRow(context.Context, string, ...interface{}) pgx.Row
+	Exec(context.Context, string, ...any) (pgconn.CommandTag, error)
+	Query(context.Context, string, ...any) (pgx.Rows, error)
+	QueryRow(context.Context, string, ...any) pgx.Row
 }
 
 func New(db DBTX) *Queries {

--- a/examples/booktest/postgresql/models.go
+++ b/examples/booktest/postgresql/models.go
@@ -18,7 +18,7 @@ const (
 	BookTypeNONFICTION BookType = "NONFICTION"
 )
 
-func (e *BookType) Scan(src interface{}) error {
+func (e *BookType) Scan(src any) error {
 	switch s := src.(type) {
 	case []byte:
 		*e = BookType(s)
@@ -36,7 +36,7 @@ type NullBookType struct {
 }
 
 // Scan implements the Scanner interface.
-func (ns *NullBookType) Scan(value interface{}) error {
+func (ns *NullBookType) Scan(value any) error {
 	if value == nil {
 		ns.BookType, ns.Valid = "", false
 		return nil

--- a/examples/booktest/sqlite/db.go
+++ b/examples/booktest/sqlite/db.go
@@ -10,10 +10,10 @@ import (
 )
 
 type DBTX interface {
-	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
 	PrepareContext(context.Context, string) (*sql.Stmt, error)
-	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
-	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
 }
 
 func New(db DBTX) *Queries {

--- a/examples/booktest/sqlite/query.sql.go
+++ b/examples/booktest/sqlite/query.sql.go
@@ -34,7 +34,7 @@ type BooksByTagsRow struct {
 
 func (q *Queries) BooksByTags(ctx context.Context, tags []string) ([]BooksByTagsRow, error) {
 	query := booksByTags
-	var queryParams []interface{}
+	var queryParams []any
 	if len(tags) > 0 {
 		for _, v := range tags {
 			queryParams = append(queryParams, v)

--- a/examples/jets/postgresql/db.go
+++ b/examples/jets/postgresql/db.go
@@ -12,9 +12,9 @@ import (
 )
 
 type DBTX interface {
-	Exec(context.Context, string, ...interface{}) (pgconn.CommandTag, error)
-	Query(context.Context, string, ...interface{}) (pgx.Rows, error)
-	QueryRow(context.Context, string, ...interface{}) pgx.Row
+	Exec(context.Context, string, ...any) (pgconn.CommandTag, error)
+	Query(context.Context, string, ...any) (pgx.Rows, error)
+	QueryRow(context.Context, string, ...any) pgx.Row
 }
 
 func New(db DBTX) *Queries {

--- a/examples/ondeck/mysql/db.go
+++ b/examples/ondeck/mysql/db.go
@@ -11,10 +11,10 @@ import (
 )
 
 type DBTX interface {
-	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
 	PrepareContext(context.Context, string) (*sql.Stmt, error)
-	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
-	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
 }
 
 func New(db DBTX) *Queries {
@@ -112,7 +112,7 @@ func (q *Queries) Close() error {
 	return err
 }
 
-func (q *Queries) exec(ctx context.Context, stmt *sql.Stmt, query string, args ...interface{}) (sql.Result, error) {
+func (q *Queries) exec(ctx context.Context, stmt *sql.Stmt, query string, args ...any) (sql.Result, error) {
 	switch {
 	case stmt != nil && q.tx != nil:
 		return q.tx.StmtContext(ctx, stmt).ExecContext(ctx, args...)
@@ -123,7 +123,7 @@ func (q *Queries) exec(ctx context.Context, stmt *sql.Stmt, query string, args .
 	}
 }
 
-func (q *Queries) query(ctx context.Context, stmt *sql.Stmt, query string, args ...interface{}) (*sql.Rows, error) {
+func (q *Queries) query(ctx context.Context, stmt *sql.Stmt, query string, args ...any) (*sql.Rows, error) {
 	switch {
 	case stmt != nil && q.tx != nil:
 		return q.tx.StmtContext(ctx, stmt).QueryContext(ctx, args...)
@@ -134,7 +134,7 @@ func (q *Queries) query(ctx context.Context, stmt *sql.Stmt, query string, args 
 	}
 }
 
-func (q *Queries) queryRow(ctx context.Context, stmt *sql.Stmt, query string, args ...interface{}) *sql.Row {
+func (q *Queries) queryRow(ctx context.Context, stmt *sql.Stmt, query string, args ...any) *sql.Row {
 	switch {
 	case stmt != nil && q.tx != nil:
 		return q.tx.StmtContext(ctx, stmt).QueryRowContext(ctx, args...)

--- a/examples/ondeck/mysql/models.go
+++ b/examples/ondeck/mysql/models.go
@@ -18,7 +18,7 @@ const (
 	VenueStatusClosed VenueStatus = "closed"
 )
 
-func (e *VenueStatus) Scan(src interface{}) error {
+func (e *VenueStatus) Scan(src any) error {
 	switch s := src.(type) {
 	case []byte:
 		*e = VenueStatus(s)
@@ -36,7 +36,7 @@ type NullVenueStatus struct {
 }
 
 // Scan implements the Scanner interface.
-func (ns *NullVenueStatus) Scan(value interface{}) error {
+func (ns *NullVenueStatus) Scan(value any) error {
 	if value == nil {
 		ns.VenueStatus, ns.Valid = "", false
 		return nil

--- a/examples/ondeck/postgresql/db.go
+++ b/examples/ondeck/postgresql/db.go
@@ -13,10 +13,10 @@ import (
 )
 
 type DBTX interface {
-	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
 	PrepareContext(context.Context, string) (*sql.Stmt, error)
-	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
-	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
 }
 
 func New(db DBTX) *Queries {
@@ -114,7 +114,7 @@ func (q *Queries) Close() error {
 	return err
 }
 
-func (q *Queries) exec(ctx context.Context, stmt *sql.Stmt, query string, args ...interface{}) (sql.Result, error) {
+func (q *Queries) exec(ctx context.Context, stmt *sql.Stmt, query string, args ...any) (sql.Result, error) {
 	switch {
 	case stmt != nil && q.tx != nil:
 		return q.tx.StmtContext(ctx, stmt).ExecContext(ctx, args...)
@@ -125,7 +125,7 @@ func (q *Queries) exec(ctx context.Context, stmt *sql.Stmt, query string, args .
 	}
 }
 
-func (q *Queries) query(ctx context.Context, stmt *sql.Stmt, query string, args ...interface{}) (*sql.Rows, error) {
+func (q *Queries) query(ctx context.Context, stmt *sql.Stmt, query string, args ...any) (*sql.Rows, error) {
 	switch {
 	case stmt != nil && q.tx != nil:
 		return q.tx.StmtContext(ctx, stmt).QueryContext(ctx, args...)
@@ -136,7 +136,7 @@ func (q *Queries) query(ctx context.Context, stmt *sql.Stmt, query string, args 
 	}
 }
 
-func (q *Queries) queryRow(ctx context.Context, stmt *sql.Stmt, query string, args ...interface{}) *sql.Row {
+func (q *Queries) queryRow(ctx context.Context, stmt *sql.Stmt, query string, args ...any) *sql.Row {
 	switch {
 	case stmt != nil && q.tx != nil:
 		return q.tx.StmtContext(ctx, stmt).QueryRowContext(ctx, args...)

--- a/examples/ondeck/postgresql/models.go
+++ b/examples/ondeck/postgresql/models.go
@@ -21,7 +21,7 @@ const (
 	StatusClosed Status = "clo@sed"
 )
 
-func (e *Status) Scan(src interface{}) error {
+func (e *Status) Scan(src any) error {
 	switch s := src.(type) {
 	case []byte:
 		*e = Status(s)
@@ -39,7 +39,7 @@ type NullStatus struct {
 }
 
 // Scan implements the Scanner interface.
-func (ns *NullStatus) Scan(value interface{}) error {
+func (ns *NullStatus) Scan(value any) error {
 	if value == nil {
 		ns.Status, ns.Valid = "", false
 		return nil

--- a/examples/ondeck/sqlite/db.go
+++ b/examples/ondeck/sqlite/db.go
@@ -11,10 +11,10 @@ import (
 )
 
 type DBTX interface {
-	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
 	PrepareContext(context.Context, string) (*sql.Stmt, error)
-	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
-	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
 }
 
 func New(db DBTX) *Queries {
@@ -112,7 +112,7 @@ func (q *Queries) Close() error {
 	return err
 }
 
-func (q *Queries) exec(ctx context.Context, stmt *sql.Stmt, query string, args ...interface{}) (sql.Result, error) {
+func (q *Queries) exec(ctx context.Context, stmt *sql.Stmt, query string, args ...any) (sql.Result, error) {
 	switch {
 	case stmt != nil && q.tx != nil:
 		return q.tx.StmtContext(ctx, stmt).ExecContext(ctx, args...)
@@ -123,7 +123,7 @@ func (q *Queries) exec(ctx context.Context, stmt *sql.Stmt, query string, args .
 	}
 }
 
-func (q *Queries) query(ctx context.Context, stmt *sql.Stmt, query string, args ...interface{}) (*sql.Rows, error) {
+func (q *Queries) query(ctx context.Context, stmt *sql.Stmt, query string, args ...any) (*sql.Rows, error) {
 	switch {
 	case stmt != nil && q.tx != nil:
 		return q.tx.StmtContext(ctx, stmt).QueryContext(ctx, args...)
@@ -134,7 +134,7 @@ func (q *Queries) query(ctx context.Context, stmt *sql.Stmt, query string, args 
 	}
 }
 
-func (q *Queries) queryRow(ctx context.Context, stmt *sql.Stmt, query string, args ...interface{}) *sql.Row {
+func (q *Queries) queryRow(ctx context.Context, stmt *sql.Stmt, query string, args ...any) *sql.Row {
 	switch {
 	case stmt != nil && q.tx != nil:
 		return q.tx.StmtContext(ctx, stmt).QueryRowContext(ctx, args...)

--- a/internal/codegen/golang/go_type.go
+++ b/internal/codegen/golang/go_type.go
@@ -87,6 +87,6 @@ func goInnerType(req *plugin.GenerateRequest, options *opts.Options, col *plugin
 	case "sqlite":
 		return sqliteType(req, options, col)
 	default:
-		return "interface{}"
+		return "any"
 	}
 }

--- a/internal/codegen/golang/mysql_type.go
+++ b/internal/codegen/golang/mysql_type.go
@@ -115,7 +115,7 @@ func mysqlType(req *plugin.GenerateRequest, options *opts.Options, col *plugin.C
 		return "json.RawMessage"
 
 	case "any":
-		return "interface{}"
+		return "any"
 
 	default:
 		for _, schema := range req.Catalog.Schemas {
@@ -138,7 +138,7 @@ func mysqlType(req *plugin.GenerateRequest, options *opts.Options, col *plugin.C
 		if debug.Active {
 			log.Printf("Unknown MySQL type: %s\n", columnType)
 		}
-		return "interface{}"
+		return "any"
 
 	}
 }

--- a/internal/codegen/golang/postgresql_type.go
+++ b/internal/codegen/golang/postgresql_type.go
@@ -182,7 +182,7 @@ func postgresType(req *plugin.GenerateRequest, options *opts.Options, col *plugi
 				return "pqtype.NullRawMessage"
 			}
 		default:
-			return "interface{}"
+			return "any"
 		}
 
 	case "jsonb", "pg_catalog.jsonb":
@@ -198,7 +198,7 @@ func postgresType(req *plugin.GenerateRequest, options *opts.Options, col *plugi
 				return "pqtype.NullRawMessage"
 			}
 		default:
-			return "interface{}"
+			return "any"
 		}
 
 	case "bytea", "blob", "pg_catalog.bytea":
@@ -297,7 +297,7 @@ func postgresType(req *plugin.GenerateRequest, options *opts.Options, col *plugi
 		case opts.SQLDriverLibPQ:
 			return "pqtype.Inet"
 		default:
-			return "interface{}"
+			return "any"
 		}
 
 	case "cidr":
@@ -312,7 +312,7 @@ func postgresType(req *plugin.GenerateRequest, options *opts.Options, col *plugi
 		case opts.SQLDriverLibPQ:
 			return "pqtype.CIDR"
 		default:
-			return "interface{}"
+			return "any"
 		}
 
 	case "macaddr", "macaddr8":
@@ -324,7 +324,7 @@ func postgresType(req *plugin.GenerateRequest, options *opts.Options, col *plugi
 		case opts.SQLDriverLibPQ:
 			return "pqtype.Macaddr"
 		default:
-			return "interface{}"
+			return "any"
 		}
 
 	case "ltree", "lquery", "ltxtquery":
@@ -363,7 +363,7 @@ func postgresType(req *plugin.GenerateRequest, options *opts.Options, col *plugi
 		case opts.SQLDriverPGXV5:
 			return "pgtype.Range[pgtype.Date]"
 		default:
-			return "interface{}"
+			return "any"
 		}
 
 	case "datemultirange":
@@ -371,7 +371,7 @@ func postgresType(req *plugin.GenerateRequest, options *opts.Options, col *plugi
 		case opts.SQLDriverPGXV5:
 			return "pgtype.Multirange[pgtype.Range[pgtype.Date]]"
 		default:
-			return "interface{}"
+			return "any"
 		}
 
 	case "tsrange":
@@ -381,7 +381,7 @@ func postgresType(req *plugin.GenerateRequest, options *opts.Options, col *plugi
 		case opts.SQLDriverPGXV5:
 			return "pgtype.Range[pgtype.Timestamp]"
 		default:
-			return "interface{}"
+			return "any"
 		}
 
 	case "tsmultirange":
@@ -389,7 +389,7 @@ func postgresType(req *plugin.GenerateRequest, options *opts.Options, col *plugi
 		case opts.SQLDriverPGXV5:
 			return "pgtype.Multirange[pgtype.Range[pgtype.Timestamp]]"
 		default:
-			return "interface{}"
+			return "any"
 		}
 
 	case "tstzrange":
@@ -399,7 +399,7 @@ func postgresType(req *plugin.GenerateRequest, options *opts.Options, col *plugi
 		case opts.SQLDriverPGXV5:
 			return "pgtype.Range[pgtype.Timestamptz]"
 		default:
-			return "interface{}"
+			return "any"
 		}
 
 	case "tstzmultirange":
@@ -407,7 +407,7 @@ func postgresType(req *plugin.GenerateRequest, options *opts.Options, col *plugi
 		case opts.SQLDriverPGXV5:
 			return "pgtype.Multirange[pgtype.Range[pgtype.Timestamptz]]"
 		default:
-			return "interface{}"
+			return "any"
 		}
 
 	case "numrange":
@@ -417,7 +417,7 @@ func postgresType(req *plugin.GenerateRequest, options *opts.Options, col *plugi
 		case opts.SQLDriverPGXV5:
 			return "pgtype.Range[pgtype.Numeric]"
 		default:
-			return "interface{}"
+			return "any"
 		}
 
 	case "nummultirange":
@@ -425,7 +425,7 @@ func postgresType(req *plugin.GenerateRequest, options *opts.Options, col *plugi
 		case opts.SQLDriverPGXV5:
 			return "pgtype.Multirange[pgtype.Range[pgtype.Numeric]]"
 		default:
-			return "interface{}"
+			return "any"
 		}
 
 	case "int4range":
@@ -435,7 +435,7 @@ func postgresType(req *plugin.GenerateRequest, options *opts.Options, col *plugi
 		case opts.SQLDriverPGXV5:
 			return "pgtype.Range[pgtype.Int4]"
 		default:
-			return "interface{}"
+			return "any"
 		}
 
 	case "int4multirange":
@@ -443,7 +443,7 @@ func postgresType(req *plugin.GenerateRequest, options *opts.Options, col *plugi
 		case opts.SQLDriverPGXV5:
 			return "pgtype.Multirange[pgtype.Range[pgtype.Int4]]"
 		default:
-			return "interface{}"
+			return "any"
 		}
 
 	case "int8range":
@@ -453,7 +453,7 @@ func postgresType(req *plugin.GenerateRequest, options *opts.Options, col *plugi
 		case opts.SQLDriverPGXV5:
 			return "pgtype.Range[pgtype.Int8]"
 		default:
-			return "interface{}"
+			return "any"
 		}
 
 	case "int8multirange":
@@ -461,14 +461,14 @@ func postgresType(req *plugin.GenerateRequest, options *opts.Options, col *plugi
 		case opts.SQLDriverPGXV5:
 			return "pgtype.Multirange[pgtype.Range[pgtype.Int8]]"
 		default:
-			return "interface{}"
+			return "any"
 		}
 
 	case "hstore":
 		if driver.IsPGX() {
 			return "pgtype.Hstore"
 		}
-		return "interface{}"
+		return "any"
 
 	case "bit", "varbit", "pg_catalog.bit", "pg_catalog.varbit":
 		if driver == opts.SQLDriverPGXV5 {
@@ -558,16 +558,16 @@ func postgresType(req *plugin.GenerateRequest, options *opts.Options, col *plugi
 
 	case "void":
 		// A void value can only be scanned into an empty interface.
-		return "interface{}"
+		return "any"
 
 	case "any":
-		return "interface{}"
+		return "any"
 
 	default:
 		rel, err := parseIdentifierString(columnType)
 		if err != nil {
 			// TODO: Should this actually return an error here?
-			return "interface{}"
+			return "any"
 		}
 		if rel.Schema == "" {
 			rel.Schema = req.Catalog.DefaultSchema
@@ -615,5 +615,5 @@ func postgresType(req *plugin.GenerateRequest, options *opts.Options, col *plugi
 	if debug.Active {
 		log.Printf("unknown PostgreSQL type: %s\n", columnType)
 	}
-	return "interface{}"
+	return "any"
 }

--- a/internal/codegen/golang/reserved.go
+++ b/internal/codegen/golang/reserved.go
@@ -9,6 +9,10 @@ func escape(s string) string {
 
 func IsReserved(s string) bool {
 	switch s {
+	// Not a keyword, but generated code refers to the predeclared type
+	// `any`, so a package-scope identifier with that name would shadow it.
+	case "any":
+		return true
 	case "break":
 		return true
 	case "default":

--- a/internal/codegen/golang/result.go
+++ b/internal/codegen/golang/result.go
@@ -198,7 +198,7 @@ func buildQueries(req *plugin.GenerateRequest, options *opts.Options, enums []En
 		if options.EmitExportedQueries {
 			constantName = sdk.Title(query.Name)
 		} else {
-			constantName = sdk.LowerTitle(query.Name)
+			constantName = escape(sdk.LowerTitle(query.Name))
 		}
 
 		comments := query.Comments
@@ -438,7 +438,7 @@ func columnsToStruct(req *plugin.GenerateRequest, options *opts.Options, name st
 	// field with the same name has a known type, assign
 	// the known type to the field without a known type
 	for i, field := range gs.Fields {
-		if len(seen[field.Name]) > 1 && field.Type == "interface{}" {
+		if len(seen[field.Name]) > 1 && field.Type == "any" {
 			for _, j := range seen[field.Name] {
 				if i == j {
 					continue

--- a/internal/codegen/golang/sqlite_type.go
+++ b/internal/codegen/golang/sqlite_type.go
@@ -60,7 +60,7 @@ func sqliteType(req *plugin.GenerateRequest, options *opts.Options, col *plugin.
 		return "json.RawMessage"
 
 	case "any":
-		return "interface{}"
+		return "any"
 
 	}
 
@@ -96,7 +96,7 @@ func sqliteType(req *plugin.GenerateRequest, options *opts.Options, col *plugin.
 			log.Printf("unknown SQLite type: %s\n", dt)
 		}
 
-		return "interface{}"
+		return "any"
 
 	}
 }

--- a/internal/codegen/golang/templates/pgx/batchCode.tmpl
+++ b/internal/codegen/golang/templates/pgx/batchCode.tmpl
@@ -35,7 +35,7 @@ type {{.Ret.Type}} struct { {{- range .Ret.Struct.Fields}}
 func (q *Queries) {{.MethodName}}(ctx context.Context, {{ if $.EmitMethodsWithDBArgument}}db DBTX,{{end}} {{.Arg.SlicePair}}) *{{.MethodName}}BatchResults {
     batch := &pgx.Batch{}
     for _, a := range {{index .Arg.Name}} {
-        vals := []interface{}{
+        vals := []any{
         {{- if .Arg.Struct }}
         {{- range .Arg.Struct.Fields }}
             a.{{.Name}},

--- a/internal/codegen/golang/templates/pgx/copyfromCopy.tmpl
+++ b/internal/codegen/golang/templates/pgx/copyfromCopy.tmpl
@@ -19,8 +19,8 @@ func (r *iteratorFor{{.MethodName}}) Next() bool {
 	return len(r.rows) > 0
 }
 
-func (r iteratorFor{{.MethodName}}) Values() ([]interface{}, error) {
-	return []interface{}{
+func (r iteratorFor{{.MethodName}}) Values() ([]any, error) {
+	return []any{
 {{- if .Arg.Struct }}
 {{- range .Arg.Struct.Fields }}
 		r.rows[0].{{.Name}},

--- a/internal/codegen/golang/templates/pgx/dbCode.tmpl
+++ b/internal/codegen/golang/templates/pgx/dbCode.tmpl
@@ -1,9 +1,9 @@
 {{define "dbCodeTemplatePgx"}}
 
 type DBTX interface {
-	Exec(context.Context, string, ...interface{}) (pgconn.CommandTag, error)
-	Query(context.Context, string, ...interface{}) (pgx.Rows, error)
-	QueryRow(context.Context, string, ...interface{}) pgx.Row
+	Exec(context.Context, string, ...any) (pgconn.CommandTag, error)
+	Query(context.Context, string, ...any) (pgx.Rows, error)
+	QueryRow(context.Context, string, ...any) pgx.Row
 {{- if .UsesCopyFrom }}
 	CopyFrom(ctx context.Context, tableName pgx.Identifier, columnNames []string, rowSrc pgx.CopyFromSource) (int64, error)
 {{- end }}

--- a/internal/codegen/golang/templates/stdlib/dbCode.tmpl
+++ b/internal/codegen/golang/templates/stdlib/dbCode.tmpl
@@ -1,9 +1,9 @@
 {{define "dbCodeTemplateStd"}}
 type DBTX interface {
-	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
 	PrepareContext(context.Context, string) (*sql.Stmt, error)
-	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
-	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
 }
 
 {{ if .EmitMethodsWithDBArgument}}
@@ -42,7 +42,7 @@ func (q *Queries) Close() error {
 	return err
 }
 
-func (q *Queries) exec(ctx context.Context, stmt *sql.Stmt, query string, args ...interface{}) (sql.Result, error) {
+func (q *Queries) exec(ctx context.Context, stmt *sql.Stmt, query string, args ...any) (sql.Result, error) {
 	switch {
 	case stmt != nil && q.tx != nil:
 		return q.tx.StmtContext(ctx, stmt).ExecContext(ctx, args...)
@@ -53,7 +53,7 @@ func (q *Queries) exec(ctx context.Context, stmt *sql.Stmt, query string, args .
 	}
 }
 
-func (q *Queries) query(ctx context.Context, stmt *sql.Stmt, query string, args ...interface{}) (*sql.Rows, error) {
+func (q *Queries) query(ctx context.Context, stmt *sql.Stmt, query string, args ...any) (*sql.Rows, error) {
 	switch {
 	case stmt != nil && q.tx != nil:
 		return q.tx.StmtContext(ctx, stmt).QueryContext(ctx, args...)
@@ -64,7 +64,7 @@ func (q *Queries) query(ctx context.Context, stmt *sql.Stmt, query string, args 
 	}
 }
 
-func (q *Queries) queryRow(ctx context.Context, stmt *sql.Stmt, query string, args ...interface{}) (*sql.Row) {
+func (q *Queries) queryRow(ctx context.Context, stmt *sql.Stmt, query string, args ...any) (*sql.Row) {
 	switch {
 	case stmt != nil && q.tx != nil:
 		return q.tx.StmtContext(ctx, stmt).QueryRowContext(ctx, args...)

--- a/internal/codegen/golang/templates/stdlib/queryCode.tmpl
+++ b/internal/codegen/golang/templates/stdlib/queryCode.tmpl
@@ -127,7 +127,7 @@ func (q *Queries) {{.MethodName}}(ctx context.Context, {{ dbarg }} {{.Arg.Pair}}
 {{define "queryCodeStdExec"}}
     {{- if .Arg.HasSqlcSlices }}
         query := {{.ConstantName}}
-        var queryParams []interface{}
+        var queryParams []any
         {{- if .Arg.Struct }}
             {{- $arg := .Arg }}
             {{- range .Arg.Struct.Fields }}

--- a/internal/codegen/golang/templates/template.tmpl
+++ b/internal/codegen/golang/templates/template.tmpl
@@ -96,7 +96,7 @@ const (
 	{{- end}}
 )
 
-func (e *{{.Name}}) Scan(src interface{}) error {
+func (e *{{.Name}}) Scan(src any) error {
 	switch s := src.(type) {
 	case []byte:
 		*e = {{.Name}}(s)
@@ -114,7 +114,7 @@ type Null{{.Name}} struct {
 }
 
 // Scan implements the Scanner interface.
-func (ns *Null{{.Name}}) Scan(value interface{}) error {
+func (ns *Null{{.Name}}) Scan(value any) error {
 	if value == nil {
 		ns.{{.Name}}, ns.Valid = "", false
 		return nil

--- a/internal/endtoend/testdata/alias/mysql/go/db.go
+++ b/internal/endtoend/testdata/alias/mysql/go/db.go
@@ -10,10 +10,10 @@ import (
 )
 
 type DBTX interface {
-	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
 	PrepareContext(context.Context, string) (*sql.Stmt, error)
-	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
-	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/alias/postgresql/pgx/v4/go/db.go
+++ b/internal/endtoend/testdata/alias/postgresql/pgx/v4/go/db.go
@@ -12,9 +12,9 @@ import (
 )
 
 type DBTX interface {
-	Exec(context.Context, string, ...interface{}) (pgconn.CommandTag, error)
-	Query(context.Context, string, ...interface{}) (pgx.Rows, error)
-	QueryRow(context.Context, string, ...interface{}) pgx.Row
+	Exec(context.Context, string, ...any) (pgconn.CommandTag, error)
+	Query(context.Context, string, ...any) (pgx.Rows, error)
+	QueryRow(context.Context, string, ...any) pgx.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/alias/postgresql/pgx/v5/go/db.go
+++ b/internal/endtoend/testdata/alias/postgresql/pgx/v5/go/db.go
@@ -12,9 +12,9 @@ import (
 )
 
 type DBTX interface {
-	Exec(context.Context, string, ...interface{}) (pgconn.CommandTag, error)
-	Query(context.Context, string, ...interface{}) (pgx.Rows, error)
-	QueryRow(context.Context, string, ...interface{}) pgx.Row
+	Exec(context.Context, string, ...any) (pgconn.CommandTag, error)
+	Query(context.Context, string, ...any) (pgx.Rows, error)
+	QueryRow(context.Context, string, ...any) pgx.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/alias/postgresql/stdlib/go/db.go
+++ b/internal/endtoend/testdata/alias/postgresql/stdlib/go/db.go
@@ -10,10 +10,10 @@ import (
 )
 
 type DBTX interface {
-	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
 	PrepareContext(context.Context, string) (*sql.Stmt, error)
-	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
-	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/alias/sqlite/go/db.go
+++ b/internal/endtoend/testdata/alias/sqlite/go/db.go
@@ -10,10 +10,10 @@ import (
 )
 
 type DBTX interface {
-	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
 	PrepareContext(context.Context, string) (*sql.Stmt, error)
-	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
-	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/any/pgx/v4/go/db.go
+++ b/internal/endtoend/testdata/any/pgx/v4/go/db.go
@@ -12,9 +12,9 @@ import (
 )
 
 type DBTX interface {
-	Exec(context.Context, string, ...interface{}) (pgconn.CommandTag, error)
-	Query(context.Context, string, ...interface{}) (pgx.Rows, error)
-	QueryRow(context.Context, string, ...interface{}) pgx.Row
+	Exec(context.Context, string, ...any) (pgconn.CommandTag, error)
+	Query(context.Context, string, ...any) (pgx.Rows, error)
+	QueryRow(context.Context, string, ...any) pgx.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/any/pgx/v4/go/query.sql.go
+++ b/internal/endtoend/testdata/any/pgx/v4/go/query.sql.go
@@ -9,14 +9,14 @@ import (
 	"context"
 )
 
-const any = `-- name: Any :many
+const any_ = `-- name: Any :many
 SELECT id
 FROM bar
 WHERE id = ANY($1::bigint[])
 `
 
 func (q *Queries) Any(ctx context.Context, dollar_1 []int64) ([]int64, error) {
-	rows, err := q.db.Query(ctx, any, dollar_1)
+	rows, err := q.db.Query(ctx, any_, dollar_1)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/endtoend/testdata/any/pgx/v5/go/db.go
+++ b/internal/endtoend/testdata/any/pgx/v5/go/db.go
@@ -12,9 +12,9 @@ import (
 )
 
 type DBTX interface {
-	Exec(context.Context, string, ...interface{}) (pgconn.CommandTag, error)
-	Query(context.Context, string, ...interface{}) (pgx.Rows, error)
-	QueryRow(context.Context, string, ...interface{}) pgx.Row
+	Exec(context.Context, string, ...any) (pgconn.CommandTag, error)
+	Query(context.Context, string, ...any) (pgx.Rows, error)
+	QueryRow(context.Context, string, ...any) pgx.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/any/pgx/v5/go/query.sql.go
+++ b/internal/endtoend/testdata/any/pgx/v5/go/query.sql.go
@@ -9,14 +9,14 @@ import (
 	"context"
 )
 
-const any = `-- name: Any :many
+const any_ = `-- name: Any :many
 SELECT id
 FROM bar
 WHERE id = ANY($1::bigint[])
 `
 
 func (q *Queries) Any(ctx context.Context, dollar_1 []int64) ([]int64, error) {
-	rows, err := q.db.Query(ctx, any, dollar_1)
+	rows, err := q.db.Query(ctx, any_, dollar_1)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/endtoend/testdata/any/stdlib/go/db.go
+++ b/internal/endtoend/testdata/any/stdlib/go/db.go
@@ -10,10 +10,10 @@ import (
 )
 
 type DBTX interface {
-	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
 	PrepareContext(context.Context, string) (*sql.Stmt, error)
-	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
-	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/any/stdlib/go/query.sql.go
+++ b/internal/endtoend/testdata/any/stdlib/go/query.sql.go
@@ -11,14 +11,14 @@ import (
 	"github.com/lib/pq"
 )
 
-const any = `-- name: Any :many
+const any_ = `-- name: Any :many
 SELECT id
 FROM bar
 WHERE id = ANY($1::bigint[])
 `
 
 func (q *Queries) Any(ctx context.Context, dollar_1 []int64) ([]int64, error) {
-	rows, err := q.db.QueryContext(ctx, any, pq.Array(dollar_1))
+	rows, err := q.db.QueryContext(ctx, any_, pq.Array(dollar_1))
 	if err != nil {
 		return nil, err
 	}

--- a/internal/endtoend/testdata/array_in/pgx/v4/go/db.go
+++ b/internal/endtoend/testdata/array_in/pgx/v4/go/db.go
@@ -12,9 +12,9 @@ import (
 )
 
 type DBTX interface {
-	Exec(context.Context, string, ...interface{}) (pgconn.CommandTag, error)
-	Query(context.Context, string, ...interface{}) (pgx.Rows, error)
-	QueryRow(context.Context, string, ...interface{}) pgx.Row
+	Exec(context.Context, string, ...any) (pgconn.CommandTag, error)
+	Query(context.Context, string, ...any) (pgx.Rows, error)
+	QueryRow(context.Context, string, ...any) pgx.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/array_in/pgx/v5/go/db.go
+++ b/internal/endtoend/testdata/array_in/pgx/v5/go/db.go
@@ -12,9 +12,9 @@ import (
 )
 
 type DBTX interface {
-	Exec(context.Context, string, ...interface{}) (pgconn.CommandTag, error)
-	Query(context.Context, string, ...interface{}) (pgx.Rows, error)
-	QueryRow(context.Context, string, ...interface{}) pgx.Row
+	Exec(context.Context, string, ...any) (pgconn.CommandTag, error)
+	Query(context.Context, string, ...any) (pgx.Rows, error)
+	QueryRow(context.Context, string, ...any) pgx.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/array_in/stdlib/go/db.go
+++ b/internal/endtoend/testdata/array_in/stdlib/go/db.go
@@ -10,10 +10,10 @@ import (
 )
 
 type DBTX interface {
-	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
 	PrepareContext(context.Context, string) (*sql.Stmt, error)
-	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
-	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/array_text/pgx/v4/go/db.go
+++ b/internal/endtoend/testdata/array_text/pgx/v4/go/db.go
@@ -12,9 +12,9 @@ import (
 )
 
 type DBTX interface {
-	Exec(context.Context, string, ...interface{}) (pgconn.CommandTag, error)
-	Query(context.Context, string, ...interface{}) (pgx.Rows, error)
-	QueryRow(context.Context, string, ...interface{}) pgx.Row
+	Exec(context.Context, string, ...any) (pgconn.CommandTag, error)
+	Query(context.Context, string, ...any) (pgx.Rows, error)
+	QueryRow(context.Context, string, ...any) pgx.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/array_text/pgx/v5/go/db.go
+++ b/internal/endtoend/testdata/array_text/pgx/v5/go/db.go
@@ -12,9 +12,9 @@ import (
 )
 
 type DBTX interface {
-	Exec(context.Context, string, ...interface{}) (pgconn.CommandTag, error)
-	Query(context.Context, string, ...interface{}) (pgx.Rows, error)
-	QueryRow(context.Context, string, ...interface{}) pgx.Row
+	Exec(context.Context, string, ...any) (pgconn.CommandTag, error)
+	Query(context.Context, string, ...any) (pgx.Rows, error)
+	QueryRow(context.Context, string, ...any) pgx.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/array_text/stdlib/go/db.go
+++ b/internal/endtoend/testdata/array_text/stdlib/go/db.go
@@ -10,10 +10,10 @@ import (
 )
 
 type DBTX interface {
-	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
 	PrepareContext(context.Context, string) (*sql.Stmt, error)
-	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
-	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/array_text_join/pgx/v4/go/db.go
+++ b/internal/endtoend/testdata/array_text_join/pgx/v4/go/db.go
@@ -12,9 +12,9 @@ import (
 )
 
 type DBTX interface {
-	Exec(context.Context, string, ...interface{}) (pgconn.CommandTag, error)
-	Query(context.Context, string, ...interface{}) (pgx.Rows, error)
-	QueryRow(context.Context, string, ...interface{}) pgx.Row
+	Exec(context.Context, string, ...any) (pgconn.CommandTag, error)
+	Query(context.Context, string, ...any) (pgx.Rows, error)
+	QueryRow(context.Context, string, ...any) pgx.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/array_text_join/pgx/v5/go/db.go
+++ b/internal/endtoend/testdata/array_text_join/pgx/v5/go/db.go
@@ -12,9 +12,9 @@ import (
 )
 
 type DBTX interface {
-	Exec(context.Context, string, ...interface{}) (pgconn.CommandTag, error)
-	Query(context.Context, string, ...interface{}) (pgx.Rows, error)
-	QueryRow(context.Context, string, ...interface{}) pgx.Row
+	Exec(context.Context, string, ...any) (pgconn.CommandTag, error)
+	Query(context.Context, string, ...any) (pgx.Rows, error)
+	QueryRow(context.Context, string, ...any) pgx.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/array_text_join/stdlib/go/db.go
+++ b/internal/endtoend/testdata/array_text_join/stdlib/go/db.go
@@ -10,10 +10,10 @@ import (
 )
 
 type DBTX interface {
-	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
 	PrepareContext(context.Context, string) (*sql.Stmt, error)
-	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
-	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/batch/postgresql/pgx/v4/go/batch.go
+++ b/internal/endtoend/testdata/batch/postgresql/pgx/v4/go/batch.go
@@ -32,7 +32,7 @@ type GetValuesBatchResults struct {
 func (q *Queries) GetValues(ctx context.Context, b []sql.NullInt32) *GetValuesBatchResults {
 	batch := &pgx.Batch{}
 	for _, a := range b {
-		vals := []interface{}{
+		vals := []any{
 			a,
 		}
 		batch.Queue(getValues, vals...)
@@ -97,7 +97,7 @@ type InsertValuesParams struct {
 func (q *Queries) InsertValues(ctx context.Context, arg []InsertValuesParams) *InsertValuesBatchResults {
 	batch := &pgx.Batch{}
 	for _, a := range arg {
-		vals := []interface{}{
+		vals := []any{
 			a.A,
 			a.B,
 		}
@@ -148,7 +148,7 @@ type UpdateValuesParams struct {
 func (q *Queries) UpdateValues(ctx context.Context, arg []UpdateValuesParams) *UpdateValuesBatchResults {
 	batch := &pgx.Batch{}
 	for _, a := range arg {
-		vals := []interface{}{
+		vals := []any{
 			a.A,
 			a.B,
 		}

--- a/internal/endtoend/testdata/batch/postgresql/pgx/v4/go/db.go
+++ b/internal/endtoend/testdata/batch/postgresql/pgx/v4/go/db.go
@@ -12,9 +12,9 @@ import (
 )
 
 type DBTX interface {
-	Exec(context.Context, string, ...interface{}) (pgconn.CommandTag, error)
-	Query(context.Context, string, ...interface{}) (pgx.Rows, error)
-	QueryRow(context.Context, string, ...interface{}) pgx.Row
+	Exec(context.Context, string, ...any) (pgconn.CommandTag, error)
+	Query(context.Context, string, ...any) (pgx.Rows, error)
+	QueryRow(context.Context, string, ...any) pgx.Row
 	SendBatch(context.Context, *pgx.Batch) pgx.BatchResults
 }
 

--- a/internal/endtoend/testdata/batch/postgresql/pgx/v5/go/batch.go
+++ b/internal/endtoend/testdata/batch/postgresql/pgx/v5/go/batch.go
@@ -32,7 +32,7 @@ type GetValuesBatchResults struct {
 func (q *Queries) GetValues(ctx context.Context, b []pgtype.Int4) *GetValuesBatchResults {
 	batch := &pgx.Batch{}
 	for _, a := range b {
-		vals := []interface{}{
+		vals := []any{
 			a,
 		}
 		batch.Queue(getValues, vals...)
@@ -97,7 +97,7 @@ type InsertValuesParams struct {
 func (q *Queries) InsertValues(ctx context.Context, arg []InsertValuesParams) *InsertValuesBatchResults {
 	batch := &pgx.Batch{}
 	for _, a := range arg {
-		vals := []interface{}{
+		vals := []any{
 			a.A,
 			a.B,
 		}
@@ -148,7 +148,7 @@ type UpdateValuesParams struct {
 func (q *Queries) UpdateValues(ctx context.Context, arg []UpdateValuesParams) *UpdateValuesBatchResults {
 	batch := &pgx.Batch{}
 	for _, a := range arg {
-		vals := []interface{}{
+		vals := []any{
 			a.A,
 			a.B,
 		}

--- a/internal/endtoend/testdata/batch/postgresql/pgx/v5/go/db.go
+++ b/internal/endtoend/testdata/batch/postgresql/pgx/v5/go/db.go
@@ -12,9 +12,9 @@ import (
 )
 
 type DBTX interface {
-	Exec(context.Context, string, ...interface{}) (pgconn.CommandTag, error)
-	Query(context.Context, string, ...interface{}) (pgx.Rows, error)
-	QueryRow(context.Context, string, ...interface{}) pgx.Row
+	Exec(context.Context, string, ...any) (pgconn.CommandTag, error)
+	Query(context.Context, string, ...any) (pgx.Rows, error)
+	QueryRow(context.Context, string, ...any) pgx.Row
 	SendBatch(context.Context, *pgx.Batch) pgx.BatchResults
 }
 

--- a/internal/endtoend/testdata/batch_imports/postgresql/pgx/v4/go/batch.go
+++ b/internal/endtoend/testdata/batch_imports/postgresql/pgx/v4/go/batch.go
@@ -32,7 +32,7 @@ type GetValuesBatchResults struct {
 func (q *Queries) GetValues(ctx context.Context, b []sql.NullInt32) *GetValuesBatchResults {
 	batch := &pgx.Batch{}
 	for _, a := range b {
-		vals := []interface{}{
+		vals := []any{
 			a,
 		}
 		batch.Queue(getValues, vals...)
@@ -97,7 +97,7 @@ type InsertValuesParams struct {
 func (q *Queries) InsertValues(ctx context.Context, arg []InsertValuesParams) *InsertValuesBatchResults {
 	batch := &pgx.Batch{}
 	for _, a := range arg {
-		vals := []interface{}{
+		vals := []any{
 			a.A,
 			a.B,
 		}

--- a/internal/endtoend/testdata/batch_imports/postgresql/pgx/v4/go/db.go
+++ b/internal/endtoend/testdata/batch_imports/postgresql/pgx/v4/go/db.go
@@ -12,9 +12,9 @@ import (
 )
 
 type DBTX interface {
-	Exec(context.Context, string, ...interface{}) (pgconn.CommandTag, error)
-	Query(context.Context, string, ...interface{}) (pgx.Rows, error)
-	QueryRow(context.Context, string, ...interface{}) pgx.Row
+	Exec(context.Context, string, ...any) (pgconn.CommandTag, error)
+	Query(context.Context, string, ...any) (pgx.Rows, error)
+	QueryRow(context.Context, string, ...any) pgx.Row
 	SendBatch(context.Context, *pgx.Batch) pgx.BatchResults
 }
 

--- a/internal/endtoend/testdata/batch_imports/postgresql/pgx/v5/go/batch.go
+++ b/internal/endtoend/testdata/batch_imports/postgresql/pgx/v5/go/batch.go
@@ -32,7 +32,7 @@ type GetValuesBatchResults struct {
 func (q *Queries) GetValues(ctx context.Context, b []pgtype.Int4) *GetValuesBatchResults {
 	batch := &pgx.Batch{}
 	for _, a := range b {
-		vals := []interface{}{
+		vals := []any{
 			a,
 		}
 		batch.Queue(getValues, vals...)
@@ -97,7 +97,7 @@ type InsertValuesParams struct {
 func (q *Queries) InsertValues(ctx context.Context, arg []InsertValuesParams) *InsertValuesBatchResults {
 	batch := &pgx.Batch{}
 	for _, a := range arg {
-		vals := []interface{}{
+		vals := []any{
 			a.A,
 			a.B,
 		}

--- a/internal/endtoend/testdata/batch_imports/postgresql/pgx/v5/go/db.go
+++ b/internal/endtoend/testdata/batch_imports/postgresql/pgx/v5/go/db.go
@@ -12,9 +12,9 @@ import (
 )
 
 type DBTX interface {
-	Exec(context.Context, string, ...interface{}) (pgconn.CommandTag, error)
-	Query(context.Context, string, ...interface{}) (pgx.Rows, error)
-	QueryRow(context.Context, string, ...interface{}) pgx.Row
+	Exec(context.Context, string, ...any) (pgconn.CommandTag, error)
+	Query(context.Context, string, ...any) (pgx.Rows, error)
+	QueryRow(context.Context, string, ...any) pgx.Row
 	SendBatch(context.Context, *pgx.Batch) pgx.BatchResults
 }
 

--- a/internal/endtoend/testdata/batch_parameter_limit/postgresql/pgx/go/batch.go
+++ b/internal/endtoend/testdata/batch_parameter_limit/postgresql/pgx/go/batch.go
@@ -39,7 +39,7 @@ type CreateAuthorsParams struct {
 func (q *Queries) CreateAuthors(ctx context.Context, arg []CreateAuthorsParams) *CreateAuthorsBatchResults {
 	batch := &pgx.Batch{}
 	for _, a := range arg {
-		vals := []interface{}{
+		vals := []any{
 			a.Name,
 			a.Bio,
 		}

--- a/internal/endtoend/testdata/batch_parameter_limit/postgresql/pgx/go/db.go
+++ b/internal/endtoend/testdata/batch_parameter_limit/postgresql/pgx/go/db.go
@@ -12,9 +12,9 @@ import (
 )
 
 type DBTX interface {
-	Exec(context.Context, string, ...interface{}) (pgconn.CommandTag, error)
-	Query(context.Context, string, ...interface{}) (pgx.Rows, error)
-	QueryRow(context.Context, string, ...interface{}) pgx.Row
+	Exec(context.Context, string, ...any) (pgconn.CommandTag, error)
+	Query(context.Context, string, ...any) (pgx.Rows, error)
+	QueryRow(context.Context, string, ...any) pgx.Row
 	SendBatch(context.Context, *pgx.Batch) pgx.BatchResults
 }
 

--- a/internal/endtoend/testdata/batch_parameter_type/postgresql/pgx/go/batch.go
+++ b/internal/endtoend/testdata/batch_parameter_type/postgresql/pgx/go/batch.go
@@ -67,7 +67,7 @@ type InsertMapppingParams struct {
 func (q *Queries) InsertMappping(ctx context.Context, arg []InsertMapppingParams) *InsertMapppingBatchResults {
 	batch := &pgx.Batch{}
 	for _, a := range arg {
-		vals := []interface{}{
+		vals := []any{
 			a.DeviceId,
 			a.Version,
 			a.Sn,

--- a/internal/endtoend/testdata/batch_parameter_type/postgresql/pgx/go/db.go
+++ b/internal/endtoend/testdata/batch_parameter_type/postgresql/pgx/go/db.go
@@ -12,9 +12,9 @@ import (
 )
 
 type DBTX interface {
-	Exec(context.Context, string, ...interface{}) (pgconn.CommandTag, error)
-	Query(context.Context, string, ...interface{}) (pgx.Rows, error)
-	QueryRow(context.Context, string, ...interface{}) pgx.Row
+	Exec(context.Context, string, ...any) (pgconn.CommandTag, error)
+	Query(context.Context, string, ...any) (pgx.Rows, error)
+	QueryRow(context.Context, string, ...any) pgx.Row
 	SendBatch(context.Context, *pgx.Batch) pgx.BatchResults
 }
 

--- a/internal/endtoend/testdata/between_args/mysql/go/db.go
+++ b/internal/endtoend/testdata/between_args/mysql/go/db.go
@@ -10,10 +10,10 @@ import (
 )
 
 type DBTX interface {
-	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
 	PrepareContext(context.Context, string) (*sql.Stmt, error)
-	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
-	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/between_args/sqlite/go/db.go
+++ b/internal/endtoend/testdata/between_args/sqlite/go/db.go
@@ -10,10 +10,10 @@ import (
 )
 
 type DBTX interface {
-	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
 	PrepareContext(context.Context, string) (*sql.Stmt, error)
-	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
-	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/bit_string/pgx/v4/go/db.go
+++ b/internal/endtoend/testdata/bit_string/pgx/v4/go/db.go
@@ -12,9 +12,9 @@ import (
 )
 
 type DBTX interface {
-	Exec(context.Context, string, ...interface{}) (pgconn.CommandTag, error)
-	Query(context.Context, string, ...interface{}) (pgx.Rows, error)
-	QueryRow(context.Context, string, ...interface{}) pgx.Row
+	Exec(context.Context, string, ...any) (pgconn.CommandTag, error)
+	Query(context.Context, string, ...any) (pgx.Rows, error)
+	QueryRow(context.Context, string, ...any) pgx.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/bit_string/pgx/v5/go/db.go
+++ b/internal/endtoend/testdata/bit_string/pgx/v5/go/db.go
@@ -12,9 +12,9 @@ import (
 )
 
 type DBTX interface {
-	Exec(context.Context, string, ...interface{}) (pgconn.CommandTag, error)
-	Query(context.Context, string, ...interface{}) (pgx.Rows, error)
-	QueryRow(context.Context, string, ...interface{}) pgx.Row
+	Exec(context.Context, string, ...any) (pgconn.CommandTag, error)
+	Query(context.Context, string, ...any) (pgx.Rows, error)
+	QueryRow(context.Context, string, ...any) pgx.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/build_tags/postgresql/stdlib/go/db.go
+++ b/internal/endtoend/testdata/build_tags/postgresql/stdlib/go/db.go
@@ -12,10 +12,10 @@ import (
 )
 
 type DBTX interface {
-	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
 	PrepareContext(context.Context, string) (*sql.Stmt, error)
-	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
-	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/builtins/postgresql/go/db.go
+++ b/internal/endtoend/testdata/builtins/postgresql/go/db.go
@@ -10,10 +10,10 @@ import (
 )
 
 type DBTX interface {
-	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
 	PrepareContext(context.Context, string) (*sql.Stmt, error)
-	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
-	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/builtins/sqlite/go/aggfunc.sql.go
+++ b/internal/endtoend/testdata/builtins/sqlite/go/aggfunc.sql.go
@@ -91,9 +91,9 @@ const getMaxInt = `-- name: GetMaxInt :one
 SELECT max(int_val) FROM test
 `
 
-func (q *Queries) GetMaxInt(ctx context.Context) (interface{}, error) {
+func (q *Queries) GetMaxInt(ctx context.Context) (any, error) {
 	row := q.db.QueryRowContext(ctx, getMaxInt)
-	var max interface{}
+	var max any
 	err := row.Scan(&max)
 	return max, err
 }
@@ -102,9 +102,9 @@ const getMaxText = `-- name: GetMaxText :one
 SELECT max(text_val) FROM test
 `
 
-func (q *Queries) GetMaxText(ctx context.Context) (interface{}, error) {
+func (q *Queries) GetMaxText(ctx context.Context) (any, error) {
 	row := q.db.QueryRowContext(ctx, getMaxText)
-	var max interface{}
+	var max any
 	err := row.Scan(&max)
 	return max, err
 }
@@ -113,9 +113,9 @@ const getMinInt = `-- name: GetMinInt :one
 SELECT min(int_val) FROM test
 `
 
-func (q *Queries) GetMinInt(ctx context.Context) (interface{}, error) {
+func (q *Queries) GetMinInt(ctx context.Context) (any, error) {
 	row := q.db.QueryRowContext(ctx, getMinInt)
-	var min interface{}
+	var min any
 	err := row.Scan(&min)
 	return min, err
 }
@@ -124,9 +124,9 @@ const getMinText = `-- name: GetMinText :one
 SELECT min(text_val) FROM test
 `
 
-func (q *Queries) GetMinText(ctx context.Context) (interface{}, error) {
+func (q *Queries) GetMinText(ctx context.Context) (any, error) {
 	row := q.db.QueryRowContext(ctx, getMinText)
-	var min interface{}
+	var min any
 	err := row.Scan(&min)
 	return min, err
 }

--- a/internal/endtoend/testdata/builtins/sqlite/go/db.go
+++ b/internal/endtoend/testdata/builtins/sqlite/go/db.go
@@ -10,10 +10,10 @@ import (
 )
 
 type DBTX interface {
-	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
 	PrepareContext(context.Context, string) (*sql.Stmt, error)
-	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
-	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/builtins/sqlite/go/scalarfunc.sql.go
+++ b/internal/endtoend/testdata/builtins/sqlite/go/scalarfunc.sql.go
@@ -58,9 +58,9 @@ const getCoalesce = `-- name: GetCoalesce :one
 SELECT coalesce(NULL, 1, 'test')
 `
 
-func (q *Queries) GetCoalesce(ctx context.Context) (interface{}, error) {
+func (q *Queries) GetCoalesce(ctx context.Context) (any, error) {
 	row := q.db.QueryRowContext(ctx, getCoalesce)
-	var coalesce interface{}
+	var coalesce any
 	err := row.Scan(&coalesce)
 	return coalesce, err
 }
@@ -102,9 +102,9 @@ const getIfnull = `-- name: GetIfnull :one
 SELECT ifnull(1, 2)
 `
 
-func (q *Queries) GetIfnull(ctx context.Context) (interface{}, error) {
+func (q *Queries) GetIfnull(ctx context.Context) (any, error) {
 	row := q.db.QueryRowContext(ctx, getIfnull)
-	var ifnull interface{}
+	var ifnull any
 	err := row.Scan(&ifnull)
 	return ifnull, err
 }
@@ -113,9 +113,9 @@ const getIif = `-- name: GetIif :one
 SELECT iif(1, 2, 3)
 `
 
-func (q *Queries) GetIif(ctx context.Context) (interface{}, error) {
+func (q *Queries) GetIif(ctx context.Context) (any, error) {
 	row := q.db.QueryRowContext(ctx, getIif)
-	var iif interface{}
+	var iif any
 	err := row.Scan(&iif)
 	return iif, err
 }
@@ -179,9 +179,9 @@ const getLikelihood = `-- name: GetLikelihood :one
 SELECT likelihood('12345', 0.5)
 `
 
-func (q *Queries) GetLikelihood(ctx context.Context) (interface{}, error) {
+func (q *Queries) GetLikelihood(ctx context.Context) (any, error) {
 	row := q.db.QueryRowContext(ctx, getLikelihood)
-	var likelihood interface{}
+	var likelihood any
 	err := row.Scan(&likelihood)
 	return likelihood, err
 }
@@ -190,9 +190,9 @@ const getLikely = `-- name: GetLikely :one
 SELECT likely('12345')
 `
 
-func (q *Queries) GetLikely(ctx context.Context) (interface{}, error) {
+func (q *Queries) GetLikely(ctx context.Context) (any, error) {
 	row := q.db.QueryRowContext(ctx, getLikely)
-	var likely interface{}
+	var likely any
 	err := row.Scan(&likely)
 	return likely, err
 }
@@ -234,9 +234,9 @@ const getMax3 = `-- name: GetMax3 :one
 SELECT max(1, 3, 2)
 `
 
-func (q *Queries) GetMax3(ctx context.Context) (interface{}, error) {
+func (q *Queries) GetMax3(ctx context.Context) (any, error) {
 	row := q.db.QueryRowContext(ctx, getMax3)
-	var max interface{}
+	var max any
 	err := row.Scan(&max)
 	return max, err
 }
@@ -245,9 +245,9 @@ const getMin3 = `-- name: GetMin3 :one
 SELECT min(1, 3, 2)
 `
 
-func (q *Queries) GetMin3(ctx context.Context) (interface{}, error) {
+func (q *Queries) GetMin3(ctx context.Context) (any, error) {
 	row := q.db.QueryRowContext(ctx, getMin3)
-	var min interface{}
+	var min any
 	err := row.Scan(&min)
 	return min, err
 }
@@ -256,9 +256,9 @@ const getNullif = `-- name: GetNullif :one
 SELECT nullif(1, 2)
 `
 
-func (q *Queries) GetNullif(ctx context.Context) (interface{}, error) {
+func (q *Queries) GetNullif(ctx context.Context) (any, error) {
 	row := q.db.QueryRowContext(ctx, getNullif)
-	var nullif interface{}
+	var nullif any
 	err := row.Scan(&nullif)
 	return nullif, err
 }
@@ -289,9 +289,9 @@ const getRandom = `-- name: GetRandom :one
 SELECT random()
 `
 
-func (q *Queries) GetRandom(ctx context.Context) (interface{}, error) {
+func (q *Queries) GetRandom(ctx context.Context) (any, error) {
 	row := q.db.QueryRowContext(ctx, getRandom)
-	var random interface{}
+	var random any
 	err := row.Scan(&random)
 	return random, err
 }
@@ -300,9 +300,9 @@ const getRandomBlob = `-- name: GetRandomBlob :one
 SELECT randomblob(16)
 `
 
-func (q *Queries) GetRandomBlob(ctx context.Context) (interface{}, error) {
+func (q *Queries) GetRandomBlob(ctx context.Context) (any, error) {
 	row := q.db.QueryRowContext(ctx, getRandomBlob)
-	var randomblob interface{}
+	var randomblob any
 	err := row.Scan(&randomblob)
 	return randomblob, err
 }
@@ -531,9 +531,9 @@ const getUnlikely = `-- name: GetUnlikely :one
 SELECT unlikely('12345')
 `
 
-func (q *Queries) GetUnlikely(ctx context.Context) (interface{}, error) {
+func (q *Queries) GetUnlikely(ctx context.Context) (any, error) {
 	row := q.db.QueryRowContext(ctx, getUnlikely)
-	var unlikely interface{}
+	var unlikely any
 	err := row.Scan(&unlikely)
 	return unlikely, err
 }

--- a/internal/endtoend/testdata/case_named_params/mysql/go/db.go
+++ b/internal/endtoend/testdata/case_named_params/mysql/go/db.go
@@ -10,10 +10,10 @@ import (
 )
 
 type DBTX interface {
-	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
 	PrepareContext(context.Context, string) (*sql.Stmt, error)
-	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
-	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/case_named_params/postgresql/go/db.go
+++ b/internal/endtoend/testdata/case_named_params/postgresql/go/db.go
@@ -10,10 +10,10 @@ import (
 )
 
 type DBTX interface {
-	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
 	PrepareContext(context.Context, string) (*sql.Stmt, error)
-	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
-	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/case_named_params/sqlite/go/db.go
+++ b/internal/endtoend/testdata/case_named_params/sqlite/go/db.go
@@ -10,10 +10,10 @@ import (
 )
 
 type DBTX interface {
-	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
 	PrepareContext(context.Context, string) (*sql.Stmt, error)
-	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
-	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/case_named_params/sqlite/go/query.sql.go
+++ b/internal/endtoend/testdata/case_named_params/sqlite/go/query.sql.go
@@ -18,8 +18,8 @@ LIMIT   1
 `
 
 type ListAuthorsParams struct {
-	Email    interface{}
-	Username interface{}
+	Email    any
+	Username any
 }
 
 func (q *Queries) ListAuthors(ctx context.Context, arg ListAuthorsParams) (Author, error) {

--- a/internal/endtoend/testdata/case_sensitive/sqlite/go/db.go
+++ b/internal/endtoend/testdata/case_sensitive/sqlite/go/db.go
@@ -10,10 +10,10 @@ import (
 )
 
 type DBTX interface {
-	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
 	PrepareContext(context.Context, string) (*sql.Stmt, error)
-	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
-	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/case_stmt_bool/pgx/v4/go/db.go
+++ b/internal/endtoend/testdata/case_stmt_bool/pgx/v4/go/db.go
@@ -12,9 +12,9 @@ import (
 )
 
 type DBTX interface {
-	Exec(context.Context, string, ...interface{}) (pgconn.CommandTag, error)
-	Query(context.Context, string, ...interface{}) (pgx.Rows, error)
-	QueryRow(context.Context, string, ...interface{}) pgx.Row
+	Exec(context.Context, string, ...any) (pgconn.CommandTag, error)
+	Query(context.Context, string, ...any) (pgx.Rows, error)
+	QueryRow(context.Context, string, ...any) pgx.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/case_stmt_bool/pgx/v5/go/db.go
+++ b/internal/endtoend/testdata/case_stmt_bool/pgx/v5/go/db.go
@@ -12,9 +12,9 @@ import (
 )
 
 type DBTX interface {
-	Exec(context.Context, string, ...interface{}) (pgconn.CommandTag, error)
-	Query(context.Context, string, ...interface{}) (pgx.Rows, error)
-	QueryRow(context.Context, string, ...interface{}) pgx.Row
+	Exec(context.Context, string, ...any) (pgconn.CommandTag, error)
+	Query(context.Context, string, ...any) (pgx.Rows, error)
+	QueryRow(context.Context, string, ...any) pgx.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/case_stmt_bool/stdlib/go/db.go
+++ b/internal/endtoend/testdata/case_stmt_bool/stdlib/go/db.go
@@ -10,10 +10,10 @@ import (
 )
 
 type DBTX interface {
-	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
 	PrepareContext(context.Context, string) (*sql.Stmt, error)
-	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
-	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/case_text/pgx/v4/go/db.go
+++ b/internal/endtoend/testdata/case_text/pgx/v4/go/db.go
@@ -12,9 +12,9 @@ import (
 )
 
 type DBTX interface {
-	Exec(context.Context, string, ...interface{}) (pgconn.CommandTag, error)
-	Query(context.Context, string, ...interface{}) (pgx.Rows, error)
-	QueryRow(context.Context, string, ...interface{}) pgx.Row
+	Exec(context.Context, string, ...any) (pgconn.CommandTag, error)
+	Query(context.Context, string, ...any) (pgx.Rows, error)
+	QueryRow(context.Context, string, ...any) pgx.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/case_text/pgx/v5/go/db.go
+++ b/internal/endtoend/testdata/case_text/pgx/v5/go/db.go
@@ -12,9 +12,9 @@ import (
 )
 
 type DBTX interface {
-	Exec(context.Context, string, ...interface{}) (pgconn.CommandTag, error)
-	Query(context.Context, string, ...interface{}) (pgx.Rows, error)
-	QueryRow(context.Context, string, ...interface{}) pgx.Row
+	Exec(context.Context, string, ...any) (pgconn.CommandTag, error)
+	Query(context.Context, string, ...any) (pgx.Rows, error)
+	QueryRow(context.Context, string, ...any) pgx.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/case_text/stdlib/go/db.go
+++ b/internal/endtoend/testdata/case_text/stdlib/go/db.go
@@ -10,10 +10,10 @@ import (
 )
 
 type DBTX interface {
-	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
 	PrepareContext(context.Context, string) (*sql.Stmt, error)
-	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
-	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/case_value_param/mysql/go/db.go
+++ b/internal/endtoend/testdata/case_value_param/mysql/go/db.go
@@ -10,10 +10,10 @@ import (
 )
 
 type DBTX interface {
-	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
 	PrepareContext(context.Context, string) (*sql.Stmt, error)
-	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
-	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/case_value_param/postgresql/go/db.go
+++ b/internal/endtoend/testdata/case_value_param/postgresql/go/db.go
@@ -12,9 +12,9 @@ import (
 )
 
 type DBTX interface {
-	Exec(context.Context, string, ...interface{}) (pgconn.CommandTag, error)
-	Query(context.Context, string, ...interface{}) (pgx.Rows, error)
-	QueryRow(context.Context, string, ...interface{}) pgx.Row
+	Exec(context.Context, string, ...any) (pgconn.CommandTag, error)
+	Query(context.Context, string, ...any) (pgx.Rows, error)
+	QueryRow(context.Context, string, ...any) pgx.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/cast_coalesce/pgx/v4/go/db.go
+++ b/internal/endtoend/testdata/cast_coalesce/pgx/v4/go/db.go
@@ -12,9 +12,9 @@ import (
 )
 
 type DBTX interface {
-	Exec(context.Context, string, ...interface{}) (pgconn.CommandTag, error)
-	Query(context.Context, string, ...interface{}) (pgx.Rows, error)
-	QueryRow(context.Context, string, ...interface{}) pgx.Row
+	Exec(context.Context, string, ...any) (pgconn.CommandTag, error)
+	Query(context.Context, string, ...any) (pgx.Rows, error)
+	QueryRow(context.Context, string, ...any) pgx.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/cast_coalesce/pgx/v5/go/db.go
+++ b/internal/endtoend/testdata/cast_coalesce/pgx/v5/go/db.go
@@ -12,9 +12,9 @@ import (
 )
 
 type DBTX interface {
-	Exec(context.Context, string, ...interface{}) (pgconn.CommandTag, error)
-	Query(context.Context, string, ...interface{}) (pgx.Rows, error)
-	QueryRow(context.Context, string, ...interface{}) pgx.Row
+	Exec(context.Context, string, ...any) (pgconn.CommandTag, error)
+	Query(context.Context, string, ...any) (pgx.Rows, error)
+	QueryRow(context.Context, string, ...any) pgx.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/cast_coalesce/stdlib/go/db.go
+++ b/internal/endtoend/testdata/cast_coalesce/stdlib/go/db.go
@@ -10,10 +10,10 @@ import (
 )
 
 type DBTX interface {
-	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
 	PrepareContext(context.Context, string) (*sql.Stmt, error)
-	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
-	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/cast_null/pgx/v4/go/db.go
+++ b/internal/endtoend/testdata/cast_null/pgx/v4/go/db.go
@@ -12,9 +12,9 @@ import (
 )
 
 type DBTX interface {
-	Exec(context.Context, string, ...interface{}) (pgconn.CommandTag, error)
-	Query(context.Context, string, ...interface{}) (pgx.Rows, error)
-	QueryRow(context.Context, string, ...interface{}) pgx.Row
+	Exec(context.Context, string, ...any) (pgconn.CommandTag, error)
+	Query(context.Context, string, ...any) (pgx.Rows, error)
+	QueryRow(context.Context, string, ...any) pgx.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/cast_null/pgx/v5/go/db.go
+++ b/internal/endtoend/testdata/cast_null/pgx/v5/go/db.go
@@ -12,9 +12,9 @@ import (
 )
 
 type DBTX interface {
-	Exec(context.Context, string, ...interface{}) (pgconn.CommandTag, error)
-	Query(context.Context, string, ...interface{}) (pgx.Rows, error)
-	QueryRow(context.Context, string, ...interface{}) pgx.Row
+	Exec(context.Context, string, ...any) (pgconn.CommandTag, error)
+	Query(context.Context, string, ...any) (pgx.Rows, error)
+	QueryRow(context.Context, string, ...any) pgx.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/cast_null/stdlib/go/db.go
+++ b/internal/endtoend/testdata/cast_null/stdlib/go/db.go
@@ -10,10 +10,10 @@ import (
 )
 
 type DBTX interface {
-	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
 	PrepareContext(context.Context, string) (*sql.Stmt, error)
-	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
-	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/cast_param/sqlite/go/db.go
+++ b/internal/endtoend/testdata/cast_param/sqlite/go/db.go
@@ -10,10 +10,10 @@ import (
 )
 
 type DBTX interface {
-	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
 	PrepareContext(context.Context, string) (*sql.Stmt, error)
-	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
-	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/cid_oid_tid_xid/pgx/v4/go/db.go
+++ b/internal/endtoend/testdata/cid_oid_tid_xid/pgx/v4/go/db.go
@@ -12,9 +12,9 @@ import (
 )
 
 type DBTX interface {
-	Exec(context.Context, string, ...interface{}) (pgconn.CommandTag, error)
-	Query(context.Context, string, ...interface{}) (pgx.Rows, error)
-	QueryRow(context.Context, string, ...interface{}) pgx.Row
+	Exec(context.Context, string, ...any) (pgconn.CommandTag, error)
+	Query(context.Context, string, ...any) (pgx.Rows, error)
+	QueryRow(context.Context, string, ...any) pgx.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/cid_oid_tid_xid/pgx/v5/go/db.go
+++ b/internal/endtoend/testdata/cid_oid_tid_xid/pgx/v5/go/db.go
@@ -12,9 +12,9 @@ import (
 )
 
 type DBTX interface {
-	Exec(context.Context, string, ...interface{}) (pgconn.CommandTag, error)
-	Query(context.Context, string, ...interface{}) (pgx.Rows, error)
-	QueryRow(context.Context, string, ...interface{}) pgx.Row
+	Exec(context.Context, string, ...any) (pgconn.CommandTag, error)
+	Query(context.Context, string, ...any) (pgx.Rows, error)
+	QueryRow(context.Context, string, ...any) pgx.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/citext/pgx/go/db.go
+++ b/internal/endtoend/testdata/citext/pgx/go/db.go
@@ -12,9 +12,9 @@ import (
 )
 
 type DBTX interface {
-	Exec(context.Context, string, ...interface{}) (pgconn.CommandTag, error)
-	Query(context.Context, string, ...interface{}) (pgx.Rows, error)
-	QueryRow(context.Context, string, ...interface{}) pgx.Row
+	Exec(context.Context, string, ...any) (pgconn.CommandTag, error)
+	Query(context.Context, string, ...any) (pgx.Rows, error)
+	QueryRow(context.Context, string, ...any) pgx.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/citext/stdlib/go/db.go
+++ b/internal/endtoend/testdata/citext/stdlib/go/db.go
@@ -10,10 +10,10 @@ import (
 )
 
 type DBTX interface {
-	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
 	PrepareContext(context.Context, string) (*sql.Stmt, error)
-	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
-	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/coalesce/mysql/go/db.go
+++ b/internal/endtoend/testdata/coalesce/mysql/go/db.go
@@ -10,10 +10,10 @@ import (
 )
 
 type DBTX interface {
-	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
 	PrepareContext(context.Context, string) (*sql.Stmt, error)
-	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
-	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/coalesce/postgresql/pgx/v4/go/db.go
+++ b/internal/endtoend/testdata/coalesce/postgresql/pgx/v4/go/db.go
@@ -12,9 +12,9 @@ import (
 )
 
 type DBTX interface {
-	Exec(context.Context, string, ...interface{}) (pgconn.CommandTag, error)
-	Query(context.Context, string, ...interface{}) (pgx.Rows, error)
-	QueryRow(context.Context, string, ...interface{}) pgx.Row
+	Exec(context.Context, string, ...any) (pgconn.CommandTag, error)
+	Query(context.Context, string, ...any) (pgx.Rows, error)
+	QueryRow(context.Context, string, ...any) pgx.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/coalesce/postgresql/pgx/v5/go/db.go
+++ b/internal/endtoend/testdata/coalesce/postgresql/pgx/v5/go/db.go
@@ -12,9 +12,9 @@ import (
 )
 
 type DBTX interface {
-	Exec(context.Context, string, ...interface{}) (pgconn.CommandTag, error)
-	Query(context.Context, string, ...interface{}) (pgx.Rows, error)
-	QueryRow(context.Context, string, ...interface{}) pgx.Row
+	Exec(context.Context, string, ...any) (pgconn.CommandTag, error)
+	Query(context.Context, string, ...any) (pgx.Rows, error)
+	QueryRow(context.Context, string, ...any) pgx.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/coalesce/postgresql/stdlib/go/db.go
+++ b/internal/endtoend/testdata/coalesce/postgresql/stdlib/go/db.go
@@ -10,10 +10,10 @@ import (
 )
 
 type DBTX interface {
-	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
 	PrepareContext(context.Context, string) (*sql.Stmt, error)
-	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
-	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/coalesce/sqlite/go/db.go
+++ b/internal/endtoend/testdata/coalesce/sqlite/go/db.go
@@ -10,10 +10,10 @@ import (
 )
 
 type DBTX interface {
-	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
 	PrepareContext(context.Context, string) (*sql.Stmt, error)
-	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
-	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/coalesce_as/mysql/go/db.go
+++ b/internal/endtoend/testdata/coalesce_as/mysql/go/db.go
@@ -10,10 +10,10 @@ import (
 )
 
 type DBTX interface {
-	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
 	PrepareContext(context.Context, string) (*sql.Stmt, error)
-	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
-	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/coalesce_as/mysql/go/query.sql.go
+++ b/internal/endtoend/testdata/coalesce_as/mysql/go/query.sql.go
@@ -18,7 +18,7 @@ GROUP BY 1
 
 type SumBazRow struct {
 	Bar      sql.NullString
-	Quantity interface{}
+	Quantity any
 }
 
 func (q *Queries) SumBaz(ctx context.Context) ([]SumBazRow, error) {

--- a/internal/endtoend/testdata/coalesce_as/postgresql/pganalyze/go/db.go
+++ b/internal/endtoend/testdata/coalesce_as/postgresql/pganalyze/go/db.go
@@ -12,9 +12,9 @@ import (
 )
 
 type DBTX interface {
-	Exec(context.Context, string, ...interface{}) (pgconn.CommandTag, error)
-	Query(context.Context, string, ...interface{}) (pgx.Rows, error)
-	QueryRow(context.Context, string, ...interface{}) pgx.Row
+	Exec(context.Context, string, ...any) (pgconn.CommandTag, error)
+	Query(context.Context, string, ...any) (pgx.Rows, error)
+	QueryRow(context.Context, string, ...any) pgx.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/coalesce_as/postgresql/pgx/v4/go/db.go
+++ b/internal/endtoend/testdata/coalesce_as/postgresql/pgx/v4/go/db.go
@@ -12,9 +12,9 @@ import (
 )
 
 type DBTX interface {
-	Exec(context.Context, string, ...interface{}) (pgconn.CommandTag, error)
-	Query(context.Context, string, ...interface{}) (pgx.Rows, error)
-	QueryRow(context.Context, string, ...interface{}) pgx.Row
+	Exec(context.Context, string, ...any) (pgconn.CommandTag, error)
+	Query(context.Context, string, ...any) (pgx.Rows, error)
+	QueryRow(context.Context, string, ...any) pgx.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/coalesce_as/postgresql/pgx/v4/go/query.sql.go
+++ b/internal/endtoend/testdata/coalesce_as/postgresql/pgx/v4/go/query.sql.go
@@ -18,7 +18,7 @@ GROUP BY 1
 
 type SumBazRow struct {
 	Bar      sql.NullString
-	Quantity interface{}
+	Quantity any
 }
 
 func (q *Queries) SumBaz(ctx context.Context) ([]SumBazRow, error) {

--- a/internal/endtoend/testdata/coalesce_as/postgresql/pgx/v5/go/db.go
+++ b/internal/endtoend/testdata/coalesce_as/postgresql/pgx/v5/go/db.go
@@ -12,9 +12,9 @@ import (
 )
 
 type DBTX interface {
-	Exec(context.Context, string, ...interface{}) (pgconn.CommandTag, error)
-	Query(context.Context, string, ...interface{}) (pgx.Rows, error)
-	QueryRow(context.Context, string, ...interface{}) pgx.Row
+	Exec(context.Context, string, ...any) (pgconn.CommandTag, error)
+	Query(context.Context, string, ...any) (pgx.Rows, error)
+	QueryRow(context.Context, string, ...any) pgx.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/coalesce_as/postgresql/pgx/v5/go/query.sql.go
+++ b/internal/endtoend/testdata/coalesce_as/postgresql/pgx/v5/go/query.sql.go
@@ -19,7 +19,7 @@ GROUP BY 1
 
 type SumBazRow struct {
 	Bar      pgtype.Text
-	Quantity interface{}
+	Quantity any
 }
 
 func (q *Queries) SumBaz(ctx context.Context) ([]SumBazRow, error) {

--- a/internal/endtoend/testdata/coalesce_as/postgresql/stdlib/go/db.go
+++ b/internal/endtoend/testdata/coalesce_as/postgresql/stdlib/go/db.go
@@ -10,10 +10,10 @@ import (
 )
 
 type DBTX interface {
-	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
 	PrepareContext(context.Context, string) (*sql.Stmt, error)
-	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
-	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/coalesce_as/postgresql/stdlib/go/query.sql.go
+++ b/internal/endtoend/testdata/coalesce_as/postgresql/stdlib/go/query.sql.go
@@ -18,7 +18,7 @@ GROUP BY 1
 
 type SumBazRow struct {
 	Bar      sql.NullString
-	Quantity interface{}
+	Quantity any
 }
 
 func (q *Queries) SumBaz(ctx context.Context) ([]SumBazRow, error) {

--- a/internal/endtoend/testdata/coalesce_as/sqlite/go/db.go
+++ b/internal/endtoend/testdata/coalesce_as/sqlite/go/db.go
@@ -10,10 +10,10 @@ import (
 )
 
 type DBTX interface {
-	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
 	PrepareContext(context.Context, string) (*sql.Stmt, error)
-	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
-	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/coalesce_as/sqlite/go/query.sql.go
+++ b/internal/endtoend/testdata/coalesce_as/sqlite/go/query.sql.go
@@ -18,7 +18,7 @@ GROUP BY 1
 
 type SumBazRow struct {
 	Bar      sql.NullString
-	Quantity interface{}
+	Quantity any
 }
 
 func (q *Queries) SumBaz(ctx context.Context) ([]SumBazRow, error) {

--- a/internal/endtoend/testdata/coalesce_join/postgresql/go/db.go
+++ b/internal/endtoend/testdata/coalesce_join/postgresql/go/db.go
@@ -10,10 +10,10 @@ import (
 )
 
 type DBTX interface {
-	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
 	PrepareContext(context.Context, string) (*sql.Stmt, error)
-	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
-	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/coalesce_params/mysql/go/db.go
+++ b/internal/endtoend/testdata/coalesce_params/mysql/go/db.go
@@ -10,10 +10,10 @@ import (
 )
 
 type DBTX interface {
-	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
 	PrepareContext(context.Context, string) (*sql.Stmt, error)
-	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
-	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/coalesce_params/mysql/go/models.go
+++ b/internal/endtoend/testdata/coalesce_params/mysql/go/models.go
@@ -18,7 +18,7 @@ const (
 	CalendarMaincalendarFalse CalendarMaincalendar = "false"
 )
 
-func (e *CalendarMaincalendar) Scan(src interface{}) error {
+func (e *CalendarMaincalendar) Scan(src any) error {
 	switch s := src.(type) {
 	case []byte:
 		*e = CalendarMaincalendar(s)
@@ -36,7 +36,7 @@ type NullCalendarMaincalendar struct {
 }
 
 // Scan implements the Scanner interface.
-func (ns *NullCalendarMaincalendar) Scan(value interface{}) error {
+func (ns *NullCalendarMaincalendar) Scan(value any) error {
 	if value == nil {
 		ns.CalendarMaincalendar, ns.Valid = "", false
 		return nil

--- a/internal/endtoend/testdata/coalesce_params/mysql/go/query.sql.go
+++ b/internal/endtoend/testdata/coalesce_params/mysql/go/query.sql.go
@@ -23,8 +23,8 @@ INSERT INTO authors (
 
 type AddAuthorParams struct {
 	Address        string
-	CalName        interface{}
-	CalDescription interface{}
+	CalName        any
+	CalDescription any
 }
 
 func (q *Queries) AddAuthor(ctx context.Context, arg AddAuthorParams) (int64, error) {
@@ -44,7 +44,7 @@ INSERT INTO ` + "`" + `Event` + "`" + ` (
 `
 
 type AddEventParams struct {
-	Timezone      interface{}
+	Timezone      any
 	CalendarIdKey string
 }
 

--- a/internal/endtoend/testdata/codegen_struct_field_names/stdlib/go/db.go
+++ b/internal/endtoend/testdata/codegen_struct_field_names/stdlib/go/db.go
@@ -10,10 +10,10 @@ import (
 )
 
 type DBTX interface {
-	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
 	PrepareContext(context.Context, string) (*sql.Stmt, error)
-	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
-	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/column_alias/stdlib/go/db.go
+++ b/internal/endtoend/testdata/column_alias/stdlib/go/db.go
@@ -10,10 +10,10 @@ import (
 )
 
 type DBTX interface {
-	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
 	PrepareContext(context.Context, string) (*sql.Stmt, error)
-	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
-	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/column_as/mysql/go/db.go
+++ b/internal/endtoend/testdata/column_as/mysql/go/db.go
@@ -10,10 +10,10 @@ import (
 )
 
 type DBTX interface {
-	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
 	PrepareContext(context.Context, string) (*sql.Stmt, error)
-	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
-	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/column_as/postgresql/pgx/v4/go/db.go
+++ b/internal/endtoend/testdata/column_as/postgresql/pgx/v4/go/db.go
@@ -12,9 +12,9 @@ import (
 )
 
 type DBTX interface {
-	Exec(context.Context, string, ...interface{}) (pgconn.CommandTag, error)
-	Query(context.Context, string, ...interface{}) (pgx.Rows, error)
-	QueryRow(context.Context, string, ...interface{}) pgx.Row
+	Exec(context.Context, string, ...any) (pgconn.CommandTag, error)
+	Query(context.Context, string, ...any) (pgx.Rows, error)
+	QueryRow(context.Context, string, ...any) pgx.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/column_as/postgresql/pgx/v5/go/db.go
+++ b/internal/endtoend/testdata/column_as/postgresql/pgx/v5/go/db.go
@@ -12,9 +12,9 @@ import (
 )
 
 type DBTX interface {
-	Exec(context.Context, string, ...interface{}) (pgconn.CommandTag, error)
-	Query(context.Context, string, ...interface{}) (pgx.Rows, error)
-	QueryRow(context.Context, string, ...interface{}) pgx.Row
+	Exec(context.Context, string, ...any) (pgconn.CommandTag, error)
+	Query(context.Context, string, ...any) (pgx.Rows, error)
+	QueryRow(context.Context, string, ...any) pgx.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/column_as/postgresql/stdlib/go/db.go
+++ b/internal/endtoend/testdata/column_as/postgresql/stdlib/go/db.go
@@ -10,10 +10,10 @@ import (
 )
 
 type DBTX interface {
-	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
 	PrepareContext(context.Context, string) (*sql.Stmt, error)
-	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
-	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/column_as/sqlite/go/db.go
+++ b/internal/endtoend/testdata/column_as/sqlite/go/db.go
@@ -10,10 +10,10 @@ import (
 )
 
 type DBTX interface {
-	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
 	PrepareContext(context.Context, string) (*sql.Stmt, error)
-	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
-	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/comment_godoc/postgresql/pgx/v4/go/db.go
+++ b/internal/endtoend/testdata/comment_godoc/postgresql/pgx/v4/go/db.go
@@ -12,9 +12,9 @@ import (
 )
 
 type DBTX interface {
-	Exec(context.Context, string, ...interface{}) (pgconn.CommandTag, error)
-	Query(context.Context, string, ...interface{}) (pgx.Rows, error)
-	QueryRow(context.Context, string, ...interface{}) pgx.Row
+	Exec(context.Context, string, ...any) (pgconn.CommandTag, error)
+	Query(context.Context, string, ...any) (pgx.Rows, error)
+	QueryRow(context.Context, string, ...any) pgx.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/comment_godoc/postgresql/pgx/v5/go/db.go
+++ b/internal/endtoend/testdata/comment_godoc/postgresql/pgx/v5/go/db.go
@@ -12,9 +12,9 @@ import (
 )
 
 type DBTX interface {
-	Exec(context.Context, string, ...interface{}) (pgconn.CommandTag, error)
-	Query(context.Context, string, ...interface{}) (pgx.Rows, error)
-	QueryRow(context.Context, string, ...interface{}) pgx.Row
+	Exec(context.Context, string, ...any) (pgconn.CommandTag, error)
+	Query(context.Context, string, ...any) (pgx.Rows, error)
+	QueryRow(context.Context, string, ...any) pgx.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/comment_godoc_db_argument/postgresql/pgx/v4/go/db.go
+++ b/internal/endtoend/testdata/comment_godoc_db_argument/postgresql/pgx/v4/go/db.go
@@ -12,9 +12,9 @@ import (
 )
 
 type DBTX interface {
-	Exec(context.Context, string, ...interface{}) (pgconn.CommandTag, error)
-	Query(context.Context, string, ...interface{}) (pgx.Rows, error)
-	QueryRow(context.Context, string, ...interface{}) pgx.Row
+	Exec(context.Context, string, ...any) (pgconn.CommandTag, error)
+	Query(context.Context, string, ...any) (pgx.Rows, error)
+	QueryRow(context.Context, string, ...any) pgx.Row
 }
 
 func New() *Queries {

--- a/internal/endtoend/testdata/comment_godoc_db_argument/postgresql/pgx/v5/go/db.go
+++ b/internal/endtoend/testdata/comment_godoc_db_argument/postgresql/pgx/v5/go/db.go
@@ -12,9 +12,9 @@ import (
 )
 
 type DBTX interface {
-	Exec(context.Context, string, ...interface{}) (pgconn.CommandTag, error)
-	Query(context.Context, string, ...interface{}) (pgx.Rows, error)
-	QueryRow(context.Context, string, ...interface{}) pgx.Row
+	Exec(context.Context, string, ...any) (pgconn.CommandTag, error)
+	Query(context.Context, string, ...any) (pgx.Rows, error)
+	QueryRow(context.Context, string, ...any) pgx.Row
 }
 
 func New() *Queries {

--- a/internal/endtoend/testdata/comment_on/postgresql/pgx/v4/go/db.go
+++ b/internal/endtoend/testdata/comment_on/postgresql/pgx/v4/go/db.go
@@ -12,9 +12,9 @@ import (
 )
 
 type DBTX interface {
-	Exec(context.Context, string, ...interface{}) (pgconn.CommandTag, error)
-	Query(context.Context, string, ...interface{}) (pgx.Rows, error)
-	QueryRow(context.Context, string, ...interface{}) pgx.Row
+	Exec(context.Context, string, ...any) (pgconn.CommandTag, error)
+	Query(context.Context, string, ...any) (pgx.Rows, error)
+	QueryRow(context.Context, string, ...any) pgx.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/comment_on/postgresql/pgx/v4/go/models.go
+++ b/internal/endtoend/testdata/comment_on/postgresql/pgx/v4/go/models.go
@@ -18,7 +18,7 @@ const (
 	FooMoodHappy FooMood = "happy"
 )
 
-func (e *FooMood) Scan(src interface{}) error {
+func (e *FooMood) Scan(src any) error {
 	switch s := src.(type) {
 	case []byte:
 		*e = FooMood(s)
@@ -36,7 +36,7 @@ type NullFooMood struct {
 }
 
 // Scan implements the Scanner interface.
-func (ns *NullFooMood) Scan(value interface{}) error {
+func (ns *NullFooMood) Scan(value any) error {
 	if value == nil {
 		ns.FooMood, ns.Valid = "", false
 		return nil

--- a/internal/endtoend/testdata/comment_on/postgresql/pgx/v5/go/db.go
+++ b/internal/endtoend/testdata/comment_on/postgresql/pgx/v5/go/db.go
@@ -12,9 +12,9 @@ import (
 )
 
 type DBTX interface {
-	Exec(context.Context, string, ...interface{}) (pgconn.CommandTag, error)
-	Query(context.Context, string, ...interface{}) (pgx.Rows, error)
-	QueryRow(context.Context, string, ...interface{}) pgx.Row
+	Exec(context.Context, string, ...any) (pgconn.CommandTag, error)
+	Query(context.Context, string, ...any) (pgx.Rows, error)
+	QueryRow(context.Context, string, ...any) pgx.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/comment_on/postgresql/pgx/v5/go/models.go
+++ b/internal/endtoend/testdata/comment_on/postgresql/pgx/v5/go/models.go
@@ -18,7 +18,7 @@ const (
 	FooMoodHappy FooMood = "happy"
 )
 
-func (e *FooMood) Scan(src interface{}) error {
+func (e *FooMood) Scan(src any) error {
 	switch s := src.(type) {
 	case []byte:
 		*e = FooMood(s)
@@ -36,7 +36,7 @@ type NullFooMood struct {
 }
 
 // Scan implements the Scanner interface.
-func (ns *NullFooMood) Scan(value interface{}) error {
+func (ns *NullFooMood) Scan(value any) error {
 	if value == nil {
 		ns.FooMood, ns.Valid = "", false
 		return nil

--- a/internal/endtoend/testdata/comment_on/postgresql/stdlib/go/db.go
+++ b/internal/endtoend/testdata/comment_on/postgresql/stdlib/go/db.go
@@ -10,10 +10,10 @@ import (
 )
 
 type DBTX interface {
-	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
 	PrepareContext(context.Context, string) (*sql.Stmt, error)
-	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
-	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/comment_on/postgresql/stdlib/go/models.go
+++ b/internal/endtoend/testdata/comment_on/postgresql/stdlib/go/models.go
@@ -18,7 +18,7 @@ const (
 	FooMoodHappy FooMood = "happy"
 )
 
-func (e *FooMood) Scan(src interface{}) error {
+func (e *FooMood) Scan(src any) error {
 	switch s := src.(type) {
 	case []byte:
 		*e = FooMood(s)
@@ -36,7 +36,7 @@ type NullFooMood struct {
 }
 
 // Scan implements the Scanner interface.
-func (ns *NullFooMood) Scan(value interface{}) error {
+func (ns *NullFooMood) Scan(value any) error {
 	if value == nil {
 		ns.FooMood, ns.Valid = "", false
 		return nil

--- a/internal/endtoend/testdata/comment_syntax/mysql/go/db.go
+++ b/internal/endtoend/testdata/comment_syntax/mysql/go/db.go
@@ -10,10 +10,10 @@ import (
 )
 
 type DBTX interface {
-	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
 	PrepareContext(context.Context, string) (*sql.Stmt, error)
-	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
-	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/comment_syntax/postgresql/pgx/v4/go/db.go
+++ b/internal/endtoend/testdata/comment_syntax/postgresql/pgx/v4/go/db.go
@@ -12,9 +12,9 @@ import (
 )
 
 type DBTX interface {
-	Exec(context.Context, string, ...interface{}) (pgconn.CommandTag, error)
-	Query(context.Context, string, ...interface{}) (pgx.Rows, error)
-	QueryRow(context.Context, string, ...interface{}) pgx.Row
+	Exec(context.Context, string, ...any) (pgconn.CommandTag, error)
+	Query(context.Context, string, ...any) (pgx.Rows, error)
+	QueryRow(context.Context, string, ...any) pgx.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/comment_syntax/postgresql/pgx/v5/go/db.go
+++ b/internal/endtoend/testdata/comment_syntax/postgresql/pgx/v5/go/db.go
@@ -12,9 +12,9 @@ import (
 )
 
 type DBTX interface {
-	Exec(context.Context, string, ...interface{}) (pgconn.CommandTag, error)
-	Query(context.Context, string, ...interface{}) (pgx.Rows, error)
-	QueryRow(context.Context, string, ...interface{}) pgx.Row
+	Exec(context.Context, string, ...any) (pgconn.CommandTag, error)
+	Query(context.Context, string, ...any) (pgx.Rows, error)
+	QueryRow(context.Context, string, ...any) pgx.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/comment_syntax/postgresql/stdlib/go/db.go
+++ b/internal/endtoend/testdata/comment_syntax/postgresql/stdlib/go/db.go
@@ -10,10 +10,10 @@ import (
 )
 
 type DBTX interface {
-	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
 	PrepareContext(context.Context, string) (*sql.Stmt, error)
-	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
-	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/comment_syntax/sqlite/go/db.go
+++ b/internal/endtoend/testdata/comment_syntax/sqlite/go/db.go
@@ -10,10 +10,10 @@ import (
 )
 
 type DBTX interface {
-	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
 	PrepareContext(context.Context, string) (*sql.Stmt, error)
-	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
-	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/comparisons/mysql/go/db.go
+++ b/internal/endtoend/testdata/comparisons/mysql/go/db.go
@@ -10,10 +10,10 @@ import (
 )
 
 type DBTX interface {
-	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
 	PrepareContext(context.Context, string) (*sql.Stmt, error)
-	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
-	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/comparisons/postgresql/pgx/v4/go/db.go
+++ b/internal/endtoend/testdata/comparisons/postgresql/pgx/v4/go/db.go
@@ -12,9 +12,9 @@ import (
 )
 
 type DBTX interface {
-	Exec(context.Context, string, ...interface{}) (pgconn.CommandTag, error)
-	Query(context.Context, string, ...interface{}) (pgx.Rows, error)
-	QueryRow(context.Context, string, ...interface{}) pgx.Row
+	Exec(context.Context, string, ...any) (pgconn.CommandTag, error)
+	Query(context.Context, string, ...any) (pgx.Rows, error)
+	QueryRow(context.Context, string, ...any) pgx.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/comparisons/postgresql/pgx/v5/go/db.go
+++ b/internal/endtoend/testdata/comparisons/postgresql/pgx/v5/go/db.go
@@ -12,9 +12,9 @@ import (
 )
 
 type DBTX interface {
-	Exec(context.Context, string, ...interface{}) (pgconn.CommandTag, error)
-	Query(context.Context, string, ...interface{}) (pgx.Rows, error)
-	QueryRow(context.Context, string, ...interface{}) pgx.Row
+	Exec(context.Context, string, ...any) (pgconn.CommandTag, error)
+	Query(context.Context, string, ...any) (pgx.Rows, error)
+	QueryRow(context.Context, string, ...any) pgx.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/comparisons/postgresql/stdlib/go/db.go
+++ b/internal/endtoend/testdata/comparisons/postgresql/stdlib/go/db.go
@@ -10,10 +10,10 @@ import (
 )
 
 type DBTX interface {
-	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
 	PrepareContext(context.Context, string) (*sql.Stmt, error)
-	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
-	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/comparisons/sqlite/go/db.go
+++ b/internal/endtoend/testdata/comparisons/sqlite/go/db.go
@@ -10,10 +10,10 @@ import (
 )
 
 type DBTX interface {
-	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
 	PrepareContext(context.Context, string) (*sql.Stmt, error)
-	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
-	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/composite_type/pgx/v4/go/db.go
+++ b/internal/endtoend/testdata/composite_type/pgx/v4/go/db.go
@@ -12,9 +12,9 @@ import (
 )
 
 type DBTX interface {
-	Exec(context.Context, string, ...interface{}) (pgconn.CommandTag, error)
-	Query(context.Context, string, ...interface{}) (pgx.Rows, error)
-	QueryRow(context.Context, string, ...interface{}) pgx.Row
+	Exec(context.Context, string, ...any) (pgconn.CommandTag, error)
+	Query(context.Context, string, ...any) (pgx.Rows, error)
+	QueryRow(context.Context, string, ...any) pgx.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/composite_type/pgx/v5/go/db.go
+++ b/internal/endtoend/testdata/composite_type/pgx/v5/go/db.go
@@ -12,9 +12,9 @@ import (
 )
 
 type DBTX interface {
-	Exec(context.Context, string, ...interface{}) (pgconn.CommandTag, error)
-	Query(context.Context, string, ...interface{}) (pgx.Rows, error)
-	QueryRow(context.Context, string, ...interface{}) pgx.Row
+	Exec(context.Context, string, ...any) (pgconn.CommandTag, error)
+	Query(context.Context, string, ...any) (pgx.Rows, error)
+	QueryRow(context.Context, string, ...any) pgx.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/composite_type/stdlib/go/db.go
+++ b/internal/endtoend/testdata/composite_type/stdlib/go/db.go
@@ -10,10 +10,10 @@ import (
 )
 
 type DBTX interface {
-	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
 	PrepareContext(context.Context, string) (*sql.Stmt, error)
-	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
-	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/conflicted_arg_name/postgresql/db/db.go
+++ b/internal/endtoend/testdata/conflicted_arg_name/postgresql/db/db.go
@@ -10,10 +10,10 @@ import (
 )
 
 type DBTX interface {
-	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
 	PrepareContext(context.Context, string) (*sql.Stmt, error)
-	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
-	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/copyfrom/mysql/go/db.go
+++ b/internal/endtoend/testdata/copyfrom/mysql/go/db.go
@@ -10,10 +10,10 @@ import (
 )
 
 type DBTX interface {
-	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
 	PrepareContext(context.Context, string) (*sql.Stmt, error)
-	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
-	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/copyfrom/postgresql/pgx/v4/go/copyfrom.go
+++ b/internal/endtoend/testdata/copyfrom/postgresql/pgx/v4/go/copyfrom.go
@@ -28,8 +28,8 @@ func (r *iteratorForInsertSingleValue) Next() bool {
 	return len(r.rows) > 0
 }
 
-func (r iteratorForInsertSingleValue) Values() ([]interface{}, error) {
-	return []interface{}{
+func (r iteratorForInsertSingleValue) Values() ([]any, error) {
+	return []any{
 		r.rows[0],
 	}, nil
 }
@@ -61,8 +61,8 @@ func (r *iteratorForInsertValues) Next() bool {
 	return len(r.rows) > 0
 }
 
-func (r iteratorForInsertValues) Values() ([]interface{}, error) {
-	return []interface{}{
+func (r iteratorForInsertValues) Values() ([]any, error) {
+	return []any{
 		r.rows[0].A,
 		r.rows[0].B,
 	}, nil

--- a/internal/endtoend/testdata/copyfrom/postgresql/pgx/v4/go/db.go
+++ b/internal/endtoend/testdata/copyfrom/postgresql/pgx/v4/go/db.go
@@ -12,9 +12,9 @@ import (
 )
 
 type DBTX interface {
-	Exec(context.Context, string, ...interface{}) (pgconn.CommandTag, error)
-	Query(context.Context, string, ...interface{}) (pgx.Rows, error)
-	QueryRow(context.Context, string, ...interface{}) pgx.Row
+	Exec(context.Context, string, ...any) (pgconn.CommandTag, error)
+	Query(context.Context, string, ...any) (pgx.Rows, error)
+	QueryRow(context.Context, string, ...any) pgx.Row
 	CopyFrom(ctx context.Context, tableName pgx.Identifier, columnNames []string, rowSrc pgx.CopyFromSource) (int64, error)
 }
 

--- a/internal/endtoend/testdata/copyfrom/postgresql/pgx/v5/go/copyfrom.go
+++ b/internal/endtoend/testdata/copyfrom/postgresql/pgx/v5/go/copyfrom.go
@@ -29,8 +29,8 @@ func (r *iteratorForInsertSingleValue) Next() bool {
 	return len(r.rows) > 0
 }
 
-func (r iteratorForInsertSingleValue) Values() ([]interface{}, error) {
-	return []interface{}{
+func (r iteratorForInsertSingleValue) Values() ([]any, error) {
+	return []any{
 		r.rows[0],
 	}, nil
 }
@@ -62,8 +62,8 @@ func (r *iteratorForInsertValues) Next() bool {
 	return len(r.rows) > 0
 }
 
-func (r iteratorForInsertValues) Values() ([]interface{}, error) {
-	return []interface{}{
+func (r iteratorForInsertValues) Values() ([]any, error) {
+	return []any{
 		r.rows[0].A,
 		r.rows[0].B,
 	}, nil

--- a/internal/endtoend/testdata/copyfrom/postgresql/pgx/v5/go/db.go
+++ b/internal/endtoend/testdata/copyfrom/postgresql/pgx/v5/go/db.go
@@ -12,9 +12,9 @@ import (
 )
 
 type DBTX interface {
-	Exec(context.Context, string, ...interface{}) (pgconn.CommandTag, error)
-	Query(context.Context, string, ...interface{}) (pgx.Rows, error)
-	QueryRow(context.Context, string, ...interface{}) pgx.Row
+	Exec(context.Context, string, ...any) (pgconn.CommandTag, error)
+	Query(context.Context, string, ...any) (pgx.Rows, error)
+	QueryRow(context.Context, string, ...any) pgx.Row
 	CopyFrom(ctx context.Context, tableName pgx.Identifier, columnNames []string, rowSrc pgx.CopyFromSource) (int64, error)
 }
 

--- a/internal/endtoend/testdata/copyfrom_imports/postgresql/pgx/v4/go/copyfrom.go
+++ b/internal/endtoend/testdata/copyfrom_imports/postgresql/pgx/v4/go/copyfrom.go
@@ -27,8 +27,8 @@ func (r *iteratorForInsertValues) Next() bool {
 	return len(r.rows) > 0
 }
 
-func (r iteratorForInsertValues) Values() ([]interface{}, error) {
-	return []interface{}{
+func (r iteratorForInsertValues) Values() ([]any, error) {
+	return []any{
 		r.rows[0].A,
 		r.rows[0].B,
 	}, nil

--- a/internal/endtoend/testdata/copyfrom_imports/postgresql/pgx/v4/go/db.go
+++ b/internal/endtoend/testdata/copyfrom_imports/postgresql/pgx/v4/go/db.go
@@ -12,9 +12,9 @@ import (
 )
 
 type DBTX interface {
-	Exec(context.Context, string, ...interface{}) (pgconn.CommandTag, error)
-	Query(context.Context, string, ...interface{}) (pgx.Rows, error)
-	QueryRow(context.Context, string, ...interface{}) pgx.Row
+	Exec(context.Context, string, ...any) (pgconn.CommandTag, error)
+	Query(context.Context, string, ...any) (pgx.Rows, error)
+	QueryRow(context.Context, string, ...any) pgx.Row
 	CopyFrom(ctx context.Context, tableName pgx.Identifier, columnNames []string, rowSrc pgx.CopyFromSource) (int64, error)
 }
 

--- a/internal/endtoend/testdata/copyfrom_imports/postgresql/pgx/v5/go/copyfrom.go
+++ b/internal/endtoend/testdata/copyfrom_imports/postgresql/pgx/v5/go/copyfrom.go
@@ -27,8 +27,8 @@ func (r *iteratorForInsertValues) Next() bool {
 	return len(r.rows) > 0
 }
 
-func (r iteratorForInsertValues) Values() ([]interface{}, error) {
-	return []interface{}{
+func (r iteratorForInsertValues) Values() ([]any, error) {
+	return []any{
 		r.rows[0].A,
 		r.rows[0].B,
 	}, nil

--- a/internal/endtoend/testdata/copyfrom_imports/postgresql/pgx/v5/go/db.go
+++ b/internal/endtoend/testdata/copyfrom_imports/postgresql/pgx/v5/go/db.go
@@ -12,9 +12,9 @@ import (
 )
 
 type DBTX interface {
-	Exec(context.Context, string, ...interface{}) (pgconn.CommandTag, error)
-	Query(context.Context, string, ...interface{}) (pgx.Rows, error)
-	QueryRow(context.Context, string, ...interface{}) pgx.Row
+	Exec(context.Context, string, ...any) (pgconn.CommandTag, error)
+	Query(context.Context, string, ...any) (pgx.Rows, error)
+	QueryRow(context.Context, string, ...any) pgx.Row
 	CopyFrom(ctx context.Context, tableName pgx.Identifier, columnNames []string, rowSrc pgx.CopyFromSource) (int64, error)
 }
 

--- a/internal/endtoend/testdata/copyfrom_multicolumn_parameter_limit/mysql/go/db.go
+++ b/internal/endtoend/testdata/copyfrom_multicolumn_parameter_limit/mysql/go/db.go
@@ -10,10 +10,10 @@ import (
 )
 
 type DBTX interface {
-	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
 	PrepareContext(context.Context, string) (*sql.Stmt, error)
-	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
-	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/copyfrom_named_params/postgresql/pgx/go/copyfrom.go
+++ b/internal/endtoend/testdata/copyfrom_named_params/postgresql/pgx/go/copyfrom.go
@@ -27,8 +27,8 @@ func (r *iteratorForStageUserData) Next() bool {
 	return len(r.rows) > 0
 }
 
-func (r iteratorForStageUserData) Values() ([]interface{}, error) {
-	return []interface{}{
+func (r iteratorForStageUserData) Values() ([]any, error) {
+	return []any{
 		r.rows[0].IDParam,
 		r.rows[0].UserParam,
 	}, nil

--- a/internal/endtoend/testdata/copyfrom_named_params/postgresql/pgx/go/db.go
+++ b/internal/endtoend/testdata/copyfrom_named_params/postgresql/pgx/go/db.go
@@ -12,9 +12,9 @@ import (
 )
 
 type DBTX interface {
-	Exec(context.Context, string, ...interface{}) (pgconn.CommandTag, error)
-	Query(context.Context, string, ...interface{}) (pgx.Rows, error)
-	QueryRow(context.Context, string, ...interface{}) pgx.Row
+	Exec(context.Context, string, ...any) (pgconn.CommandTag, error)
+	Query(context.Context, string, ...any) (pgx.Rows, error)
+	QueryRow(context.Context, string, ...any) pgx.Row
 	CopyFrom(ctx context.Context, tableName pgx.Identifier, columnNames []string, rowSrc pgx.CopyFromSource) (int64, error)
 }
 

--- a/internal/endtoend/testdata/copyfrom_singlecolumn/postgresql/pgx/v4/go/copyfrom.go
+++ b/internal/endtoend/testdata/copyfrom_singlecolumn/postgresql/pgx/v4/go/copyfrom.go
@@ -27,8 +27,8 @@ func (r *iteratorForCreateAuthors) Next() bool {
 	return len(r.rows) > 0
 }
 
-func (r iteratorForCreateAuthors) Values() ([]interface{}, error) {
-	return []interface{}{
+func (r iteratorForCreateAuthors) Values() ([]any, error) {
+	return []any{
 		r.rows[0],
 	}, nil
 }

--- a/internal/endtoend/testdata/copyfrom_singlecolumn/postgresql/pgx/v4/go/db.go
+++ b/internal/endtoend/testdata/copyfrom_singlecolumn/postgresql/pgx/v4/go/db.go
@@ -12,9 +12,9 @@ import (
 )
 
 type DBTX interface {
-	Exec(context.Context, string, ...interface{}) (pgconn.CommandTag, error)
-	Query(context.Context, string, ...interface{}) (pgx.Rows, error)
-	QueryRow(context.Context, string, ...interface{}) pgx.Row
+	Exec(context.Context, string, ...any) (pgconn.CommandTag, error)
+	Query(context.Context, string, ...any) (pgx.Rows, error)
+	QueryRow(context.Context, string, ...any) pgx.Row
 	CopyFrom(ctx context.Context, tableName pgx.Identifier, columnNames []string, rowSrc pgx.CopyFromSource) (int64, error)
 }
 

--- a/internal/endtoend/testdata/copyfrom_singlecolumn/postgresql/pgx/v5/go/copyfrom.go
+++ b/internal/endtoend/testdata/copyfrom_singlecolumn/postgresql/pgx/v5/go/copyfrom.go
@@ -27,8 +27,8 @@ func (r *iteratorForCreateAuthors) Next() bool {
 	return len(r.rows) > 0
 }
 
-func (r iteratorForCreateAuthors) Values() ([]interface{}, error) {
-	return []interface{}{
+func (r iteratorForCreateAuthors) Values() ([]any, error) {
+	return []any{
 		r.rows[0],
 	}, nil
 }

--- a/internal/endtoend/testdata/copyfrom_singlecolumn/postgresql/pgx/v5/go/db.go
+++ b/internal/endtoend/testdata/copyfrom_singlecolumn/postgresql/pgx/v5/go/db.go
@@ -12,9 +12,9 @@ import (
 )
 
 type DBTX interface {
-	Exec(context.Context, string, ...interface{}) (pgconn.CommandTag, error)
-	Query(context.Context, string, ...interface{}) (pgx.Rows, error)
-	QueryRow(context.Context, string, ...interface{}) pgx.Row
+	Exec(context.Context, string, ...any) (pgconn.CommandTag, error)
+	Query(context.Context, string, ...any) (pgx.Rows, error)
+	QueryRow(context.Context, string, ...any) pgx.Row
 	CopyFrom(ctx context.Context, tableName pgx.Identifier, columnNames []string, rowSrc pgx.CopyFromSource) (int64, error)
 }
 

--- a/internal/endtoend/testdata/copyfrom_singlecolumn_struct_only/mysql/go/db.go
+++ b/internal/endtoend/testdata/copyfrom_singlecolumn_struct_only/mysql/go/db.go
@@ -10,10 +10,10 @@ import (
 )
 
 type DBTX interface {
-	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
 	PrepareContext(context.Context, string) (*sql.Stmt, error)
-	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
-	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/count_star/mysql/go/db.go
+++ b/internal/endtoend/testdata/count_star/mysql/go/db.go
@@ -10,10 +10,10 @@ import (
 )
 
 type DBTX interface {
-	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
 	PrepareContext(context.Context, string) (*sql.Stmt, error)
-	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
-	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/count_star/postgresql/pgx/v4/go/db.go
+++ b/internal/endtoend/testdata/count_star/postgresql/pgx/v4/go/db.go
@@ -12,9 +12,9 @@ import (
 )
 
 type DBTX interface {
-	Exec(context.Context, string, ...interface{}) (pgconn.CommandTag, error)
-	Query(context.Context, string, ...interface{}) (pgx.Rows, error)
-	QueryRow(context.Context, string, ...interface{}) pgx.Row
+	Exec(context.Context, string, ...any) (pgconn.CommandTag, error)
+	Query(context.Context, string, ...any) (pgx.Rows, error)
+	QueryRow(context.Context, string, ...any) pgx.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/count_star/postgresql/pgx/v5/go/db.go
+++ b/internal/endtoend/testdata/count_star/postgresql/pgx/v5/go/db.go
@@ -12,9 +12,9 @@ import (
 )
 
 type DBTX interface {
-	Exec(context.Context, string, ...interface{}) (pgconn.CommandTag, error)
-	Query(context.Context, string, ...interface{}) (pgx.Rows, error)
-	QueryRow(context.Context, string, ...interface{}) pgx.Row
+	Exec(context.Context, string, ...any) (pgconn.CommandTag, error)
+	Query(context.Context, string, ...any) (pgx.Rows, error)
+	QueryRow(context.Context, string, ...any) pgx.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/count_star/postgresql/stdlib/go/db.go
+++ b/internal/endtoend/testdata/count_star/postgresql/stdlib/go/db.go
@@ -10,10 +10,10 @@ import (
 )
 
 type DBTX interface {
-	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
 	PrepareContext(context.Context, string) (*sql.Stmt, error)
-	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
-	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/count_star/sqlite/go/db.go
+++ b/internal/endtoend/testdata/count_star/sqlite/go/db.go
@@ -10,10 +10,10 @@ import (
 )
 
 type DBTX interface {
-	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
 	PrepareContext(context.Context, string) (*sql.Stmt, error)
-	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
-	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/create_materialized_view/postgresql/go/db.go
+++ b/internal/endtoend/testdata/create_materialized_view/postgresql/go/db.go
@@ -10,10 +10,10 @@ import (
 )
 
 type DBTX interface {
-	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
 	PrepareContext(context.Context, string) (*sql.Stmt, error)
-	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
-	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/create_table_as/postgresql/go/db.go
+++ b/internal/endtoend/testdata/create_table_as/postgresql/go/db.go
@@ -10,10 +10,10 @@ import (
 )
 
 type DBTX interface {
-	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
 	PrepareContext(context.Context, string) (*sql.Stmt, error)
-	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
-	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/create_table_like/mysql/go/db.go
+++ b/internal/endtoend/testdata/create_table_like/mysql/go/db.go
@@ -10,10 +10,10 @@ import (
 )
 
 type DBTX interface {
-	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
 	PrepareContext(context.Context, string) (*sql.Stmt, error)
-	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
-	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/create_table_like/postgresql/go/db.go
+++ b/internal/endtoend/testdata/create_table_like/postgresql/go/db.go
@@ -10,10 +10,10 @@ import (
 )
 
 type DBTX interface {
-	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
 	PrepareContext(context.Context, string) (*sql.Stmt, error)
-	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
-	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/create_view/mysql/go/db.go
+++ b/internal/endtoend/testdata/create_view/mysql/go/db.go
@@ -10,10 +10,10 @@ import (
 )
 
 type DBTX interface {
-	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
 	PrepareContext(context.Context, string) (*sql.Stmt, error)
-	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
-	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/create_view/postgresql/go/db.go
+++ b/internal/endtoend/testdata/create_view/postgresql/go/db.go
@@ -10,10 +10,10 @@ import (
 )
 
 type DBTX interface {
-	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
 	PrepareContext(context.Context, string) (*sql.Stmt, error)
-	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
-	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/create_view/sqlite/go/db.go
+++ b/internal/endtoend/testdata/create_view/sqlite/go/db.go
@@ -10,10 +10,10 @@ import (
 )
 
 type DBTX interface {
-	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
 	PrepareContext(context.Context, string) (*sql.Stmt, error)
-	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
-	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/cte_count/mysql/go/db.go
+++ b/internal/endtoend/testdata/cte_count/mysql/go/db.go
@@ -10,10 +10,10 @@ import (
 )
 
 type DBTX interface {
-	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
 	PrepareContext(context.Context, string) (*sql.Stmt, error)
-	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
-	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/cte_count/pgx/v4/go/db.go
+++ b/internal/endtoend/testdata/cte_count/pgx/v4/go/db.go
@@ -12,9 +12,9 @@ import (
 )
 
 type DBTX interface {
-	Exec(context.Context, string, ...interface{}) (pgconn.CommandTag, error)
-	Query(context.Context, string, ...interface{}) (pgx.Rows, error)
-	QueryRow(context.Context, string, ...interface{}) pgx.Row
+	Exec(context.Context, string, ...any) (pgconn.CommandTag, error)
+	Query(context.Context, string, ...any) (pgx.Rows, error)
+	QueryRow(context.Context, string, ...any) pgx.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/cte_count/pgx/v5/go/db.go
+++ b/internal/endtoend/testdata/cte_count/pgx/v5/go/db.go
@@ -12,9 +12,9 @@ import (
 )
 
 type DBTX interface {
-	Exec(context.Context, string, ...interface{}) (pgconn.CommandTag, error)
-	Query(context.Context, string, ...interface{}) (pgx.Rows, error)
-	QueryRow(context.Context, string, ...interface{}) pgx.Row
+	Exec(context.Context, string, ...any) (pgconn.CommandTag, error)
+	Query(context.Context, string, ...any) (pgx.Rows, error)
+	QueryRow(context.Context, string, ...any) pgx.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/cte_count/stdlib/go/db.go
+++ b/internal/endtoend/testdata/cte_count/stdlib/go/db.go
@@ -10,10 +10,10 @@ import (
 )
 
 type DBTX interface {
-	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
 	PrepareContext(context.Context, string) (*sql.Stmt, error)
-	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
-	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/cte_filter/mysql/go/db.go
+++ b/internal/endtoend/testdata/cte_filter/mysql/go/db.go
@@ -10,10 +10,10 @@ import (
 )
 
 type DBTX interface {
-	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
 	PrepareContext(context.Context, string) (*sql.Stmt, error)
-	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
-	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/cte_filter/pgx/v4/go/db.go
+++ b/internal/endtoend/testdata/cte_filter/pgx/v4/go/db.go
@@ -12,9 +12,9 @@ import (
 )
 
 type DBTX interface {
-	Exec(context.Context, string, ...interface{}) (pgconn.CommandTag, error)
-	Query(context.Context, string, ...interface{}) (pgx.Rows, error)
-	QueryRow(context.Context, string, ...interface{}) pgx.Row
+	Exec(context.Context, string, ...any) (pgconn.CommandTag, error)
+	Query(context.Context, string, ...any) (pgx.Rows, error)
+	QueryRow(context.Context, string, ...any) pgx.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/cte_filter/pgx/v5/go/db.go
+++ b/internal/endtoend/testdata/cte_filter/pgx/v5/go/db.go
@@ -12,9 +12,9 @@ import (
 )
 
 type DBTX interface {
-	Exec(context.Context, string, ...interface{}) (pgconn.CommandTag, error)
-	Query(context.Context, string, ...interface{}) (pgx.Rows, error)
-	QueryRow(context.Context, string, ...interface{}) pgx.Row
+	Exec(context.Context, string, ...any) (pgconn.CommandTag, error)
+	Query(context.Context, string, ...any) (pgx.Rows, error)
+	QueryRow(context.Context, string, ...any) pgx.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/cte_filter/stdlib/go/db.go
+++ b/internal/endtoend/testdata/cte_filter/stdlib/go/db.go
@@ -10,10 +10,10 @@ import (
 )
 
 type DBTX interface {
-	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
 	PrepareContext(context.Context, string) (*sql.Stmt, error)
-	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
-	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/cte_in_delete/mysql/go/db.go
+++ b/internal/endtoend/testdata/cte_in_delete/mysql/go/db.go
@@ -10,10 +10,10 @@ import (
 )
 
 type DBTX interface {
-	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
 	PrepareContext(context.Context, string) (*sql.Stmt, error)
-	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
-	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/cte_in_delete/pgx/v4/go/db.go
+++ b/internal/endtoend/testdata/cte_in_delete/pgx/v4/go/db.go
@@ -12,9 +12,9 @@ import (
 )
 
 type DBTX interface {
-	Exec(context.Context, string, ...interface{}) (pgconn.CommandTag, error)
-	Query(context.Context, string, ...interface{}) (pgx.Rows, error)
-	QueryRow(context.Context, string, ...interface{}) pgx.Row
+	Exec(context.Context, string, ...any) (pgconn.CommandTag, error)
+	Query(context.Context, string, ...any) (pgx.Rows, error)
+	QueryRow(context.Context, string, ...any) pgx.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/cte_in_delete/pgx/v5/go/db.go
+++ b/internal/endtoend/testdata/cte_in_delete/pgx/v5/go/db.go
@@ -12,9 +12,9 @@ import (
 )
 
 type DBTX interface {
-	Exec(context.Context, string, ...interface{}) (pgconn.CommandTag, error)
-	Query(context.Context, string, ...interface{}) (pgx.Rows, error)
-	QueryRow(context.Context, string, ...interface{}) pgx.Row
+	Exec(context.Context, string, ...any) (pgconn.CommandTag, error)
+	Query(context.Context, string, ...any) (pgx.Rows, error)
+	QueryRow(context.Context, string, ...any) pgx.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/cte_in_delete/stdlib/go/db.go
+++ b/internal/endtoend/testdata/cte_in_delete/stdlib/go/db.go
@@ -10,10 +10,10 @@ import (
 )
 
 type DBTX interface {
-	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
 	PrepareContext(context.Context, string) (*sql.Stmt, error)
-	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
-	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/cte_join_self/postgresql/pgx/go/db.go
+++ b/internal/endtoend/testdata/cte_join_self/postgresql/pgx/go/db.go
@@ -12,9 +12,9 @@ import (
 )
 
 type DBTX interface {
-	Exec(context.Context, string, ...interface{}) (pgconn.CommandTag, error)
-	Query(context.Context, string, ...interface{}) (pgx.Rows, error)
-	QueryRow(context.Context, string, ...interface{}) pgx.Row
+	Exec(context.Context, string, ...any) (pgconn.CommandTag, error)
+	Query(context.Context, string, ...any) (pgx.Rows, error)
+	QueryRow(context.Context, string, ...any) pgx.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/cte_left_join/postgresql/pgx/go/db.go
+++ b/internal/endtoend/testdata/cte_left_join/postgresql/pgx/go/db.go
@@ -12,9 +12,9 @@ import (
 )
 
 type DBTX interface {
-	Exec(context.Context, string, ...interface{}) (pgconn.CommandTag, error)
-	Query(context.Context, string, ...interface{}) (pgx.Rows, error)
-	QueryRow(context.Context, string, ...interface{}) pgx.Row
+	Exec(context.Context, string, ...any) (pgconn.CommandTag, error)
+	Query(context.Context, string, ...any) (pgx.Rows, error)
+	QueryRow(context.Context, string, ...any) pgx.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/cte_multiple_alias/postgresql/pgx/go/db.go
+++ b/internal/endtoend/testdata/cte_multiple_alias/postgresql/pgx/go/db.go
@@ -12,9 +12,9 @@ import (
 )
 
 type DBTX interface {
-	Exec(context.Context, string, ...interface{}) (pgconn.CommandTag, error)
-	Query(context.Context, string, ...interface{}) (pgx.Rows, error)
-	QueryRow(context.Context, string, ...interface{}) pgx.Row
+	Exec(context.Context, string, ...any) (pgconn.CommandTag, error)
+	Query(context.Context, string, ...any) (pgx.Rows, error)
+	QueryRow(context.Context, string, ...any) pgx.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/cte_nested_with/postgresql/pgx/go/db.go
+++ b/internal/endtoend/testdata/cte_nested_with/postgresql/pgx/go/db.go
@@ -12,9 +12,9 @@ import (
 )
 
 type DBTX interface {
-	Exec(context.Context, string, ...interface{}) (pgconn.CommandTag, error)
-	Query(context.Context, string, ...interface{}) (pgx.Rows, error)
-	QueryRow(context.Context, string, ...interface{}) pgx.Row
+	Exec(context.Context, string, ...any) (pgconn.CommandTag, error)
+	Query(context.Context, string, ...any) (pgx.Rows, error)
+	QueryRow(context.Context, string, ...any) pgx.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/cte_recursive/mysql/go/db.go
+++ b/internal/endtoend/testdata/cte_recursive/mysql/go/db.go
@@ -10,10 +10,10 @@ import (
 )
 
 type DBTX interface {
-	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
 	PrepareContext(context.Context, string) (*sql.Stmt, error)
-	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
-	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/cte_recursive/pgx/v4/go/db.go
+++ b/internal/endtoend/testdata/cte_recursive/pgx/v4/go/db.go
@@ -12,9 +12,9 @@ import (
 )
 
 type DBTX interface {
-	Exec(context.Context, string, ...interface{}) (pgconn.CommandTag, error)
-	Query(context.Context, string, ...interface{}) (pgx.Rows, error)
-	QueryRow(context.Context, string, ...interface{}) pgx.Row
+	Exec(context.Context, string, ...any) (pgconn.CommandTag, error)
+	Query(context.Context, string, ...any) (pgx.Rows, error)
+	QueryRow(context.Context, string, ...any) pgx.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/cte_recursive/pgx/v5/go/db.go
+++ b/internal/endtoend/testdata/cte_recursive/pgx/v5/go/db.go
@@ -12,9 +12,9 @@ import (
 )
 
 type DBTX interface {
-	Exec(context.Context, string, ...interface{}) (pgconn.CommandTag, error)
-	Query(context.Context, string, ...interface{}) (pgx.Rows, error)
-	QueryRow(context.Context, string, ...interface{}) pgx.Row
+	Exec(context.Context, string, ...any) (pgconn.CommandTag, error)
+	Query(context.Context, string, ...any) (pgx.Rows, error)
+	QueryRow(context.Context, string, ...any) pgx.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/cte_recursive/stdlib/go/db.go
+++ b/internal/endtoend/testdata/cte_recursive/stdlib/go/db.go
@@ -10,10 +10,10 @@ import (
 )
 
 type DBTX interface {
-	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
 	PrepareContext(context.Context, string) (*sql.Stmt, error)
-	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
-	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/cte_recursive_employees/postgresql/pgx/go/db.go
+++ b/internal/endtoend/testdata/cte_recursive_employees/postgresql/pgx/go/db.go
@@ -12,9 +12,9 @@ import (
 )
 
 type DBTX interface {
-	Exec(context.Context, string, ...interface{}) (pgconn.CommandTag, error)
-	Query(context.Context, string, ...interface{}) (pgx.Rows, error)
-	QueryRow(context.Context, string, ...interface{}) pgx.Row
+	Exec(context.Context, string, ...any) (pgconn.CommandTag, error)
+	Query(context.Context, string, ...any) (pgx.Rows, error)
+	QueryRow(context.Context, string, ...any) pgx.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/cte_recursive_star/postgresql/pgx/go/db.go
+++ b/internal/endtoend/testdata/cte_recursive_star/postgresql/pgx/go/db.go
@@ -12,9 +12,9 @@ import (
 )
 
 type DBTX interface {
-	Exec(context.Context, string, ...interface{}) (pgconn.CommandTag, error)
-	Query(context.Context, string, ...interface{}) (pgx.Rows, error)
-	QueryRow(context.Context, string, ...interface{}) pgx.Row
+	Exec(context.Context, string, ...any) (pgconn.CommandTag, error)
+	Query(context.Context, string, ...any) (pgx.Rows, error)
+	QueryRow(context.Context, string, ...any) pgx.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/cte_recursive_subquery/postgresql/pgx/go/db.go
+++ b/internal/endtoend/testdata/cte_recursive_subquery/postgresql/pgx/go/db.go
@@ -12,9 +12,9 @@ import (
 )
 
 type DBTX interface {
-	Exec(context.Context, string, ...interface{}) (pgconn.CommandTag, error)
-	Query(context.Context, string, ...interface{}) (pgx.Rows, error)
-	QueryRow(context.Context, string, ...interface{}) pgx.Row
+	Exec(context.Context, string, ...any) (pgconn.CommandTag, error)
+	Query(context.Context, string, ...any) (pgx.Rows, error)
+	QueryRow(context.Context, string, ...any) pgx.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/cte_recursive_union/postgresql/pgx/go/db.go
+++ b/internal/endtoend/testdata/cte_recursive_union/postgresql/pgx/go/db.go
@@ -12,9 +12,9 @@ import (
 )
 
 type DBTX interface {
-	Exec(context.Context, string, ...interface{}) (pgconn.CommandTag, error)
-	Query(context.Context, string, ...interface{}) (pgx.Rows, error)
-	QueryRow(context.Context, string, ...interface{}) pgx.Row
+	Exec(context.Context, string, ...any) (pgconn.CommandTag, error)
+	Query(context.Context, string, ...any) (pgx.Rows, error)
+	QueryRow(context.Context, string, ...any) pgx.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/cte_select_one/postgresql/pgx/go/db.go
+++ b/internal/endtoend/testdata/cte_select_one/postgresql/pgx/go/db.go
@@ -12,9 +12,9 @@ import (
 )
 
 type DBTX interface {
-	Exec(context.Context, string, ...interface{}) (pgconn.CommandTag, error)
-	Query(context.Context, string, ...interface{}) (pgx.Rows, error)
-	QueryRow(context.Context, string, ...interface{}) pgx.Row
+	Exec(context.Context, string, ...any) (pgconn.CommandTag, error)
+	Query(context.Context, string, ...any) (pgx.Rows, error)
+	QueryRow(context.Context, string, ...any) pgx.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/cte_update/postgresql/pgx/go/db.go
+++ b/internal/endtoend/testdata/cte_update/postgresql/pgx/go/db.go
@@ -12,9 +12,9 @@ import (
 )
 
 type DBTX interface {
-	Exec(context.Context, string, ...interface{}) (pgconn.CommandTag, error)
-	Query(context.Context, string, ...interface{}) (pgx.Rows, error)
-	QueryRow(context.Context, string, ...interface{}) pgx.Row
+	Exec(context.Context, string, ...any) (pgconn.CommandTag, error)
+	Query(context.Context, string, ...any) (pgx.Rows, error)
+	QueryRow(context.Context, string, ...any) pgx.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/cte_update_multiple/postgresql/pgx/go/db.go
+++ b/internal/endtoend/testdata/cte_update_multiple/postgresql/pgx/go/db.go
@@ -12,9 +12,9 @@ import (
 )
 
 type DBTX interface {
-	Exec(context.Context, string, ...interface{}) (pgconn.CommandTag, error)
-	Query(context.Context, string, ...interface{}) (pgx.Rows, error)
-	QueryRow(context.Context, string, ...interface{}) pgx.Row
+	Exec(context.Context, string, ...any) (pgconn.CommandTag, error)
+	Query(context.Context, string, ...any) (pgx.Rows, error)
+	QueryRow(context.Context, string, ...any) pgx.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/cte_with_in/postgresql/pganalyze/go/db.go
+++ b/internal/endtoend/testdata/cte_with_in/postgresql/pganalyze/go/db.go
@@ -12,9 +12,9 @@ import (
 )
 
 type DBTX interface {
-	Exec(context.Context, string, ...interface{}) (pgconn.CommandTag, error)
-	Query(context.Context, string, ...interface{}) (pgx.Rows, error)
-	QueryRow(context.Context, string, ...interface{}) pgx.Row
+	Exec(context.Context, string, ...any) (pgconn.CommandTag, error)
+	Query(context.Context, string, ...any) (pgx.Rows, error)
+	QueryRow(context.Context, string, ...any) pgx.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/data_type_boolean/mysql/db/db.go
+++ b/internal/endtoend/testdata/data_type_boolean/mysql/db/db.go
@@ -10,10 +10,10 @@ import (
 )
 
 type DBTX interface {
-	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
 	PrepareContext(context.Context, string) (*sql.Stmt, error)
-	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
-	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/data_type_boolean/postgresql/pgx/v4/go/db.go
+++ b/internal/endtoend/testdata/data_type_boolean/postgresql/pgx/v4/go/db.go
@@ -12,9 +12,9 @@ import (
 )
 
 type DBTX interface {
-	Exec(context.Context, string, ...interface{}) (pgconn.CommandTag, error)
-	Query(context.Context, string, ...interface{}) (pgx.Rows, error)
-	QueryRow(context.Context, string, ...interface{}) pgx.Row
+	Exec(context.Context, string, ...any) (pgconn.CommandTag, error)
+	Query(context.Context, string, ...any) (pgx.Rows, error)
+	QueryRow(context.Context, string, ...any) pgx.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/data_type_boolean/postgresql/pgx/v5/go/db.go
+++ b/internal/endtoend/testdata/data_type_boolean/postgresql/pgx/v5/go/db.go
@@ -12,9 +12,9 @@ import (
 )
 
 type DBTX interface {
-	Exec(context.Context, string, ...interface{}) (pgconn.CommandTag, error)
-	Query(context.Context, string, ...interface{}) (pgx.Rows, error)
-	QueryRow(context.Context, string, ...interface{}) pgx.Row
+	Exec(context.Context, string, ...any) (pgconn.CommandTag, error)
+	Query(context.Context, string, ...any) (pgx.Rows, error)
+	QueryRow(context.Context, string, ...any) pgx.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/data_type_boolean/postgresql/stdlib/go/db.go
+++ b/internal/endtoend/testdata/data_type_boolean/postgresql/stdlib/go/db.go
@@ -10,10 +10,10 @@ import (
 )
 
 type DBTX interface {
-	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
 	PrepareContext(context.Context, string) (*sql.Stmt, error)
-	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
-	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/data_type_boolean/sqlite/db/db.go
+++ b/internal/endtoend/testdata/data_type_boolean/sqlite/db/db.go
@@ -10,10 +10,10 @@ import (
 )
 
 type DBTX interface {
-	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
 	PrepareContext(context.Context, string) (*sql.Stmt, error)
-	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
-	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/datatype/mysql/go/db.go
+++ b/internal/endtoend/testdata/datatype/mysql/go/db.go
@@ -10,10 +10,10 @@ import (
 )
 
 type DBTX interface {
-	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
 	PrepareContext(context.Context, string) (*sql.Stmt, error)
-	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
-	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/datatype/mysql/go/models.go
+++ b/internal/endtoend/testdata/datatype/mysql/go/models.go
@@ -58,7 +58,7 @@ type DtNumeric struct {
 	D sql.NullInt16
 	E sql.NullInt32
 	F sql.NullInt64
-	G interface{}
+	G any
 	H sql.NullString
 	I sql.NullString
 	J sql.NullFloat64
@@ -73,7 +73,7 @@ type DtNumericNotNull struct {
 	D int16
 	E int32
 	F int64
-	G interface{}
+	G any
 	H string
 	I string
 	J float64

--- a/internal/endtoend/testdata/datatype/pgx/v4/go/db.go
+++ b/internal/endtoend/testdata/datatype/pgx/v4/go/db.go
@@ -12,9 +12,9 @@ import (
 )
 
 type DBTX interface {
-	Exec(context.Context, string, ...interface{}) (pgconn.CommandTag, error)
-	Query(context.Context, string, ...interface{}) (pgx.Rows, error)
-	QueryRow(context.Context, string, ...interface{}) pgx.Row
+	Exec(context.Context, string, ...any) (pgconn.CommandTag, error)
+	Query(context.Context, string, ...any) (pgx.Rows, error)
+	QueryRow(context.Context, string, ...any) pgx.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/datatype/pgx/v5/go/db.go
+++ b/internal/endtoend/testdata/datatype/pgx/v5/go/db.go
@@ -12,9 +12,9 @@ import (
 )
 
 type DBTX interface {
-	Exec(context.Context, string, ...interface{}) (pgconn.CommandTag, error)
-	Query(context.Context, string, ...interface{}) (pgx.Rows, error)
-	QueryRow(context.Context, string, ...interface{}) pgx.Row
+	Exec(context.Context, string, ...any) (pgconn.CommandTag, error)
+	Query(context.Context, string, ...any) (pgx.Rows, error)
+	QueryRow(context.Context, string, ...any) pgx.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/datatype/sqlite/go/db.go
+++ b/internal/endtoend/testdata/datatype/sqlite/go/db.go
@@ -10,10 +10,10 @@ import (
 )
 
 type DBTX interface {
-	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
 	PrepareContext(context.Context, string) (*sql.Stmt, error)
-	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
-	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/datatype/stdlib/go/db.go
+++ b/internal/endtoend/testdata/datatype/stdlib/go/db.go
@@ -10,10 +10,10 @@ import (
 )
 
 type DBTX interface {
-	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
 	PrepareContext(context.Context, string) (*sql.Stmt, error)
-	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
-	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/datatype/stdlib/go/models.go
+++ b/internal/endtoend/testdata/datatype/stdlib/go/models.go
@@ -94,19 +94,19 @@ type DtNumericNotNull struct {
 }
 
 type DtRange struct {
-	A interface{}
-	B interface{}
-	C interface{}
-	D interface{}
-	E interface{}
-	F interface{}
+	A any
+	B any
+	C any
+	D any
+	E any
+	F any
 }
 
 type DtRangeNotNull struct {
-	A interface{}
-	B interface{}
-	C interface{}
-	D interface{}
-	E interface{}
-	F interface{}
+	A any
+	B any
+	C any
+	D any
+	E any
+	F any
 }

--- a/internal/endtoend/testdata/ddl_alter_materialized_views_set_schema/postgresql/pgx/go/db.go
+++ b/internal/endtoend/testdata/ddl_alter_materialized_views_set_schema/postgresql/pgx/go/db.go
@@ -12,9 +12,9 @@ import (
 )
 
 type DBTX interface {
-	Exec(context.Context, string, ...interface{}) (pgconn.CommandTag, error)
-	Query(context.Context, string, ...interface{}) (pgx.Rows, error)
-	QueryRow(context.Context, string, ...interface{}) pgx.Row
+	Exec(context.Context, string, ...any) (pgconn.CommandTag, error)
+	Query(context.Context, string, ...any) (pgx.Rows, error)
+	QueryRow(context.Context, string, ...any) pgx.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/ddl_alter_table_add_column/mysql/go/db.go
+++ b/internal/endtoend/testdata/ddl_alter_table_add_column/mysql/go/db.go
@@ -10,10 +10,10 @@ import (
 )
 
 type DBTX interface {
-	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
 	PrepareContext(context.Context, string) (*sql.Stmt, error)
-	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
-	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/ddl_alter_table_add_column/postgresql/pgx/v4/go/db.go
+++ b/internal/endtoend/testdata/ddl_alter_table_add_column/postgresql/pgx/v4/go/db.go
@@ -12,9 +12,9 @@ import (
 )
 
 type DBTX interface {
-	Exec(context.Context, string, ...interface{}) (pgconn.CommandTag, error)
-	Query(context.Context, string, ...interface{}) (pgx.Rows, error)
-	QueryRow(context.Context, string, ...interface{}) pgx.Row
+	Exec(context.Context, string, ...any) (pgconn.CommandTag, error)
+	Query(context.Context, string, ...any) (pgx.Rows, error)
+	QueryRow(context.Context, string, ...any) pgx.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/ddl_alter_table_add_column/postgresql/pgx/v5/go/db.go
+++ b/internal/endtoend/testdata/ddl_alter_table_add_column/postgresql/pgx/v5/go/db.go
@@ -12,9 +12,9 @@ import (
 )
 
 type DBTX interface {
-	Exec(context.Context, string, ...interface{}) (pgconn.CommandTag, error)
-	Query(context.Context, string, ...interface{}) (pgx.Rows, error)
-	QueryRow(context.Context, string, ...interface{}) pgx.Row
+	Exec(context.Context, string, ...any) (pgconn.CommandTag, error)
+	Query(context.Context, string, ...any) (pgx.Rows, error)
+	QueryRow(context.Context, string, ...any) pgx.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/ddl_alter_table_add_column/postgresql/stdlib/go/db.go
+++ b/internal/endtoend/testdata/ddl_alter_table_add_column/postgresql/stdlib/go/db.go
@@ -10,10 +10,10 @@ import (
 )
 
 type DBTX interface {
-	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
 	PrepareContext(context.Context, string) (*sql.Stmt, error)
-	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
-	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/ddl_alter_table_add_column/sqlite/go/db.go
+++ b/internal/endtoend/testdata/ddl_alter_table_add_column/sqlite/go/db.go
@@ -10,10 +10,10 @@ import (
 )
 
 type DBTX interface {
-	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
 	PrepareContext(context.Context, string) (*sql.Stmt, error)
-	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
-	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/ddl_alter_table_add_column_if_not_exists/postgresql/pgx/v4/go/db.go
+++ b/internal/endtoend/testdata/ddl_alter_table_add_column_if_not_exists/postgresql/pgx/v4/go/db.go
@@ -12,9 +12,9 @@ import (
 )
 
 type DBTX interface {
-	Exec(context.Context, string, ...interface{}) (pgconn.CommandTag, error)
-	Query(context.Context, string, ...interface{}) (pgx.Rows, error)
-	QueryRow(context.Context, string, ...interface{}) pgx.Row
+	Exec(context.Context, string, ...any) (pgconn.CommandTag, error)
+	Query(context.Context, string, ...any) (pgx.Rows, error)
+	QueryRow(context.Context, string, ...any) pgx.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/ddl_alter_table_add_column_if_not_exists/postgresql/pgx/v5/go/db.go
+++ b/internal/endtoend/testdata/ddl_alter_table_add_column_if_not_exists/postgresql/pgx/v5/go/db.go
@@ -12,9 +12,9 @@ import (
 )
 
 type DBTX interface {
-	Exec(context.Context, string, ...interface{}) (pgconn.CommandTag, error)
-	Query(context.Context, string, ...interface{}) (pgx.Rows, error)
-	QueryRow(context.Context, string, ...interface{}) pgx.Row
+	Exec(context.Context, string, ...any) (pgconn.CommandTag, error)
+	Query(context.Context, string, ...any) (pgx.Rows, error)
+	QueryRow(context.Context, string, ...any) pgx.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/ddl_alter_table_add_column_if_not_exists/postgresql/stdlib/go/db.go
+++ b/internal/endtoend/testdata/ddl_alter_table_add_column_if_not_exists/postgresql/stdlib/go/db.go
@@ -10,10 +10,10 @@ import (
 )
 
 type DBTX interface {
-	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
 	PrepareContext(context.Context, string) (*sql.Stmt, error)
-	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
-	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/ddl_alter_table_alter_type/mysql/go/db.go
+++ b/internal/endtoend/testdata/ddl_alter_table_alter_type/mysql/go/db.go
@@ -10,10 +10,10 @@ import (
 )
 
 type DBTX interface {
-	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
 	PrepareContext(context.Context, string) (*sql.Stmt, error)
-	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
-	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/ddl_alter_table_alter_type/postgresql/pgx/v4/go/db.go
+++ b/internal/endtoend/testdata/ddl_alter_table_alter_type/postgresql/pgx/v4/go/db.go
@@ -12,9 +12,9 @@ import (
 )
 
 type DBTX interface {
-	Exec(context.Context, string, ...interface{}) (pgconn.CommandTag, error)
-	Query(context.Context, string, ...interface{}) (pgx.Rows, error)
-	QueryRow(context.Context, string, ...interface{}) pgx.Row
+	Exec(context.Context, string, ...any) (pgconn.CommandTag, error)
+	Query(context.Context, string, ...any) (pgx.Rows, error)
+	QueryRow(context.Context, string, ...any) pgx.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/ddl_alter_table_alter_type/postgresql/pgx/v5/go/db.go
+++ b/internal/endtoend/testdata/ddl_alter_table_alter_type/postgresql/pgx/v5/go/db.go
@@ -12,9 +12,9 @@ import (
 )
 
 type DBTX interface {
-	Exec(context.Context, string, ...interface{}) (pgconn.CommandTag, error)
-	Query(context.Context, string, ...interface{}) (pgx.Rows, error)
-	QueryRow(context.Context, string, ...interface{}) pgx.Row
+	Exec(context.Context, string, ...any) (pgconn.CommandTag, error)
+	Query(context.Context, string, ...any) (pgx.Rows, error)
+	QueryRow(context.Context, string, ...any) pgx.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/ddl_alter_table_alter_type/postgresql/stdlib/go/db.go
+++ b/internal/endtoend/testdata/ddl_alter_table_alter_type/postgresql/stdlib/go/db.go
@@ -10,10 +10,10 @@ import (
 )
 
 type DBTX interface {
-	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
 	PrepareContext(context.Context, string) (*sql.Stmt, error)
-	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
-	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/ddl_alter_table_case_sensitivity/sqlite/go/db.go
+++ b/internal/endtoend/testdata/ddl_alter_table_case_sensitivity/sqlite/go/db.go
@@ -10,10 +10,10 @@ import (
 )
 
 type DBTX interface {
-	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
 	PrepareContext(context.Context, string) (*sql.Stmt, error)
-	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
-	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/ddl_alter_table_change_column/mysql/go/db.go
+++ b/internal/endtoend/testdata/ddl_alter_table_change_column/mysql/go/db.go
@@ -10,10 +10,10 @@ import (
 )
 
 type DBTX interface {
-	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
 	PrepareContext(context.Context, string) (*sql.Stmt, error)
-	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
-	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/ddl_alter_table_change_column/postgresql/pgx/v4/go/db.go
+++ b/internal/endtoend/testdata/ddl_alter_table_change_column/postgresql/pgx/v4/go/db.go
@@ -12,9 +12,9 @@ import (
 )
 
 type DBTX interface {
-	Exec(context.Context, string, ...interface{}) (pgconn.CommandTag, error)
-	Query(context.Context, string, ...interface{}) (pgx.Rows, error)
-	QueryRow(context.Context, string, ...interface{}) pgx.Row
+	Exec(context.Context, string, ...any) (pgconn.CommandTag, error)
+	Query(context.Context, string, ...any) (pgx.Rows, error)
+	QueryRow(context.Context, string, ...any) pgx.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/ddl_alter_table_change_column/postgresql/pgx/v5/go/db.go
+++ b/internal/endtoend/testdata/ddl_alter_table_change_column/postgresql/pgx/v5/go/db.go
@@ -12,9 +12,9 @@ import (
 )
 
 type DBTX interface {
-	Exec(context.Context, string, ...interface{}) (pgconn.CommandTag, error)
-	Query(context.Context, string, ...interface{}) (pgx.Rows, error)
-	QueryRow(context.Context, string, ...interface{}) pgx.Row
+	Exec(context.Context, string, ...any) (pgconn.CommandTag, error)
+	Query(context.Context, string, ...any) (pgx.Rows, error)
+	QueryRow(context.Context, string, ...any) pgx.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/ddl_alter_table_change_column/postgresql/stdlib/go/db.go
+++ b/internal/endtoend/testdata/ddl_alter_table_change_column/postgresql/stdlib/go/db.go
@@ -10,10 +10,10 @@ import (
 )
 
 type DBTX interface {
-	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
 	PrepareContext(context.Context, string) (*sql.Stmt, error)
-	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
-	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/ddl_alter_table_column_drop_not_null/mysql/go/db.go
+++ b/internal/endtoend/testdata/ddl_alter_table_column_drop_not_null/mysql/go/db.go
@@ -10,10 +10,10 @@ import (
 )
 
 type DBTX interface {
-	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
 	PrepareContext(context.Context, string) (*sql.Stmt, error)
-	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
-	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/ddl_alter_table_column_drop_not_null/postgresql/pgx/v4/go/db.go
+++ b/internal/endtoend/testdata/ddl_alter_table_column_drop_not_null/postgresql/pgx/v4/go/db.go
@@ -12,9 +12,9 @@ import (
 )
 
 type DBTX interface {
-	Exec(context.Context, string, ...interface{}) (pgconn.CommandTag, error)
-	Query(context.Context, string, ...interface{}) (pgx.Rows, error)
-	QueryRow(context.Context, string, ...interface{}) pgx.Row
+	Exec(context.Context, string, ...any) (pgconn.CommandTag, error)
+	Query(context.Context, string, ...any) (pgx.Rows, error)
+	QueryRow(context.Context, string, ...any) pgx.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/ddl_alter_table_column_drop_not_null/postgresql/pgx/v5/go/db.go
+++ b/internal/endtoend/testdata/ddl_alter_table_column_drop_not_null/postgresql/pgx/v5/go/db.go
@@ -12,9 +12,9 @@ import (
 )
 
 type DBTX interface {
-	Exec(context.Context, string, ...interface{}) (pgconn.CommandTag, error)
-	Query(context.Context, string, ...interface{}) (pgx.Rows, error)
-	QueryRow(context.Context, string, ...interface{}) pgx.Row
+	Exec(context.Context, string, ...any) (pgconn.CommandTag, error)
+	Query(context.Context, string, ...any) (pgx.Rows, error)
+	QueryRow(context.Context, string, ...any) pgx.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/ddl_alter_table_column_drop_not_null/postgresql/stdlib/go/db.go
+++ b/internal/endtoend/testdata/ddl_alter_table_column_drop_not_null/postgresql/stdlib/go/db.go
@@ -10,10 +10,10 @@ import (
 )
 
 type DBTX interface {
-	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
 	PrepareContext(context.Context, string) (*sql.Stmt, error)
-	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
-	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/ddl_alter_table_drop_column/mysql/go/db.go
+++ b/internal/endtoend/testdata/ddl_alter_table_drop_column/mysql/go/db.go
@@ -10,10 +10,10 @@ import (
 )
 
 type DBTX interface {
-	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
 	PrepareContext(context.Context, string) (*sql.Stmt, error)
-	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
-	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/ddl_alter_table_drop_column/postgresql/pgx/v4/go/db.go
+++ b/internal/endtoend/testdata/ddl_alter_table_drop_column/postgresql/pgx/v4/go/db.go
@@ -12,9 +12,9 @@ import (
 )
 
 type DBTX interface {
-	Exec(context.Context, string, ...interface{}) (pgconn.CommandTag, error)
-	Query(context.Context, string, ...interface{}) (pgx.Rows, error)
-	QueryRow(context.Context, string, ...interface{}) pgx.Row
+	Exec(context.Context, string, ...any) (pgconn.CommandTag, error)
+	Query(context.Context, string, ...any) (pgx.Rows, error)
+	QueryRow(context.Context, string, ...any) pgx.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/ddl_alter_table_drop_column/postgresql/pgx/v5/go/db.go
+++ b/internal/endtoend/testdata/ddl_alter_table_drop_column/postgresql/pgx/v5/go/db.go
@@ -12,9 +12,9 @@ import (
 )
 
 type DBTX interface {
-	Exec(context.Context, string, ...interface{}) (pgconn.CommandTag, error)
-	Query(context.Context, string, ...interface{}) (pgx.Rows, error)
-	QueryRow(context.Context, string, ...interface{}) pgx.Row
+	Exec(context.Context, string, ...any) (pgconn.CommandTag, error)
+	Query(context.Context, string, ...any) (pgx.Rows, error)
+	QueryRow(context.Context, string, ...any) pgx.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/ddl_alter_table_drop_column/postgresql/stdlib/go/db.go
+++ b/internal/endtoend/testdata/ddl_alter_table_drop_column/postgresql/stdlib/go/db.go
@@ -10,10 +10,10 @@ import (
 )
 
 type DBTX interface {
-	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
 	PrepareContext(context.Context, string) (*sql.Stmt, error)
-	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
-	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/ddl_alter_table_drop_column/sqlite/go/db.go
+++ b/internal/endtoend/testdata/ddl_alter_table_drop_column/sqlite/go/db.go
@@ -10,10 +10,10 @@ import (
 )
 
 type DBTX interface {
-	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
 	PrepareContext(context.Context, string) (*sql.Stmt, error)
-	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
-	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/ddl_alter_table_drop_column_if_exists/mysql/go/db.go
+++ b/internal/endtoend/testdata/ddl_alter_table_drop_column_if_exists/mysql/go/db.go
@@ -10,10 +10,10 @@ import (
 )
 
 type DBTX interface {
-	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
 	PrepareContext(context.Context, string) (*sql.Stmt, error)
-	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
-	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/ddl_alter_table_drop_column_if_exists/postgresql/pgx/v4/go/db.go
+++ b/internal/endtoend/testdata/ddl_alter_table_drop_column_if_exists/postgresql/pgx/v4/go/db.go
@@ -12,9 +12,9 @@ import (
 )
 
 type DBTX interface {
-	Exec(context.Context, string, ...interface{}) (pgconn.CommandTag, error)
-	Query(context.Context, string, ...interface{}) (pgx.Rows, error)
-	QueryRow(context.Context, string, ...interface{}) pgx.Row
+	Exec(context.Context, string, ...any) (pgconn.CommandTag, error)
+	Query(context.Context, string, ...any) (pgx.Rows, error)
+	QueryRow(context.Context, string, ...any) pgx.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/ddl_alter_table_drop_column_if_exists/postgresql/pgx/v5/go/db.go
+++ b/internal/endtoend/testdata/ddl_alter_table_drop_column_if_exists/postgresql/pgx/v5/go/db.go
@@ -12,9 +12,9 @@ import (
 )
 
 type DBTX interface {
-	Exec(context.Context, string, ...interface{}) (pgconn.CommandTag, error)
-	Query(context.Context, string, ...interface{}) (pgx.Rows, error)
-	QueryRow(context.Context, string, ...interface{}) pgx.Row
+	Exec(context.Context, string, ...any) (pgconn.CommandTag, error)
+	Query(context.Context, string, ...any) (pgx.Rows, error)
+	QueryRow(context.Context, string, ...any) pgx.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/ddl_alter_table_drop_column_if_exists/postgresql/stdlib/go/db.go
+++ b/internal/endtoend/testdata/ddl_alter_table_drop_column_if_exists/postgresql/stdlib/go/db.go
@@ -10,10 +10,10 @@ import (
 )
 
 type DBTX interface {
-	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
 	PrepareContext(context.Context, string) (*sql.Stmt, error)
-	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
-	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/ddl_alter_table_drop_constraint/mysql/go/db.go
+++ b/internal/endtoend/testdata/ddl_alter_table_drop_constraint/mysql/go/db.go
@@ -10,10 +10,10 @@ import (
 )
 
 type DBTX interface {
-	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
 	PrepareContext(context.Context, string) (*sql.Stmt, error)
-	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
-	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/ddl_alter_table_drop_constraint/postgresql/pgx/v4/go/db.go
+++ b/internal/endtoend/testdata/ddl_alter_table_drop_constraint/postgresql/pgx/v4/go/db.go
@@ -12,9 +12,9 @@ import (
 )
 
 type DBTX interface {
-	Exec(context.Context, string, ...interface{}) (pgconn.CommandTag, error)
-	Query(context.Context, string, ...interface{}) (pgx.Rows, error)
-	QueryRow(context.Context, string, ...interface{}) pgx.Row
+	Exec(context.Context, string, ...any) (pgconn.CommandTag, error)
+	Query(context.Context, string, ...any) (pgx.Rows, error)
+	QueryRow(context.Context, string, ...any) pgx.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/ddl_alter_table_drop_constraint/postgresql/pgx/v5/go/db.go
+++ b/internal/endtoend/testdata/ddl_alter_table_drop_constraint/postgresql/pgx/v5/go/db.go
@@ -12,9 +12,9 @@ import (
 )
 
 type DBTX interface {
-	Exec(context.Context, string, ...interface{}) (pgconn.CommandTag, error)
-	Query(context.Context, string, ...interface{}) (pgx.Rows, error)
-	QueryRow(context.Context, string, ...interface{}) pgx.Row
+	Exec(context.Context, string, ...any) (pgconn.CommandTag, error)
+	Query(context.Context, string, ...any) (pgx.Rows, error)
+	QueryRow(context.Context, string, ...any) pgx.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/ddl_alter_table_drop_constraint/postgresql/stdlib/go/db.go
+++ b/internal/endtoend/testdata/ddl_alter_table_drop_constraint/postgresql/stdlib/go/db.go
@@ -10,10 +10,10 @@ import (
 )
 
 type DBTX interface {
-	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
 	PrepareContext(context.Context, string) (*sql.Stmt, error)
-	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
-	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/ddl_alter_table_if_exists/postgresql/pgx/v4/go/db.go
+++ b/internal/endtoend/testdata/ddl_alter_table_if_exists/postgresql/pgx/v4/go/db.go
@@ -12,9 +12,9 @@ import (
 )
 
 type DBTX interface {
-	Exec(context.Context, string, ...interface{}) (pgconn.CommandTag, error)
-	Query(context.Context, string, ...interface{}) (pgx.Rows, error)
-	QueryRow(context.Context, string, ...interface{}) pgx.Row
+	Exec(context.Context, string, ...any) (pgconn.CommandTag, error)
+	Query(context.Context, string, ...any) (pgx.Rows, error)
+	QueryRow(context.Context, string, ...any) pgx.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/ddl_alter_table_if_exists/postgresql/pgx/v5/go/db.go
+++ b/internal/endtoend/testdata/ddl_alter_table_if_exists/postgresql/pgx/v5/go/db.go
@@ -12,9 +12,9 @@ import (
 )
 
 type DBTX interface {
-	Exec(context.Context, string, ...interface{}) (pgconn.CommandTag, error)
-	Query(context.Context, string, ...interface{}) (pgx.Rows, error)
-	QueryRow(context.Context, string, ...interface{}) pgx.Row
+	Exec(context.Context, string, ...any) (pgconn.CommandTag, error)
+	Query(context.Context, string, ...any) (pgx.Rows, error)
+	QueryRow(context.Context, string, ...any) pgx.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/ddl_alter_table_if_exists/postgresql/stdlib/go/db.go
+++ b/internal/endtoend/testdata/ddl_alter_table_if_exists/postgresql/stdlib/go/db.go
@@ -10,10 +10,10 @@ import (
 )
 
 type DBTX interface {
-	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
 	PrepareContext(context.Context, string) (*sql.Stmt, error)
-	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
-	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/ddl_alter_table_index/postgresql/pgx/v4/go/db.go
+++ b/internal/endtoend/testdata/ddl_alter_table_index/postgresql/pgx/v4/go/db.go
@@ -12,9 +12,9 @@ import (
 )
 
 type DBTX interface {
-	Exec(context.Context, string, ...interface{}) (pgconn.CommandTag, error)
-	Query(context.Context, string, ...interface{}) (pgx.Rows, error)
-	QueryRow(context.Context, string, ...interface{}) pgx.Row
+	Exec(context.Context, string, ...any) (pgconn.CommandTag, error)
+	Query(context.Context, string, ...any) (pgx.Rows, error)
+	QueryRow(context.Context, string, ...any) pgx.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/ddl_alter_table_index/postgresql/pgx/v5/go/db.go
+++ b/internal/endtoend/testdata/ddl_alter_table_index/postgresql/pgx/v5/go/db.go
@@ -12,9 +12,9 @@ import (
 )
 
 type DBTX interface {
-	Exec(context.Context, string, ...interface{}) (pgconn.CommandTag, error)
-	Query(context.Context, string, ...interface{}) (pgx.Rows, error)
-	QueryRow(context.Context, string, ...interface{}) pgx.Row
+	Exec(context.Context, string, ...any) (pgconn.CommandTag, error)
+	Query(context.Context, string, ...any) (pgx.Rows, error)
+	QueryRow(context.Context, string, ...any) pgx.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/ddl_alter_table_index/postgresql/stdlib/go/db.go
+++ b/internal/endtoend/testdata/ddl_alter_table_index/postgresql/stdlib/go/db.go
@@ -10,10 +10,10 @@ import (
 )
 
 type DBTX interface {
-	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
 	PrepareContext(context.Context, string) (*sql.Stmt, error)
-	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
-	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/ddl_alter_table_rename/mysql/go/db.go
+++ b/internal/endtoend/testdata/ddl_alter_table_rename/mysql/go/db.go
@@ -10,10 +10,10 @@ import (
 )
 
 type DBTX interface {
-	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
 	PrepareContext(context.Context, string) (*sql.Stmt, error)
-	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
-	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/ddl_alter_table_rename/postgresql/pgx/v4/go/db.go
+++ b/internal/endtoend/testdata/ddl_alter_table_rename/postgresql/pgx/v4/go/db.go
@@ -12,9 +12,9 @@ import (
 )
 
 type DBTX interface {
-	Exec(context.Context, string, ...interface{}) (pgconn.CommandTag, error)
-	Query(context.Context, string, ...interface{}) (pgx.Rows, error)
-	QueryRow(context.Context, string, ...interface{}) pgx.Row
+	Exec(context.Context, string, ...any) (pgconn.CommandTag, error)
+	Query(context.Context, string, ...any) (pgx.Rows, error)
+	QueryRow(context.Context, string, ...any) pgx.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/ddl_alter_table_rename/postgresql/pgx/v5/go/db.go
+++ b/internal/endtoend/testdata/ddl_alter_table_rename/postgresql/pgx/v5/go/db.go
@@ -12,9 +12,9 @@ import (
 )
 
 type DBTX interface {
-	Exec(context.Context, string, ...interface{}) (pgconn.CommandTag, error)
-	Query(context.Context, string, ...interface{}) (pgx.Rows, error)
-	QueryRow(context.Context, string, ...interface{}) pgx.Row
+	Exec(context.Context, string, ...any) (pgconn.CommandTag, error)
+	Query(context.Context, string, ...any) (pgx.Rows, error)
+	QueryRow(context.Context, string, ...any) pgx.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/ddl_alter_table_rename/postgresql/stdlib/go/db.go
+++ b/internal/endtoend/testdata/ddl_alter_table_rename/postgresql/stdlib/go/db.go
@@ -10,10 +10,10 @@ import (
 )
 
 type DBTX interface {
-	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
 	PrepareContext(context.Context, string) (*sql.Stmt, error)
-	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
-	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/ddl_alter_table_rename/sqlite/go/db.go
+++ b/internal/endtoend/testdata/ddl_alter_table_rename/sqlite/go/db.go
@@ -10,10 +10,10 @@ import (
 )
 
 type DBTX interface {
-	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
 	PrepareContext(context.Context, string) (*sql.Stmt, error)
-	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
-	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/ddl_alter_table_rename_column/mysql/go/db.go
+++ b/internal/endtoend/testdata/ddl_alter_table_rename_column/mysql/go/db.go
@@ -10,10 +10,10 @@ import (
 )
 
 type DBTX interface {
-	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
 	PrepareContext(context.Context, string) (*sql.Stmt, error)
-	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
-	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/ddl_alter_table_rename_column/postgresql/pgx/v4/go/db.go
+++ b/internal/endtoend/testdata/ddl_alter_table_rename_column/postgresql/pgx/v4/go/db.go
@@ -12,9 +12,9 @@ import (
 )
 
 type DBTX interface {
-	Exec(context.Context, string, ...interface{}) (pgconn.CommandTag, error)
-	Query(context.Context, string, ...interface{}) (pgx.Rows, error)
-	QueryRow(context.Context, string, ...interface{}) pgx.Row
+	Exec(context.Context, string, ...any) (pgconn.CommandTag, error)
+	Query(context.Context, string, ...any) (pgx.Rows, error)
+	QueryRow(context.Context, string, ...any) pgx.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/ddl_alter_table_rename_column/postgresql/pgx/v5/go/db.go
+++ b/internal/endtoend/testdata/ddl_alter_table_rename_column/postgresql/pgx/v5/go/db.go
@@ -12,9 +12,9 @@ import (
 )
 
 type DBTX interface {
-	Exec(context.Context, string, ...interface{}) (pgconn.CommandTag, error)
-	Query(context.Context, string, ...interface{}) (pgx.Rows, error)
-	QueryRow(context.Context, string, ...interface{}) pgx.Row
+	Exec(context.Context, string, ...any) (pgconn.CommandTag, error)
+	Query(context.Context, string, ...any) (pgx.Rows, error)
+	QueryRow(context.Context, string, ...any) pgx.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/ddl_alter_table_rename_column/postgresql/stdlib/go/db.go
+++ b/internal/endtoend/testdata/ddl_alter_table_rename_column/postgresql/stdlib/go/db.go
@@ -10,10 +10,10 @@ import (
 )
 
 type DBTX interface {
-	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
 	PrepareContext(context.Context, string) (*sql.Stmt, error)
-	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
-	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/ddl_alter_table_rename_column/sqlite/go/db.go
+++ b/internal/endtoend/testdata/ddl_alter_table_rename_column/sqlite/go/db.go
@@ -10,10 +10,10 @@ import (
 )
 
 type DBTX interface {
-	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
 	PrepareContext(context.Context, string) (*sql.Stmt, error)
-	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
-	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/ddl_alter_table_set_data_type/mysql/go/db.go
+++ b/internal/endtoend/testdata/ddl_alter_table_set_data_type/mysql/go/db.go
@@ -10,10 +10,10 @@ import (
 )
 
 type DBTX interface {
-	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
 	PrepareContext(context.Context, string) (*sql.Stmt, error)
-	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
-	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/ddl_alter_table_set_data_type/postgresql/pgx/v4/go/db.go
+++ b/internal/endtoend/testdata/ddl_alter_table_set_data_type/postgresql/pgx/v4/go/db.go
@@ -12,9 +12,9 @@ import (
 )
 
 type DBTX interface {
-	Exec(context.Context, string, ...interface{}) (pgconn.CommandTag, error)
-	Query(context.Context, string, ...interface{}) (pgx.Rows, error)
-	QueryRow(context.Context, string, ...interface{}) pgx.Row
+	Exec(context.Context, string, ...any) (pgconn.CommandTag, error)
+	Query(context.Context, string, ...any) (pgx.Rows, error)
+	QueryRow(context.Context, string, ...any) pgx.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/ddl_alter_table_set_data_type/postgresql/pgx/v5/go/db.go
+++ b/internal/endtoend/testdata/ddl_alter_table_set_data_type/postgresql/pgx/v5/go/db.go
@@ -12,9 +12,9 @@ import (
 )
 
 type DBTX interface {
-	Exec(context.Context, string, ...interface{}) (pgconn.CommandTag, error)
-	Query(context.Context, string, ...interface{}) (pgx.Rows, error)
-	QueryRow(context.Context, string, ...interface{}) pgx.Row
+	Exec(context.Context, string, ...any) (pgconn.CommandTag, error)
+	Query(context.Context, string, ...any) (pgx.Rows, error)
+	QueryRow(context.Context, string, ...any) pgx.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/ddl_alter_table_set_data_type/postgresql/stdlib/go/db.go
+++ b/internal/endtoend/testdata/ddl_alter_table_set_data_type/postgresql/stdlib/go/db.go
@@ -10,10 +10,10 @@ import (
 )
 
 type DBTX interface {
-	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
 	PrepareContext(context.Context, string) (*sql.Stmt, error)
-	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
-	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/ddl_alter_table_set_not_null/mysql/go/db.go
+++ b/internal/endtoend/testdata/ddl_alter_table_set_not_null/mysql/go/db.go
@@ -10,10 +10,10 @@ import (
 )
 
 type DBTX interface {
-	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
 	PrepareContext(context.Context, string) (*sql.Stmt, error)
-	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
-	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/ddl_alter_table_set_not_null/postgresql/pgx/v4/go/db.go
+++ b/internal/endtoend/testdata/ddl_alter_table_set_not_null/postgresql/pgx/v4/go/db.go
@@ -12,9 +12,9 @@ import (
 )
 
 type DBTX interface {
-	Exec(context.Context, string, ...interface{}) (pgconn.CommandTag, error)
-	Query(context.Context, string, ...interface{}) (pgx.Rows, error)
-	QueryRow(context.Context, string, ...interface{}) pgx.Row
+	Exec(context.Context, string, ...any) (pgconn.CommandTag, error)
+	Query(context.Context, string, ...any) (pgx.Rows, error)
+	QueryRow(context.Context, string, ...any) pgx.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/ddl_alter_table_set_not_null/postgresql/pgx/v5/go/db.go
+++ b/internal/endtoend/testdata/ddl_alter_table_set_not_null/postgresql/pgx/v5/go/db.go
@@ -12,9 +12,9 @@ import (
 )
 
 type DBTX interface {
-	Exec(context.Context, string, ...interface{}) (pgconn.CommandTag, error)
-	Query(context.Context, string, ...interface{}) (pgx.Rows, error)
-	QueryRow(context.Context, string, ...interface{}) pgx.Row
+	Exec(context.Context, string, ...any) (pgconn.CommandTag, error)
+	Query(context.Context, string, ...any) (pgx.Rows, error)
+	QueryRow(context.Context, string, ...any) pgx.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/ddl_alter_table_set_not_null/postgresql/stdlib/go/db.go
+++ b/internal/endtoend/testdata/ddl_alter_table_set_not_null/postgresql/stdlib/go/db.go
@@ -10,10 +10,10 @@ import (
 )
 
 type DBTX interface {
-	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
 	PrepareContext(context.Context, string) (*sql.Stmt, error)
-	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
-	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/ddl_alter_table_set_schema/postgresql/pgx/v4/go/db.go
+++ b/internal/endtoend/testdata/ddl_alter_table_set_schema/postgresql/pgx/v4/go/db.go
@@ -12,9 +12,9 @@ import (
 )
 
 type DBTX interface {
-	Exec(context.Context, string, ...interface{}) (pgconn.CommandTag, error)
-	Query(context.Context, string, ...interface{}) (pgx.Rows, error)
-	QueryRow(context.Context, string, ...interface{}) pgx.Row
+	Exec(context.Context, string, ...any) (pgconn.CommandTag, error)
+	Query(context.Context, string, ...any) (pgx.Rows, error)
+	QueryRow(context.Context, string, ...any) pgx.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/ddl_alter_table_set_schema/postgresql/pgx/v5/go/db.go
+++ b/internal/endtoend/testdata/ddl_alter_table_set_schema/postgresql/pgx/v5/go/db.go
@@ -12,9 +12,9 @@ import (
 )
 
 type DBTX interface {
-	Exec(context.Context, string, ...interface{}) (pgconn.CommandTag, error)
-	Query(context.Context, string, ...interface{}) (pgx.Rows, error)
-	QueryRow(context.Context, string, ...interface{}) pgx.Row
+	Exec(context.Context, string, ...any) (pgconn.CommandTag, error)
+	Query(context.Context, string, ...any) (pgx.Rows, error)
+	QueryRow(context.Context, string, ...any) pgx.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/ddl_alter_table_set_schema/postgresql/stdlib/go/db.go
+++ b/internal/endtoend/testdata/ddl_alter_table_set_schema/postgresql/stdlib/go/db.go
@@ -10,10 +10,10 @@ import (
 )
 
 type DBTX interface {
-	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
 	PrepareContext(context.Context, string) (*sql.Stmt, error)
-	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
-	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/ddl_alter_type_add_value/postgresql/pgx/v4/go/db.go
+++ b/internal/endtoend/testdata/ddl_alter_type_add_value/postgresql/pgx/v4/go/db.go
@@ -12,9 +12,9 @@ import (
 )
 
 type DBTX interface {
-	Exec(context.Context, string, ...interface{}) (pgconn.CommandTag, error)
-	Query(context.Context, string, ...interface{}) (pgx.Rows, error)
-	QueryRow(context.Context, string, ...interface{}) pgx.Row
+	Exec(context.Context, string, ...any) (pgconn.CommandTag, error)
+	Query(context.Context, string, ...any) (pgx.Rows, error)
+	QueryRow(context.Context, string, ...any) pgx.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/ddl_alter_type_add_value/postgresql/pgx/v4/go/models.go
+++ b/internal/endtoend/testdata/ddl_alter_type_add_value/postgresql/pgx/v4/go/models.go
@@ -17,7 +17,7 @@ const (
 	StatusUnknown Status = "unknown"
 )
 
-func (e *Status) Scan(src interface{}) error {
+func (e *Status) Scan(src any) error {
 	switch s := src.(type) {
 	case []byte:
 		*e = Status(s)
@@ -35,7 +35,7 @@ type NullStatus struct {
 }
 
 // Scan implements the Scanner interface.
-func (ns *NullStatus) Scan(value interface{}) error {
+func (ns *NullStatus) Scan(value any) error {
 	if value == nil {
 		ns.Status, ns.Valid = "", false
 		return nil

--- a/internal/endtoend/testdata/ddl_alter_type_add_value/postgresql/pgx/v5/go/db.go
+++ b/internal/endtoend/testdata/ddl_alter_type_add_value/postgresql/pgx/v5/go/db.go
@@ -12,9 +12,9 @@ import (
 )
 
 type DBTX interface {
-	Exec(context.Context, string, ...interface{}) (pgconn.CommandTag, error)
-	Query(context.Context, string, ...interface{}) (pgx.Rows, error)
-	QueryRow(context.Context, string, ...interface{}) pgx.Row
+	Exec(context.Context, string, ...any) (pgconn.CommandTag, error)
+	Query(context.Context, string, ...any) (pgx.Rows, error)
+	QueryRow(context.Context, string, ...any) pgx.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/ddl_alter_type_add_value/postgresql/pgx/v5/go/models.go
+++ b/internal/endtoend/testdata/ddl_alter_type_add_value/postgresql/pgx/v5/go/models.go
@@ -17,7 +17,7 @@ const (
 	StatusUnknown Status = "unknown"
 )
 
-func (e *Status) Scan(src interface{}) error {
+func (e *Status) Scan(src any) error {
 	switch s := src.(type) {
 	case []byte:
 		*e = Status(s)
@@ -35,7 +35,7 @@ type NullStatus struct {
 }
 
 // Scan implements the Scanner interface.
-func (ns *NullStatus) Scan(value interface{}) error {
+func (ns *NullStatus) Scan(value any) error {
 	if value == nil {
 		ns.Status, ns.Valid = "", false
 		return nil

--- a/internal/endtoend/testdata/ddl_alter_type_add_value/postgresql/stdlib/go/db.go
+++ b/internal/endtoend/testdata/ddl_alter_type_add_value/postgresql/stdlib/go/db.go
@@ -10,10 +10,10 @@ import (
 )
 
 type DBTX interface {
-	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
 	PrepareContext(context.Context, string) (*sql.Stmt, error)
-	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
-	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/ddl_alter_type_add_value/postgresql/stdlib/go/models.go
+++ b/internal/endtoend/testdata/ddl_alter_type_add_value/postgresql/stdlib/go/models.go
@@ -17,7 +17,7 @@ const (
 	StatusUnknown Status = "unknown"
 )
 
-func (e *Status) Scan(src interface{}) error {
+func (e *Status) Scan(src any) error {
 	switch s := src.(type) {
 	case []byte:
 		*e = Status(s)
@@ -35,7 +35,7 @@ type NullStatus struct {
 }
 
 // Scan implements the Scanner interface.
-func (ns *NullStatus) Scan(value interface{}) error {
+func (ns *NullStatus) Scan(value any) error {
 	if value == nil {
 		ns.Status, ns.Valid = "", false
 		return nil

--- a/internal/endtoend/testdata/ddl_alter_type_rename/postgresql/pgx/v4/go/db.go
+++ b/internal/endtoend/testdata/ddl_alter_type_rename/postgresql/pgx/v4/go/db.go
@@ -12,9 +12,9 @@ import (
 )
 
 type DBTX interface {
-	Exec(context.Context, string, ...interface{}) (pgconn.CommandTag, error)
-	Query(context.Context, string, ...interface{}) (pgx.Rows, error)
-	QueryRow(context.Context, string, ...interface{}) pgx.Row
+	Exec(context.Context, string, ...any) (pgconn.CommandTag, error)
+	Query(context.Context, string, ...any) (pgx.Rows, error)
+	QueryRow(context.Context, string, ...any) pgx.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/ddl_alter_type_rename/postgresql/pgx/v4/go/models.go
+++ b/internal/endtoend/testdata/ddl_alter_type_rename/postgresql/pgx/v4/go/models.go
@@ -16,7 +16,7 @@ const (
 	NewEventSTOP  NewEvent = "STOP"
 )
 
-func (e *NewEvent) Scan(src interface{}) error {
+func (e *NewEvent) Scan(src any) error {
 	switch s := src.(type) {
 	case []byte:
 		*e = NewEvent(s)
@@ -34,7 +34,7 @@ type NullNewEvent struct {
 }
 
 // Scan implements the Scanner interface.
-func (ns *NullNewEvent) Scan(value interface{}) error {
+func (ns *NullNewEvent) Scan(value any) error {
 	if value == nil {
 		ns.NewEvent, ns.Valid = "", false
 		return nil

--- a/internal/endtoend/testdata/ddl_alter_type_rename/postgresql/pgx/v5/go/db.go
+++ b/internal/endtoend/testdata/ddl_alter_type_rename/postgresql/pgx/v5/go/db.go
@@ -12,9 +12,9 @@ import (
 )
 
 type DBTX interface {
-	Exec(context.Context, string, ...interface{}) (pgconn.CommandTag, error)
-	Query(context.Context, string, ...interface{}) (pgx.Rows, error)
-	QueryRow(context.Context, string, ...interface{}) pgx.Row
+	Exec(context.Context, string, ...any) (pgconn.CommandTag, error)
+	Query(context.Context, string, ...any) (pgx.Rows, error)
+	QueryRow(context.Context, string, ...any) pgx.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/ddl_alter_type_rename/postgresql/pgx/v5/go/models.go
+++ b/internal/endtoend/testdata/ddl_alter_type_rename/postgresql/pgx/v5/go/models.go
@@ -16,7 +16,7 @@ const (
 	NewEventSTOP  NewEvent = "STOP"
 )
 
-func (e *NewEvent) Scan(src interface{}) error {
+func (e *NewEvent) Scan(src any) error {
 	switch s := src.(type) {
 	case []byte:
 		*e = NewEvent(s)
@@ -34,7 +34,7 @@ type NullNewEvent struct {
 }
 
 // Scan implements the Scanner interface.
-func (ns *NullNewEvent) Scan(value interface{}) error {
+func (ns *NullNewEvent) Scan(value any) error {
 	if value == nil {
 		ns.NewEvent, ns.Valid = "", false
 		return nil

--- a/internal/endtoend/testdata/ddl_alter_type_rename/postgresql/stdlib/go/db.go
+++ b/internal/endtoend/testdata/ddl_alter_type_rename/postgresql/stdlib/go/db.go
@@ -10,10 +10,10 @@ import (
 )
 
 type DBTX interface {
-	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
 	PrepareContext(context.Context, string) (*sql.Stmt, error)
-	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
-	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/ddl_alter_type_rename/postgresql/stdlib/go/models.go
+++ b/internal/endtoend/testdata/ddl_alter_type_rename/postgresql/stdlib/go/models.go
@@ -16,7 +16,7 @@ const (
 	NewEventSTOP  NewEvent = "STOP"
 )
 
-func (e *NewEvent) Scan(src interface{}) error {
+func (e *NewEvent) Scan(src any) error {
 	switch s := src.(type) {
 	case []byte:
 		*e = NewEvent(s)
@@ -34,7 +34,7 @@ type NullNewEvent struct {
 }
 
 // Scan implements the Scanner interface.
-func (ns *NullNewEvent) Scan(value interface{}) error {
+func (ns *NullNewEvent) Scan(value any) error {
 	if value == nil {
 		ns.NewEvent, ns.Valid = "", false
 		return nil

--- a/internal/endtoend/testdata/ddl_alter_type_rename_and_update_columns/postgresql/pgx/v4/go/db.go
+++ b/internal/endtoend/testdata/ddl_alter_type_rename_and_update_columns/postgresql/pgx/v4/go/db.go
@@ -12,9 +12,9 @@ import (
 )
 
 type DBTX interface {
-	Exec(context.Context, string, ...interface{}) (pgconn.CommandTag, error)
-	Query(context.Context, string, ...interface{}) (pgx.Rows, error)
-	QueryRow(context.Context, string, ...interface{}) pgx.Row
+	Exec(context.Context, string, ...any) (pgconn.CommandTag, error)
+	Query(context.Context, string, ...any) (pgx.Rows, error)
+	QueryRow(context.Context, string, ...any) pgx.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/ddl_alter_type_rename_and_update_columns/postgresql/pgx/v4/go/models.go
+++ b/internal/endtoend/testdata/ddl_alter_type_rename_and_update_columns/postgresql/pgx/v4/go/models.go
@@ -16,7 +16,7 @@ const (
 	NewEventSTOP  NewEvent = "STOP"
 )
 
-func (e *NewEvent) Scan(src interface{}) error {
+func (e *NewEvent) Scan(src any) error {
 	switch s := src.(type) {
 	case []byte:
 		*e = NewEvent(s)
@@ -34,7 +34,7 @@ type NullNewEvent struct {
 }
 
 // Scan implements the Scanner interface.
-func (ns *NullNewEvent) Scan(value interface{}) error {
+func (ns *NullNewEvent) Scan(value any) error {
 	if value == nil {
 		ns.NewEvent, ns.Valid = "", false
 		return nil

--- a/internal/endtoend/testdata/ddl_alter_type_rename_and_update_columns/postgresql/pgx/v5/go/db.go
+++ b/internal/endtoend/testdata/ddl_alter_type_rename_and_update_columns/postgresql/pgx/v5/go/db.go
@@ -12,9 +12,9 @@ import (
 )
 
 type DBTX interface {
-	Exec(context.Context, string, ...interface{}) (pgconn.CommandTag, error)
-	Query(context.Context, string, ...interface{}) (pgx.Rows, error)
-	QueryRow(context.Context, string, ...interface{}) pgx.Row
+	Exec(context.Context, string, ...any) (pgconn.CommandTag, error)
+	Query(context.Context, string, ...any) (pgx.Rows, error)
+	QueryRow(context.Context, string, ...any) pgx.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/ddl_alter_type_rename_and_update_columns/postgresql/pgx/v5/go/models.go
+++ b/internal/endtoend/testdata/ddl_alter_type_rename_and_update_columns/postgresql/pgx/v5/go/models.go
@@ -16,7 +16,7 @@ const (
 	NewEventSTOP  NewEvent = "STOP"
 )
 
-func (e *NewEvent) Scan(src interface{}) error {
+func (e *NewEvent) Scan(src any) error {
 	switch s := src.(type) {
 	case []byte:
 		*e = NewEvent(s)
@@ -34,7 +34,7 @@ type NullNewEvent struct {
 }
 
 // Scan implements the Scanner interface.
-func (ns *NullNewEvent) Scan(value interface{}) error {
+func (ns *NullNewEvent) Scan(value any) error {
 	if value == nil {
 		ns.NewEvent, ns.Valid = "", false
 		return nil

--- a/internal/endtoend/testdata/ddl_alter_type_rename_and_update_columns/postgresql/stdlib/go/db.go
+++ b/internal/endtoend/testdata/ddl_alter_type_rename_and_update_columns/postgresql/stdlib/go/db.go
@@ -10,10 +10,10 @@ import (
 )
 
 type DBTX interface {
-	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
 	PrepareContext(context.Context, string) (*sql.Stmt, error)
-	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
-	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/ddl_alter_type_rename_and_update_columns/postgresql/stdlib/go/models.go
+++ b/internal/endtoend/testdata/ddl_alter_type_rename_and_update_columns/postgresql/stdlib/go/models.go
@@ -16,7 +16,7 @@ const (
 	NewEventSTOP  NewEvent = "STOP"
 )
 
-func (e *NewEvent) Scan(src interface{}) error {
+func (e *NewEvent) Scan(src any) error {
 	switch s := src.(type) {
 	case []byte:
 		*e = NewEvent(s)
@@ -34,7 +34,7 @@ type NullNewEvent struct {
 }
 
 // Scan implements the Scanner interface.
-func (ns *NullNewEvent) Scan(value interface{}) error {
+func (ns *NullNewEvent) Scan(value any) error {
 	if value == nil {
 		ns.NewEvent, ns.Valid = "", false
 		return nil

--- a/internal/endtoend/testdata/ddl_alter_type_rename_value/postgresql/pgx/v4/go/db.go
+++ b/internal/endtoend/testdata/ddl_alter_type_rename_value/postgresql/pgx/v4/go/db.go
@@ -12,9 +12,9 @@ import (
 )
 
 type DBTX interface {
-	Exec(context.Context, string, ...interface{}) (pgconn.CommandTag, error)
-	Query(context.Context, string, ...interface{}) (pgx.Rows, error)
-	QueryRow(context.Context, string, ...interface{}) pgx.Row
+	Exec(context.Context, string, ...any) (pgconn.CommandTag, error)
+	Query(context.Context, string, ...any) (pgx.Rows, error)
+	QueryRow(context.Context, string, ...any) pgx.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/ddl_alter_type_rename_value/postgresql/pgx/v4/go/models.go
+++ b/internal/endtoend/testdata/ddl_alter_type_rename_value/postgresql/pgx/v4/go/models.go
@@ -16,7 +16,7 @@ const (
 	StatusShut Status = "shut"
 )
 
-func (e *Status) Scan(src interface{}) error {
+func (e *Status) Scan(src any) error {
 	switch s := src.(type) {
 	case []byte:
 		*e = Status(s)
@@ -34,7 +34,7 @@ type NullStatus struct {
 }
 
 // Scan implements the Scanner interface.
-func (ns *NullStatus) Scan(value interface{}) error {
+func (ns *NullStatus) Scan(value any) error {
 	if value == nil {
 		ns.Status, ns.Valid = "", false
 		return nil

--- a/internal/endtoend/testdata/ddl_alter_type_rename_value/postgresql/pgx/v5/go/db.go
+++ b/internal/endtoend/testdata/ddl_alter_type_rename_value/postgresql/pgx/v5/go/db.go
@@ -12,9 +12,9 @@ import (
 )
 
 type DBTX interface {
-	Exec(context.Context, string, ...interface{}) (pgconn.CommandTag, error)
-	Query(context.Context, string, ...interface{}) (pgx.Rows, error)
-	QueryRow(context.Context, string, ...interface{}) pgx.Row
+	Exec(context.Context, string, ...any) (pgconn.CommandTag, error)
+	Query(context.Context, string, ...any) (pgx.Rows, error)
+	QueryRow(context.Context, string, ...any) pgx.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/ddl_alter_type_rename_value/postgresql/pgx/v5/go/models.go
+++ b/internal/endtoend/testdata/ddl_alter_type_rename_value/postgresql/pgx/v5/go/models.go
@@ -16,7 +16,7 @@ const (
 	StatusShut Status = "shut"
 )
 
-func (e *Status) Scan(src interface{}) error {
+func (e *Status) Scan(src any) error {
 	switch s := src.(type) {
 	case []byte:
 		*e = Status(s)
@@ -34,7 +34,7 @@ type NullStatus struct {
 }
 
 // Scan implements the Scanner interface.
-func (ns *NullStatus) Scan(value interface{}) error {
+func (ns *NullStatus) Scan(value any) error {
 	if value == nil {
 		ns.Status, ns.Valid = "", false
 		return nil

--- a/internal/endtoend/testdata/ddl_alter_type_rename_value/postgresql/stdlib/go/db.go
+++ b/internal/endtoend/testdata/ddl_alter_type_rename_value/postgresql/stdlib/go/db.go
@@ -10,10 +10,10 @@ import (
 )
 
 type DBTX interface {
-	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
 	PrepareContext(context.Context, string) (*sql.Stmt, error)
-	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
-	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/ddl_alter_type_rename_value/postgresql/stdlib/go/models.go
+++ b/internal/endtoend/testdata/ddl_alter_type_rename_value/postgresql/stdlib/go/models.go
@@ -16,7 +16,7 @@ const (
 	StatusShut Status = "shut"
 )
 
-func (e *Status) Scan(src interface{}) error {
+func (e *Status) Scan(src any) error {
 	switch s := src.(type) {
 	case []byte:
 		*e = Status(s)
@@ -34,7 +34,7 @@ type NullStatus struct {
 }
 
 // Scan implements the Scanner interface.
-func (ns *NullStatus) Scan(value interface{}) error {
+func (ns *NullStatus) Scan(value any) error {
 	if value == nil {
 		ns.Status, ns.Valid = "", false
 		return nil

--- a/internal/endtoend/testdata/ddl_alter_type_set_schema/postgresql/pgx/v4/go/db.go
+++ b/internal/endtoend/testdata/ddl_alter_type_set_schema/postgresql/pgx/v4/go/db.go
@@ -12,9 +12,9 @@ import (
 )
 
 type DBTX interface {
-	Exec(context.Context, string, ...interface{}) (pgconn.CommandTag, error)
-	Query(context.Context, string, ...interface{}) (pgx.Rows, error)
-	QueryRow(context.Context, string, ...interface{}) pgx.Row
+	Exec(context.Context, string, ...any) (pgconn.CommandTag, error)
+	Query(context.Context, string, ...any) (pgx.Rows, error)
+	QueryRow(context.Context, string, ...any) pgx.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/ddl_alter_type_set_schema/postgresql/pgx/v4/go/models.go
+++ b/internal/endtoend/testdata/ddl_alter_type_set_schema/postgresql/pgx/v4/go/models.go
@@ -19,7 +19,7 @@ const (
 	LevelFATAL Level = "FATAL"
 )
 
-func (e *Level) Scan(src interface{}) error {
+func (e *Level) Scan(src any) error {
 	switch s := src.(type) {
 	case []byte:
 		*e = Level(s)
@@ -37,7 +37,7 @@ type NullLevel struct {
 }
 
 // Scan implements the Scanner interface.
-func (ns *NullLevel) Scan(value interface{}) error {
+func (ns *NullLevel) Scan(value any) error {
 	if value == nil {
 		ns.Level, ns.Valid = "", false
 		return nil
@@ -61,7 +61,7 @@ const (
 	NewEventSTOP  NewEvent = "STOP"
 )
 
-func (e *NewEvent) Scan(src interface{}) error {
+func (e *NewEvent) Scan(src any) error {
 	switch s := src.(type) {
 	case []byte:
 		*e = NewEvent(s)
@@ -79,7 +79,7 @@ type NullNewEvent struct {
 }
 
 // Scan implements the Scanner interface.
-func (ns *NullNewEvent) Scan(value interface{}) error {
+func (ns *NullNewEvent) Scan(value any) error {
 	if value == nil {
 		ns.NewEvent, ns.Valid = "", false
 		return nil

--- a/internal/endtoend/testdata/ddl_alter_type_set_schema/postgresql/pgx/v5/go/db.go
+++ b/internal/endtoend/testdata/ddl_alter_type_set_schema/postgresql/pgx/v5/go/db.go
@@ -12,9 +12,9 @@ import (
 )
 
 type DBTX interface {
-	Exec(context.Context, string, ...interface{}) (pgconn.CommandTag, error)
-	Query(context.Context, string, ...interface{}) (pgx.Rows, error)
-	QueryRow(context.Context, string, ...interface{}) pgx.Row
+	Exec(context.Context, string, ...any) (pgconn.CommandTag, error)
+	Query(context.Context, string, ...any) (pgx.Rows, error)
+	QueryRow(context.Context, string, ...any) pgx.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/ddl_alter_type_set_schema/postgresql/pgx/v5/go/models.go
+++ b/internal/endtoend/testdata/ddl_alter_type_set_schema/postgresql/pgx/v5/go/models.go
@@ -19,7 +19,7 @@ const (
 	LevelFATAL Level = "FATAL"
 )
 
-func (e *Level) Scan(src interface{}) error {
+func (e *Level) Scan(src any) error {
 	switch s := src.(type) {
 	case []byte:
 		*e = Level(s)
@@ -37,7 +37,7 @@ type NullLevel struct {
 }
 
 // Scan implements the Scanner interface.
-func (ns *NullLevel) Scan(value interface{}) error {
+func (ns *NullLevel) Scan(value any) error {
 	if value == nil {
 		ns.Level, ns.Valid = "", false
 		return nil
@@ -61,7 +61,7 @@ const (
 	NewEventSTOP  NewEvent = "STOP"
 )
 
-func (e *NewEvent) Scan(src interface{}) error {
+func (e *NewEvent) Scan(src any) error {
 	switch s := src.(type) {
 	case []byte:
 		*e = NewEvent(s)
@@ -79,7 +79,7 @@ type NullNewEvent struct {
 }
 
 // Scan implements the Scanner interface.
-func (ns *NullNewEvent) Scan(value interface{}) error {
+func (ns *NullNewEvent) Scan(value any) error {
 	if value == nil {
 		ns.NewEvent, ns.Valid = "", false
 		return nil

--- a/internal/endtoend/testdata/ddl_alter_type_set_schema/postgresql/stdlib/go/db.go
+++ b/internal/endtoend/testdata/ddl_alter_type_set_schema/postgresql/stdlib/go/db.go
@@ -10,10 +10,10 @@ import (
 )
 
 type DBTX interface {
-	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
 	PrepareContext(context.Context, string) (*sql.Stmt, error)
-	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
-	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/ddl_alter_type_set_schema/postgresql/stdlib/go/models.go
+++ b/internal/endtoend/testdata/ddl_alter_type_set_schema/postgresql/stdlib/go/models.go
@@ -19,7 +19,7 @@ const (
 	LevelFATAL Level = "FATAL"
 )
 
-func (e *Level) Scan(src interface{}) error {
+func (e *Level) Scan(src any) error {
 	switch s := src.(type) {
 	case []byte:
 		*e = Level(s)
@@ -37,7 +37,7 @@ type NullLevel struct {
 }
 
 // Scan implements the Scanner interface.
-func (ns *NullLevel) Scan(value interface{}) error {
+func (ns *NullLevel) Scan(value any) error {
 	if value == nil {
 		ns.Level, ns.Valid = "", false
 		return nil
@@ -61,7 +61,7 @@ const (
 	NewEventSTOP  NewEvent = "STOP"
 )
 
-func (e *NewEvent) Scan(src interface{}) error {
+func (e *NewEvent) Scan(src any) error {
 	switch s := src.(type) {
 	case []byte:
 		*e = NewEvent(s)
@@ -79,7 +79,7 @@ type NullNewEvent struct {
 }
 
 // Scan implements the Scanner interface.
-func (ns *NullNewEvent) Scan(value interface{}) error {
+func (ns *NullNewEvent) Scan(value any) error {
 	if value == nil {
 		ns.NewEvent, ns.Valid = "", false
 		return nil

--- a/internal/endtoend/testdata/ddl_comment/mysql/go/db.go
+++ b/internal/endtoend/testdata/ddl_comment/mysql/go/db.go
@@ -10,10 +10,10 @@ import (
 )
 
 type DBTX interface {
-	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
 	PrepareContext(context.Context, string) (*sql.Stmt, error)
-	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
-	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/ddl_comment/postgresql/pgx/v4/go/db.go
+++ b/internal/endtoend/testdata/ddl_comment/postgresql/pgx/v4/go/db.go
@@ -12,9 +12,9 @@ import (
 )
 
 type DBTX interface {
-	Exec(context.Context, string, ...interface{}) (pgconn.CommandTag, error)
-	Query(context.Context, string, ...interface{}) (pgx.Rows, error)
-	QueryRow(context.Context, string, ...interface{}) pgx.Row
+	Exec(context.Context, string, ...any) (pgconn.CommandTag, error)
+	Query(context.Context, string, ...any) (pgx.Rows, error)
+	QueryRow(context.Context, string, ...any) pgx.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/ddl_comment/postgresql/pgx/v4/go/models.go
+++ b/internal/endtoend/testdata/ddl_comment/postgresql/pgx/v4/go/models.go
@@ -17,7 +17,7 @@ const (
 	FooBatBat FooBat = "bat"
 )
 
-func (e *FooBat) Scan(src interface{}) error {
+func (e *FooBat) Scan(src any) error {
 	switch s := src.(type) {
 	case []byte:
 		*e = FooBat(s)
@@ -35,7 +35,7 @@ type NullFooBat struct {
 }
 
 // Scan implements the Scanner interface.
-func (ns *NullFooBat) Scan(value interface{}) error {
+func (ns *NullFooBat) Scan(value any) error {
 	if value == nil {
 		ns.FooBat, ns.Valid = "", false
 		return nil

--- a/internal/endtoend/testdata/ddl_comment/postgresql/pgx/v5/go/db.go
+++ b/internal/endtoend/testdata/ddl_comment/postgresql/pgx/v5/go/db.go
@@ -12,9 +12,9 @@ import (
 )
 
 type DBTX interface {
-	Exec(context.Context, string, ...interface{}) (pgconn.CommandTag, error)
-	Query(context.Context, string, ...interface{}) (pgx.Rows, error)
-	QueryRow(context.Context, string, ...interface{}) pgx.Row
+	Exec(context.Context, string, ...any) (pgconn.CommandTag, error)
+	Query(context.Context, string, ...any) (pgx.Rows, error)
+	QueryRow(context.Context, string, ...any) pgx.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/ddl_comment/postgresql/pgx/v5/go/models.go
+++ b/internal/endtoend/testdata/ddl_comment/postgresql/pgx/v5/go/models.go
@@ -18,7 +18,7 @@ const (
 	FooBatBat FooBat = "bat"
 )
 
-func (e *FooBat) Scan(src interface{}) error {
+func (e *FooBat) Scan(src any) error {
 	switch s := src.(type) {
 	case []byte:
 		*e = FooBat(s)
@@ -36,7 +36,7 @@ type NullFooBat struct {
 }
 
 // Scan implements the Scanner interface.
-func (ns *NullFooBat) Scan(value interface{}) error {
+func (ns *NullFooBat) Scan(value any) error {
 	if value == nil {
 		ns.FooBat, ns.Valid = "", false
 		return nil

--- a/internal/endtoend/testdata/ddl_comment/postgresql/stdlib/go/db.go
+++ b/internal/endtoend/testdata/ddl_comment/postgresql/stdlib/go/db.go
@@ -10,10 +10,10 @@ import (
 )
 
 type DBTX interface {
-	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
 	PrepareContext(context.Context, string) (*sql.Stmt, error)
-	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
-	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/ddl_comment/postgresql/stdlib/go/models.go
+++ b/internal/endtoend/testdata/ddl_comment/postgresql/stdlib/go/models.go
@@ -17,7 +17,7 @@ const (
 	FooBatBat FooBat = "bat"
 )
 
-func (e *FooBat) Scan(src interface{}) error {
+func (e *FooBat) Scan(src any) error {
 	switch s := src.(type) {
 	case []byte:
 		*e = FooBat(s)
@@ -35,7 +35,7 @@ type NullFooBat struct {
 }
 
 // Scan implements the Scanner interface.
-func (ns *NullFooBat) Scan(value interface{}) error {
+func (ns *NullFooBat) Scan(value any) error {
 	if value == nil {
 		ns.FooBat, ns.Valid = "", false
 		return nil

--- a/internal/endtoend/testdata/ddl_create_enum/mysql/go/db.go
+++ b/internal/endtoend/testdata/ddl_create_enum/mysql/go/db.go
@@ -10,10 +10,10 @@ import (
 )
 
 type DBTX interface {
-	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
 	PrepareContext(context.Context, string) (*sql.Stmt, error)
-	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
-	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/ddl_create_enum/mysql/go/models.go
+++ b/internal/endtoend/testdata/ddl_create_enum/mysql/go/models.go
@@ -26,7 +26,7 @@ const (
 	FooDigitValue11 FooDigit = "*"
 )
 
-func (e *FooDigit) Scan(src interface{}) error {
+func (e *FooDigit) Scan(src any) error {
 	switch s := src.(type) {
 	case []byte:
 		*e = FooDigit(s)
@@ -44,7 +44,7 @@ type NullFooDigit struct {
 }
 
 // Scan implements the Scanner interface.
-func (ns *NullFooDigit) Scan(value interface{}) error {
+func (ns *NullFooDigit) Scan(value any) error {
 	if value == nil {
 		ns.FooDigit, ns.Valid = "", false
 		return nil
@@ -73,7 +73,7 @@ const (
 	FooFoobarFoog FooFoobar = "foo!g"
 )
 
-func (e *FooFoobar) Scan(src interface{}) error {
+func (e *FooFoobar) Scan(src any) error {
 	switch s := src.(type) {
 	case []byte:
 		*e = FooFoobar(s)
@@ -91,7 +91,7 @@ type NullFooFoobar struct {
 }
 
 // Scan implements the Scanner interface.
-func (ns *NullFooFoobar) Scan(value interface{}) error {
+func (ns *NullFooFoobar) Scan(value any) error {
 	if value == nil {
 		ns.FooFoobar, ns.Valid = "", false
 		return nil

--- a/internal/endtoend/testdata/ddl_create_enum/postgresql/pgx/v4/go/db.go
+++ b/internal/endtoend/testdata/ddl_create_enum/postgresql/pgx/v4/go/db.go
@@ -12,9 +12,9 @@ import (
 )
 
 type DBTX interface {
-	Exec(context.Context, string, ...interface{}) (pgconn.CommandTag, error)
-	Query(context.Context, string, ...interface{}) (pgx.Rows, error)
-	QueryRow(context.Context, string, ...interface{}) pgx.Row
+	Exec(context.Context, string, ...any) (pgconn.CommandTag, error)
+	Query(context.Context, string, ...any) (pgx.Rows, error)
+	QueryRow(context.Context, string, ...any) pgx.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/ddl_create_enum/postgresql/pgx/v4/go/models.go
+++ b/internal/endtoend/testdata/ddl_create_enum/postgresql/pgx/v4/go/models.go
@@ -26,7 +26,7 @@ const (
 	DigitValue11 Digit = "*"
 )
 
-func (e *Digit) Scan(src interface{}) error {
+func (e *Digit) Scan(src any) error {
 	switch s := src.(type) {
 	case []byte:
 		*e = Digit(s)
@@ -44,7 +44,7 @@ type NullDigit struct {
 }
 
 // Scan implements the Scanner interface.
-func (ns *NullDigit) Scan(value interface{}) error {
+func (ns *NullDigit) Scan(value any) error {
 	if value == nil {
 		ns.Digit, ns.Valid = "", false
 		return nil
@@ -73,7 +73,7 @@ const (
 	FoobarFoog Foobar = "foo!g"
 )
 
-func (e *Foobar) Scan(src interface{}) error {
+func (e *Foobar) Scan(src any) error {
 	switch s := src.(type) {
 	case []byte:
 		*e = Foobar(s)
@@ -91,7 +91,7 @@ type NullFoobar struct {
 }
 
 // Scan implements the Scanner interface.
-func (ns *NullFoobar) Scan(value interface{}) error {
+func (ns *NullFoobar) Scan(value any) error {
 	if value == nil {
 		ns.Foobar, ns.Valid = "", false
 		return nil

--- a/internal/endtoend/testdata/ddl_create_enum/postgresql/pgx/v5/go/db.go
+++ b/internal/endtoend/testdata/ddl_create_enum/postgresql/pgx/v5/go/db.go
@@ -12,9 +12,9 @@ import (
 )
 
 type DBTX interface {
-	Exec(context.Context, string, ...interface{}) (pgconn.CommandTag, error)
-	Query(context.Context, string, ...interface{}) (pgx.Rows, error)
-	QueryRow(context.Context, string, ...interface{}) pgx.Row
+	Exec(context.Context, string, ...any) (pgconn.CommandTag, error)
+	Query(context.Context, string, ...any) (pgx.Rows, error)
+	QueryRow(context.Context, string, ...any) pgx.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/ddl_create_enum/postgresql/pgx/v5/go/models.go
+++ b/internal/endtoend/testdata/ddl_create_enum/postgresql/pgx/v5/go/models.go
@@ -26,7 +26,7 @@ const (
 	DigitValue11 Digit = "*"
 )
 
-func (e *Digit) Scan(src interface{}) error {
+func (e *Digit) Scan(src any) error {
 	switch s := src.(type) {
 	case []byte:
 		*e = Digit(s)
@@ -44,7 +44,7 @@ type NullDigit struct {
 }
 
 // Scan implements the Scanner interface.
-func (ns *NullDigit) Scan(value interface{}) error {
+func (ns *NullDigit) Scan(value any) error {
 	if value == nil {
 		ns.Digit, ns.Valid = "", false
 		return nil
@@ -73,7 +73,7 @@ const (
 	FoobarFoog Foobar = "foo!g"
 )
 
-func (e *Foobar) Scan(src interface{}) error {
+func (e *Foobar) Scan(src any) error {
 	switch s := src.(type) {
 	case []byte:
 		*e = Foobar(s)
@@ -91,7 +91,7 @@ type NullFoobar struct {
 }
 
 // Scan implements the Scanner interface.
-func (ns *NullFoobar) Scan(value interface{}) error {
+func (ns *NullFoobar) Scan(value any) error {
 	if value == nil {
 		ns.Foobar, ns.Valid = "", false
 		return nil

--- a/internal/endtoend/testdata/ddl_create_enum/postgresql/stdlib/go/db.go
+++ b/internal/endtoend/testdata/ddl_create_enum/postgresql/stdlib/go/db.go
@@ -10,10 +10,10 @@ import (
 )
 
 type DBTX interface {
-	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
 	PrepareContext(context.Context, string) (*sql.Stmt, error)
-	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
-	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/ddl_create_enum/postgresql/stdlib/go/models.go
+++ b/internal/endtoend/testdata/ddl_create_enum/postgresql/stdlib/go/models.go
@@ -26,7 +26,7 @@ const (
 	DigitValue11 Digit = "*"
 )
 
-func (e *Digit) Scan(src interface{}) error {
+func (e *Digit) Scan(src any) error {
 	switch s := src.(type) {
 	case []byte:
 		*e = Digit(s)
@@ -44,7 +44,7 @@ type NullDigit struct {
 }
 
 // Scan implements the Scanner interface.
-func (ns *NullDigit) Scan(value interface{}) error {
+func (ns *NullDigit) Scan(value any) error {
 	if value == nil {
 		ns.Digit, ns.Valid = "", false
 		return nil
@@ -73,7 +73,7 @@ const (
 	FoobarFoog Foobar = "foo!g"
 )
 
-func (e *Foobar) Scan(src interface{}) error {
+func (e *Foobar) Scan(src any) error {
 	switch s := src.(type) {
 	case []byte:
 		*e = Foobar(s)
@@ -91,7 +91,7 @@ type NullFoobar struct {
 }
 
 // Scan implements the Scanner interface.
-func (ns *NullFoobar) Scan(value interface{}) error {
+func (ns *NullFoobar) Scan(value any) error {
 	if value == nil {
 		ns.Foobar, ns.Valid = "", false
 		return nil

--- a/internal/endtoend/testdata/ddl_create_function/postgresql/pgx/v4/go/db.go
+++ b/internal/endtoend/testdata/ddl_create_function/postgresql/pgx/v4/go/db.go
@@ -12,9 +12,9 @@ import (
 )
 
 type DBTX interface {
-	Exec(context.Context, string, ...interface{}) (pgconn.CommandTag, error)
-	Query(context.Context, string, ...interface{}) (pgx.Rows, error)
-	QueryRow(context.Context, string, ...interface{}) pgx.Row
+	Exec(context.Context, string, ...any) (pgconn.CommandTag, error)
+	Query(context.Context, string, ...any) (pgx.Rows, error)
+	QueryRow(context.Context, string, ...any) pgx.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/ddl_create_function/postgresql/pgx/v5/go/db.go
+++ b/internal/endtoend/testdata/ddl_create_function/postgresql/pgx/v5/go/db.go
@@ -12,9 +12,9 @@ import (
 )
 
 type DBTX interface {
-	Exec(context.Context, string, ...interface{}) (pgconn.CommandTag, error)
-	Query(context.Context, string, ...interface{}) (pgx.Rows, error)
-	QueryRow(context.Context, string, ...interface{}) pgx.Row
+	Exec(context.Context, string, ...any) (pgconn.CommandTag, error)
+	Query(context.Context, string, ...any) (pgx.Rows, error)
+	QueryRow(context.Context, string, ...any) pgx.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/ddl_create_function/postgresql/stdlib/go/db.go
+++ b/internal/endtoend/testdata/ddl_create_function/postgresql/stdlib/go/db.go
@@ -10,10 +10,10 @@ import (
 )
 
 type DBTX interface {
-	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
 	PrepareContext(context.Context, string) (*sql.Stmt, error)
-	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
-	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/ddl_create_function_args/postgresql/pgx/v4/go/db.go
+++ b/internal/endtoend/testdata/ddl_create_function_args/postgresql/pgx/v4/go/db.go
@@ -12,9 +12,9 @@ import (
 )
 
 type DBTX interface {
-	Exec(context.Context, string, ...interface{}) (pgconn.CommandTag, error)
-	Query(context.Context, string, ...interface{}) (pgx.Rows, error)
-	QueryRow(context.Context, string, ...interface{}) pgx.Row
+	Exec(context.Context, string, ...any) (pgconn.CommandTag, error)
+	Query(context.Context, string, ...any) (pgx.Rows, error)
+	QueryRow(context.Context, string, ...any) pgx.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/ddl_create_function_args/postgresql/pgx/v5/go/db.go
+++ b/internal/endtoend/testdata/ddl_create_function_args/postgresql/pgx/v5/go/db.go
@@ -12,9 +12,9 @@ import (
 )
 
 type DBTX interface {
-	Exec(context.Context, string, ...interface{}) (pgconn.CommandTag, error)
-	Query(context.Context, string, ...interface{}) (pgx.Rows, error)
-	QueryRow(context.Context, string, ...interface{}) pgx.Row
+	Exec(context.Context, string, ...any) (pgconn.CommandTag, error)
+	Query(context.Context, string, ...any) (pgx.Rows, error)
+	QueryRow(context.Context, string, ...any) pgx.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/ddl_create_function_args/postgresql/stdlib/go/db.go
+++ b/internal/endtoend/testdata/ddl_create_function_args/postgresql/stdlib/go/db.go
@@ -10,10 +10,10 @@ import (
 )
 
 type DBTX interface {
-	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
 	PrepareContext(context.Context, string) (*sql.Stmt, error)
-	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
-	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/ddl_create_function_return/postgresql/pgx/v4/go/db.go
+++ b/internal/endtoend/testdata/ddl_create_function_return/postgresql/pgx/v4/go/db.go
@@ -12,9 +12,9 @@ import (
 )
 
 type DBTX interface {
-	Exec(context.Context, string, ...interface{}) (pgconn.CommandTag, error)
-	Query(context.Context, string, ...interface{}) (pgx.Rows, error)
-	QueryRow(context.Context, string, ...interface{}) pgx.Row
+	Exec(context.Context, string, ...any) (pgconn.CommandTag, error)
+	Query(context.Context, string, ...any) (pgx.Rows, error)
+	QueryRow(context.Context, string, ...any) pgx.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/ddl_create_function_return/postgresql/pgx/v5/go/db.go
+++ b/internal/endtoend/testdata/ddl_create_function_return/postgresql/pgx/v5/go/db.go
@@ -12,9 +12,9 @@ import (
 )
 
 type DBTX interface {
-	Exec(context.Context, string, ...interface{}) (pgconn.CommandTag, error)
-	Query(context.Context, string, ...interface{}) (pgx.Rows, error)
-	QueryRow(context.Context, string, ...interface{}) pgx.Row
+	Exec(context.Context, string, ...any) (pgconn.CommandTag, error)
+	Query(context.Context, string, ...any) (pgx.Rows, error)
+	QueryRow(context.Context, string, ...any) pgx.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/ddl_create_function_return/postgresql/stdlib/go/db.go
+++ b/internal/endtoend/testdata/ddl_create_function_return/postgresql/stdlib/go/db.go
@@ -10,10 +10,10 @@ import (
 )
 
 type DBTX interface {
-	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
 	PrepareContext(context.Context, string) (*sql.Stmt, error)
-	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
-	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/ddl_create_function_types/postgresql/pgx/v4/go/db.go
+++ b/internal/endtoend/testdata/ddl_create_function_types/postgresql/pgx/v4/go/db.go
@@ -12,9 +12,9 @@ import (
 )
 
 type DBTX interface {
-	Exec(context.Context, string, ...interface{}) (pgconn.CommandTag, error)
-	Query(context.Context, string, ...interface{}) (pgx.Rows, error)
-	QueryRow(context.Context, string, ...interface{}) pgx.Row
+	Exec(context.Context, string, ...any) (pgconn.CommandTag, error)
+	Query(context.Context, string, ...any) (pgx.Rows, error)
+	QueryRow(context.Context, string, ...any) pgx.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/ddl_create_function_types/postgresql/pgx/v5/go/db.go
+++ b/internal/endtoend/testdata/ddl_create_function_types/postgresql/pgx/v5/go/db.go
@@ -12,9 +12,9 @@ import (
 )
 
 type DBTX interface {
-	Exec(context.Context, string, ...interface{}) (pgconn.CommandTag, error)
-	Query(context.Context, string, ...interface{}) (pgx.Rows, error)
-	QueryRow(context.Context, string, ...interface{}) pgx.Row
+	Exec(context.Context, string, ...any) (pgconn.CommandTag, error)
+	Query(context.Context, string, ...any) (pgx.Rows, error)
+	QueryRow(context.Context, string, ...any) pgx.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/ddl_create_function_types/postgresql/stdlib/go/db.go
+++ b/internal/endtoend/testdata/ddl_create_function_types/postgresql/stdlib/go/db.go
@@ -10,10 +10,10 @@ import (
 )
 
 type DBTX interface {
-	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
 	PrepareContext(context.Context, string) (*sql.Stmt, error)
-	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
-	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/ddl_create_procedure/mysql/go/db.go
+++ b/internal/endtoend/testdata/ddl_create_procedure/mysql/go/db.go
@@ -10,10 +10,10 @@ import (
 )
 
 type DBTX interface {
-	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
 	PrepareContext(context.Context, string) (*sql.Stmt, error)
-	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
-	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/ddl_create_procedure/postgresql/pgx/v4/go/db.go
+++ b/internal/endtoend/testdata/ddl_create_procedure/postgresql/pgx/v4/go/db.go
@@ -12,9 +12,9 @@ import (
 )
 
 type DBTX interface {
-	Exec(context.Context, string, ...interface{}) (pgconn.CommandTag, error)
-	Query(context.Context, string, ...interface{}) (pgx.Rows, error)
-	QueryRow(context.Context, string, ...interface{}) pgx.Row
+	Exec(context.Context, string, ...any) (pgconn.CommandTag, error)
+	Query(context.Context, string, ...any) (pgx.Rows, error)
+	QueryRow(context.Context, string, ...any) pgx.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/ddl_create_procedure/postgresql/pgx/v5/go/db.go
+++ b/internal/endtoend/testdata/ddl_create_procedure/postgresql/pgx/v5/go/db.go
@@ -12,9 +12,9 @@ import (
 )
 
 type DBTX interface {
-	Exec(context.Context, string, ...interface{}) (pgconn.CommandTag, error)
-	Query(context.Context, string, ...interface{}) (pgx.Rows, error)
-	QueryRow(context.Context, string, ...interface{}) pgx.Row
+	Exec(context.Context, string, ...any) (pgconn.CommandTag, error)
+	Query(context.Context, string, ...any) (pgx.Rows, error)
+	QueryRow(context.Context, string, ...any) pgx.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/ddl_create_procedure/postgresql/stdlib/go/db.go
+++ b/internal/endtoend/testdata/ddl_create_procedure/postgresql/stdlib/go/db.go
@@ -10,10 +10,10 @@ import (
 )
 
 type DBTX interface {
-	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
 	PrepareContext(context.Context, string) (*sql.Stmt, error)
-	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
-	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/ddl_create_table/mysql/go/db.go
+++ b/internal/endtoend/testdata/ddl_create_table/mysql/go/db.go
@@ -10,10 +10,10 @@ import (
 )
 
 type DBTX interface {
-	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
 	PrepareContext(context.Context, string) (*sql.Stmt, error)
-	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
-	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/ddl_create_table/postgresql/pgx/v4/go/db.go
+++ b/internal/endtoend/testdata/ddl_create_table/postgresql/pgx/v4/go/db.go
@@ -12,9 +12,9 @@ import (
 )
 
 type DBTX interface {
-	Exec(context.Context, string, ...interface{}) (pgconn.CommandTag, error)
-	Query(context.Context, string, ...interface{}) (pgx.Rows, error)
-	QueryRow(context.Context, string, ...interface{}) pgx.Row
+	Exec(context.Context, string, ...any) (pgconn.CommandTag, error)
+	Query(context.Context, string, ...any) (pgx.Rows, error)
+	QueryRow(context.Context, string, ...any) pgx.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/ddl_create_table/postgresql/pgx/v5/go/db.go
+++ b/internal/endtoend/testdata/ddl_create_table/postgresql/pgx/v5/go/db.go
@@ -12,9 +12,9 @@ import (
 )
 
 type DBTX interface {
-	Exec(context.Context, string, ...interface{}) (pgconn.CommandTag, error)
-	Query(context.Context, string, ...interface{}) (pgx.Rows, error)
-	QueryRow(context.Context, string, ...interface{}) pgx.Row
+	Exec(context.Context, string, ...any) (pgconn.CommandTag, error)
+	Query(context.Context, string, ...any) (pgx.Rows, error)
+	QueryRow(context.Context, string, ...any) pgx.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/ddl_create_table/postgresql/stdlib/go/db.go
+++ b/internal/endtoend/testdata/ddl_create_table/postgresql/stdlib/go/db.go
@@ -10,10 +10,10 @@ import (
 )
 
 type DBTX interface {
-	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
 	PrepareContext(context.Context, string) (*sql.Stmt, error)
-	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
-	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/ddl_create_table/sqlite/go/db.go
+++ b/internal/endtoend/testdata/ddl_create_table/sqlite/go/db.go
@@ -10,10 +10,10 @@ import (
 )
 
 type DBTX interface {
-	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
 	PrepareContext(context.Context, string) (*sql.Stmt, error)
-	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
-	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/ddl_create_table_include/postgresql/pgx/v4/go/db.go
+++ b/internal/endtoend/testdata/ddl_create_table_include/postgresql/pgx/v4/go/db.go
@@ -12,9 +12,9 @@ import (
 )
 
 type DBTX interface {
-	Exec(context.Context, string, ...interface{}) (pgconn.CommandTag, error)
-	Query(context.Context, string, ...interface{}) (pgx.Rows, error)
-	QueryRow(context.Context, string, ...interface{}) pgx.Row
+	Exec(context.Context, string, ...any) (pgconn.CommandTag, error)
+	Query(context.Context, string, ...any) (pgx.Rows, error)
+	QueryRow(context.Context, string, ...any) pgx.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/ddl_create_table_include/postgresql/pgx/v5/go/db.go
+++ b/internal/endtoend/testdata/ddl_create_table_include/postgresql/pgx/v5/go/db.go
@@ -12,9 +12,9 @@ import (
 )
 
 type DBTX interface {
-	Exec(context.Context, string, ...interface{}) (pgconn.CommandTag, error)
-	Query(context.Context, string, ...interface{}) (pgx.Rows, error)
-	QueryRow(context.Context, string, ...interface{}) pgx.Row
+	Exec(context.Context, string, ...any) (pgconn.CommandTag, error)
+	Query(context.Context, string, ...any) (pgx.Rows, error)
+	QueryRow(context.Context, string, ...any) pgx.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/ddl_create_table_include/postgresql/stdlib/go/db.go
+++ b/internal/endtoend/testdata/ddl_create_table_include/postgresql/stdlib/go/db.go
@@ -10,10 +10,10 @@ import (
 )
 
 type DBTX interface {
-	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
 	PrepareContext(context.Context, string) (*sql.Stmt, error)
-	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
-	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/ddl_create_table_inherits/postgresql/pgx/v4/go/db.go
+++ b/internal/endtoend/testdata/ddl_create_table_inherits/postgresql/pgx/v4/go/db.go
@@ -12,9 +12,9 @@ import (
 )
 
 type DBTX interface {
-	Exec(context.Context, string, ...interface{}) (pgconn.CommandTag, error)
-	Query(context.Context, string, ...interface{}) (pgx.Rows, error)
-	QueryRow(context.Context, string, ...interface{}) pgx.Row
+	Exec(context.Context, string, ...any) (pgconn.CommandTag, error)
+	Query(context.Context, string, ...any) (pgx.Rows, error)
+	QueryRow(context.Context, string, ...any) pgx.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/ddl_create_table_inherits/postgresql/pgx/v5/go/db.go
+++ b/internal/endtoend/testdata/ddl_create_table_inherits/postgresql/pgx/v5/go/db.go
@@ -12,9 +12,9 @@ import (
 )
 
 type DBTX interface {
-	Exec(context.Context, string, ...interface{}) (pgconn.CommandTag, error)
-	Query(context.Context, string, ...interface{}) (pgx.Rows, error)
-	QueryRow(context.Context, string, ...interface{}) pgx.Row
+	Exec(context.Context, string, ...any) (pgconn.CommandTag, error)
+	Query(context.Context, string, ...any) (pgx.Rows, error)
+	QueryRow(context.Context, string, ...any) pgx.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/ddl_create_table_inherits/postgresql/stdlib/go/db.go
+++ b/internal/endtoend/testdata/ddl_create_table_inherits/postgresql/stdlib/go/db.go
@@ -10,10 +10,10 @@ import (
 )
 
 type DBTX interface {
-	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
 	PrepareContext(context.Context, string) (*sql.Stmt, error)
-	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
-	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/ddl_create_table_like/postgresql/pgx/go/db.go
+++ b/internal/endtoend/testdata/ddl_create_table_like/postgresql/pgx/go/db.go
@@ -12,9 +12,9 @@ import (
 )
 
 type DBTX interface {
-	Exec(context.Context, string, ...interface{}) (pgconn.CommandTag, error)
-	Query(context.Context, string, ...interface{}) (pgx.Rows, error)
-	QueryRow(context.Context, string, ...interface{}) pgx.Row
+	Exec(context.Context, string, ...any) (pgconn.CommandTag, error)
+	Query(context.Context, string, ...any) (pgx.Rows, error)
+	QueryRow(context.Context, string, ...any) pgx.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/ddl_create_table_partition/postgresql/pgx/v4/go/db.go
+++ b/internal/endtoend/testdata/ddl_create_table_partition/postgresql/pgx/v4/go/db.go
@@ -12,9 +12,9 @@ import (
 )
 
 type DBTX interface {
-	Exec(context.Context, string, ...interface{}) (pgconn.CommandTag, error)
-	Query(context.Context, string, ...interface{}) (pgx.Rows, error)
-	QueryRow(context.Context, string, ...interface{}) pgx.Row
+	Exec(context.Context, string, ...any) (pgconn.CommandTag, error)
+	Query(context.Context, string, ...any) (pgx.Rows, error)
+	QueryRow(context.Context, string, ...any) pgx.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/ddl_create_table_partition/postgresql/pgx/v5/go/db.go
+++ b/internal/endtoend/testdata/ddl_create_table_partition/postgresql/pgx/v5/go/db.go
@@ -12,9 +12,9 @@ import (
 )
 
 type DBTX interface {
-	Exec(context.Context, string, ...interface{}) (pgconn.CommandTag, error)
-	Query(context.Context, string, ...interface{}) (pgx.Rows, error)
-	QueryRow(context.Context, string, ...interface{}) pgx.Row
+	Exec(context.Context, string, ...any) (pgconn.CommandTag, error)
+	Query(context.Context, string, ...any) (pgx.Rows, error)
+	QueryRow(context.Context, string, ...any) pgx.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/ddl_create_table_partition/postgresql/stdlib/go/db.go
+++ b/internal/endtoend/testdata/ddl_create_table_partition/postgresql/stdlib/go/db.go
@@ -10,10 +10,10 @@ import (
 )
 
 type DBTX interface {
-	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
 	PrepareContext(context.Context, string) (*sql.Stmt, error)
-	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
-	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/ddl_create_table_reserved/mysql/go/db.go
+++ b/internal/endtoend/testdata/ddl_create_table_reserved/mysql/go/db.go
@@ -10,10 +10,10 @@ import (
 )
 
 type DBTX interface {
-	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
 	PrepareContext(context.Context, string) (*sql.Stmt, error)
-	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
-	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/ddl_create_table_reserved/postgresql/pgx/v4/go/db.go
+++ b/internal/endtoend/testdata/ddl_create_table_reserved/postgresql/pgx/v4/go/db.go
@@ -12,9 +12,9 @@ import (
 )
 
 type DBTX interface {
-	Exec(context.Context, string, ...interface{}) (pgconn.CommandTag, error)
-	Query(context.Context, string, ...interface{}) (pgx.Rows, error)
-	QueryRow(context.Context, string, ...interface{}) pgx.Row
+	Exec(context.Context, string, ...any) (pgconn.CommandTag, error)
+	Query(context.Context, string, ...any) (pgx.Rows, error)
+	QueryRow(context.Context, string, ...any) pgx.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/ddl_create_table_reserved/postgresql/pgx/v5/go/db.go
+++ b/internal/endtoend/testdata/ddl_create_table_reserved/postgresql/pgx/v5/go/db.go
@@ -12,9 +12,9 @@ import (
 )
 
 type DBTX interface {
-	Exec(context.Context, string, ...interface{}) (pgconn.CommandTag, error)
-	Query(context.Context, string, ...interface{}) (pgx.Rows, error)
-	QueryRow(context.Context, string, ...interface{}) pgx.Row
+	Exec(context.Context, string, ...any) (pgconn.CommandTag, error)
+	Query(context.Context, string, ...any) (pgx.Rows, error)
+	QueryRow(context.Context, string, ...any) pgx.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/ddl_create_table_reserved/postgresql/stdlib/go/db.go
+++ b/internal/endtoend/testdata/ddl_create_table_reserved/postgresql/stdlib/go/db.go
@@ -10,10 +10,10 @@ import (
 )
 
 type DBTX interface {
-	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
 	PrepareContext(context.Context, string) (*sql.Stmt, error)
-	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
-	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/ddl_create_table_strict/sqlite/go/db.go
+++ b/internal/endtoend/testdata/ddl_create_table_strict/sqlite/go/db.go
@@ -10,10 +10,10 @@ import (
 )
 
 type DBTX interface {
-	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
 	PrepareContext(context.Context, string) (*sql.Stmt, error)
-	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
-	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/ddl_create_table_without_rowid/sqlite/go/db.go
+++ b/internal/endtoend/testdata/ddl_create_table_without_rowid/sqlite/go/db.go
@@ -10,10 +10,10 @@ import (
 )
 
 type DBTX interface {
-	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
 	PrepareContext(context.Context, string) (*sql.Stmt, error)
-	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
-	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/ddl_create_trigger/postgresql/pgx/v4/go/db.go
+++ b/internal/endtoend/testdata/ddl_create_trigger/postgresql/pgx/v4/go/db.go
@@ -12,9 +12,9 @@ import (
 )
 
 type DBTX interface {
-	Exec(context.Context, string, ...interface{}) (pgconn.CommandTag, error)
-	Query(context.Context, string, ...interface{}) (pgx.Rows, error)
-	QueryRow(context.Context, string, ...interface{}) pgx.Row
+	Exec(context.Context, string, ...any) (pgconn.CommandTag, error)
+	Query(context.Context, string, ...any) (pgx.Rows, error)
+	QueryRow(context.Context, string, ...any) pgx.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/ddl_create_trigger/postgresql/pgx/v5/go/db.go
+++ b/internal/endtoend/testdata/ddl_create_trigger/postgresql/pgx/v5/go/db.go
@@ -12,9 +12,9 @@ import (
 )
 
 type DBTX interface {
-	Exec(context.Context, string, ...interface{}) (pgconn.CommandTag, error)
-	Query(context.Context, string, ...interface{}) (pgx.Rows, error)
-	QueryRow(context.Context, string, ...interface{}) pgx.Row
+	Exec(context.Context, string, ...any) (pgconn.CommandTag, error)
+	Query(context.Context, string, ...any) (pgx.Rows, error)
+	QueryRow(context.Context, string, ...any) pgx.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/ddl_create_trigger/postgresql/stdlib/go/db.go
+++ b/internal/endtoend/testdata/ddl_create_trigger/postgresql/stdlib/go/db.go
@@ -10,10 +10,10 @@ import (
 )
 
 type DBTX interface {
-	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
 	PrepareContext(context.Context, string) (*sql.Stmt, error)
-	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
-	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/ddl_create_trigger/sqlite/go/db.go
+++ b/internal/endtoend/testdata/ddl_create_trigger/sqlite/go/db.go
@@ -10,10 +10,10 @@ import (
 )
 
 type DBTX interface {
-	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
 	PrepareContext(context.Context, string) (*sql.Stmt, error)
-	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
-	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/ddl_drop_function/postgresql/pgx/v4/go/db.go
+++ b/internal/endtoend/testdata/ddl_drop_function/postgresql/pgx/v4/go/db.go
@@ -12,9 +12,9 @@ import (
 )
 
 type DBTX interface {
-	Exec(context.Context, string, ...interface{}) (pgconn.CommandTag, error)
-	Query(context.Context, string, ...interface{}) (pgx.Rows, error)
-	QueryRow(context.Context, string, ...interface{}) pgx.Row
+	Exec(context.Context, string, ...any) (pgconn.CommandTag, error)
+	Query(context.Context, string, ...any) (pgx.Rows, error)
+	QueryRow(context.Context, string, ...any) pgx.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/ddl_drop_function/postgresql/pgx/v5/go/db.go
+++ b/internal/endtoend/testdata/ddl_drop_function/postgresql/pgx/v5/go/db.go
@@ -12,9 +12,9 @@ import (
 )
 
 type DBTX interface {
-	Exec(context.Context, string, ...interface{}) (pgconn.CommandTag, error)
-	Query(context.Context, string, ...interface{}) (pgx.Rows, error)
-	QueryRow(context.Context, string, ...interface{}) pgx.Row
+	Exec(context.Context, string, ...any) (pgconn.CommandTag, error)
+	Query(context.Context, string, ...any) (pgx.Rows, error)
+	QueryRow(context.Context, string, ...any) pgx.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/ddl_drop_function/postgresql/stdlib/go/db.go
+++ b/internal/endtoend/testdata/ddl_drop_function/postgresql/stdlib/go/db.go
@@ -10,10 +10,10 @@ import (
 )
 
 type DBTX interface {
-	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
 	PrepareContext(context.Context, string) (*sql.Stmt, error)
-	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
-	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/ddl_drop_function_args/postgresql/pgx/v4/go/db.go
+++ b/internal/endtoend/testdata/ddl_drop_function_args/postgresql/pgx/v4/go/db.go
@@ -12,9 +12,9 @@ import (
 )
 
 type DBTX interface {
-	Exec(context.Context, string, ...interface{}) (pgconn.CommandTag, error)
-	Query(context.Context, string, ...interface{}) (pgx.Rows, error)
-	QueryRow(context.Context, string, ...interface{}) pgx.Row
+	Exec(context.Context, string, ...any) (pgconn.CommandTag, error)
+	Query(context.Context, string, ...any) (pgx.Rows, error)
+	QueryRow(context.Context, string, ...any) pgx.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/ddl_drop_function_args/postgresql/pgx/v5/go/db.go
+++ b/internal/endtoend/testdata/ddl_drop_function_args/postgresql/pgx/v5/go/db.go
@@ -12,9 +12,9 @@ import (
 )
 
 type DBTX interface {
-	Exec(context.Context, string, ...interface{}) (pgconn.CommandTag, error)
-	Query(context.Context, string, ...interface{}) (pgx.Rows, error)
-	QueryRow(context.Context, string, ...interface{}) pgx.Row
+	Exec(context.Context, string, ...any) (pgconn.CommandTag, error)
+	Query(context.Context, string, ...any) (pgx.Rows, error)
+	QueryRow(context.Context, string, ...any) pgx.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/ddl_drop_function_args/postgresql/stdlib/go/db.go
+++ b/internal/endtoend/testdata/ddl_drop_function_args/postgresql/stdlib/go/db.go
@@ -10,10 +10,10 @@ import (
 )
 
 type DBTX interface {
-	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
 	PrepareContext(context.Context, string) (*sql.Stmt, error)
-	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
-	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/ddl_drop_function_if_exists/postgresql/pgx/v4/go/db.go
+++ b/internal/endtoend/testdata/ddl_drop_function_if_exists/postgresql/pgx/v4/go/db.go
@@ -12,9 +12,9 @@ import (
 )
 
 type DBTX interface {
-	Exec(context.Context, string, ...interface{}) (pgconn.CommandTag, error)
-	Query(context.Context, string, ...interface{}) (pgx.Rows, error)
-	QueryRow(context.Context, string, ...interface{}) pgx.Row
+	Exec(context.Context, string, ...any) (pgconn.CommandTag, error)
+	Query(context.Context, string, ...any) (pgx.Rows, error)
+	QueryRow(context.Context, string, ...any) pgx.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/ddl_drop_function_if_exists/postgresql/pgx/v5/go/db.go
+++ b/internal/endtoend/testdata/ddl_drop_function_if_exists/postgresql/pgx/v5/go/db.go
@@ -12,9 +12,9 @@ import (
 )
 
 type DBTX interface {
-	Exec(context.Context, string, ...interface{}) (pgconn.CommandTag, error)
-	Query(context.Context, string, ...interface{}) (pgx.Rows, error)
-	QueryRow(context.Context, string, ...interface{}) pgx.Row
+	Exec(context.Context, string, ...any) (pgconn.CommandTag, error)
+	Query(context.Context, string, ...any) (pgx.Rows, error)
+	QueryRow(context.Context, string, ...any) pgx.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/ddl_drop_function_if_exists/postgresql/stdlib/go/db.go
+++ b/internal/endtoend/testdata/ddl_drop_function_if_exists/postgresql/stdlib/go/db.go
@@ -10,10 +10,10 @@ import (
 )
 
 type DBTX interface {
-	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
 	PrepareContext(context.Context, string) (*sql.Stmt, error)
-	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
-	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/ddl_drop_schema/mysql/go/db.go
+++ b/internal/endtoend/testdata/ddl_drop_schema/mysql/go/db.go
@@ -10,10 +10,10 @@ import (
 )
 
 type DBTX interface {
-	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
 	PrepareContext(context.Context, string) (*sql.Stmt, error)
-	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
-	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/ddl_drop_schema/postgresql/pgx/v4/go/db.go
+++ b/internal/endtoend/testdata/ddl_drop_schema/postgresql/pgx/v4/go/db.go
@@ -12,9 +12,9 @@ import (
 )
 
 type DBTX interface {
-	Exec(context.Context, string, ...interface{}) (pgconn.CommandTag, error)
-	Query(context.Context, string, ...interface{}) (pgx.Rows, error)
-	QueryRow(context.Context, string, ...interface{}) pgx.Row
+	Exec(context.Context, string, ...any) (pgconn.CommandTag, error)
+	Query(context.Context, string, ...any) (pgx.Rows, error)
+	QueryRow(context.Context, string, ...any) pgx.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/ddl_drop_schema/postgresql/pgx/v5/go/db.go
+++ b/internal/endtoend/testdata/ddl_drop_schema/postgresql/pgx/v5/go/db.go
@@ -12,9 +12,9 @@ import (
 )
 
 type DBTX interface {
-	Exec(context.Context, string, ...interface{}) (pgconn.CommandTag, error)
-	Query(context.Context, string, ...interface{}) (pgx.Rows, error)
-	QueryRow(context.Context, string, ...interface{}) pgx.Row
+	Exec(context.Context, string, ...any) (pgconn.CommandTag, error)
+	Query(context.Context, string, ...any) (pgx.Rows, error)
+	QueryRow(context.Context, string, ...any) pgx.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/ddl_drop_schema/postgresql/stdlib/go/db.go
+++ b/internal/endtoend/testdata/ddl_drop_schema/postgresql/stdlib/go/db.go
@@ -10,10 +10,10 @@ import (
 )
 
 type DBTX interface {
-	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
 	PrepareContext(context.Context, string) (*sql.Stmt, error)
-	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
-	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/ddl_drop_schema_if_exists/postgresql/pgx/v4/go/db.go
+++ b/internal/endtoend/testdata/ddl_drop_schema_if_exists/postgresql/pgx/v4/go/db.go
@@ -12,9 +12,9 @@ import (
 )
 
 type DBTX interface {
-	Exec(context.Context, string, ...interface{}) (pgconn.CommandTag, error)
-	Query(context.Context, string, ...interface{}) (pgx.Rows, error)
-	QueryRow(context.Context, string, ...interface{}) pgx.Row
+	Exec(context.Context, string, ...any) (pgconn.CommandTag, error)
+	Query(context.Context, string, ...any) (pgx.Rows, error)
+	QueryRow(context.Context, string, ...any) pgx.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/ddl_drop_schema_if_exists/postgresql/pgx/v5/go/db.go
+++ b/internal/endtoend/testdata/ddl_drop_schema_if_exists/postgresql/pgx/v5/go/db.go
@@ -12,9 +12,9 @@ import (
 )
 
 type DBTX interface {
-	Exec(context.Context, string, ...interface{}) (pgconn.CommandTag, error)
-	Query(context.Context, string, ...interface{}) (pgx.Rows, error)
-	QueryRow(context.Context, string, ...interface{}) pgx.Row
+	Exec(context.Context, string, ...any) (pgconn.CommandTag, error)
+	Query(context.Context, string, ...any) (pgx.Rows, error)
+	QueryRow(context.Context, string, ...any) pgx.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/ddl_drop_schema_if_exists/postgresql/stdlib/go/db.go
+++ b/internal/endtoend/testdata/ddl_drop_schema_if_exists/postgresql/stdlib/go/db.go
@@ -10,10 +10,10 @@ import (
 )
 
 type DBTX interface {
-	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
 	PrepareContext(context.Context, string) (*sql.Stmt, error)
-	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
-	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/ddl_drop_table/postgresql/pgx/v4/go/db.go
+++ b/internal/endtoend/testdata/ddl_drop_table/postgresql/pgx/v4/go/db.go
@@ -12,9 +12,9 @@ import (
 )
 
 type DBTX interface {
-	Exec(context.Context, string, ...interface{}) (pgconn.CommandTag, error)
-	Query(context.Context, string, ...interface{}) (pgx.Rows, error)
-	QueryRow(context.Context, string, ...interface{}) pgx.Row
+	Exec(context.Context, string, ...any) (pgconn.CommandTag, error)
+	Query(context.Context, string, ...any) (pgx.Rows, error)
+	QueryRow(context.Context, string, ...any) pgx.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/ddl_drop_table/postgresql/pgx/v5/go/db.go
+++ b/internal/endtoend/testdata/ddl_drop_table/postgresql/pgx/v5/go/db.go
@@ -12,9 +12,9 @@ import (
 )
 
 type DBTX interface {
-	Exec(context.Context, string, ...interface{}) (pgconn.CommandTag, error)
-	Query(context.Context, string, ...interface{}) (pgx.Rows, error)
-	QueryRow(context.Context, string, ...interface{}) pgx.Row
+	Exec(context.Context, string, ...any) (pgconn.CommandTag, error)
+	Query(context.Context, string, ...any) (pgx.Rows, error)
+	QueryRow(context.Context, string, ...any) pgx.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/ddl_drop_table/postgresql/stdlib/go/db.go
+++ b/internal/endtoend/testdata/ddl_drop_table/postgresql/stdlib/go/db.go
@@ -10,10 +10,10 @@ import (
 )
 
 type DBTX interface {
-	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
 	PrepareContext(context.Context, string) (*sql.Stmt, error)
-	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
-	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/ddl_drop_table/sqlite/go/db.go
+++ b/internal/endtoend/testdata/ddl_drop_table/sqlite/go/db.go
@@ -10,10 +10,10 @@ import (
 )
 
 type DBTX interface {
-	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
 	PrepareContext(context.Context, string) (*sql.Stmt, error)
-	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
-	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/ddl_drop_table_if_exists/postgresql/pgx/v4/go/db.go
+++ b/internal/endtoend/testdata/ddl_drop_table_if_exists/postgresql/pgx/v4/go/db.go
@@ -12,9 +12,9 @@ import (
 )
 
 type DBTX interface {
-	Exec(context.Context, string, ...interface{}) (pgconn.CommandTag, error)
-	Query(context.Context, string, ...interface{}) (pgx.Rows, error)
-	QueryRow(context.Context, string, ...interface{}) pgx.Row
+	Exec(context.Context, string, ...any) (pgconn.CommandTag, error)
+	Query(context.Context, string, ...any) (pgx.Rows, error)
+	QueryRow(context.Context, string, ...any) pgx.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/ddl_drop_table_if_exists/postgresql/pgx/v5/go/db.go
+++ b/internal/endtoend/testdata/ddl_drop_table_if_exists/postgresql/pgx/v5/go/db.go
@@ -12,9 +12,9 @@ import (
 )
 
 type DBTX interface {
-	Exec(context.Context, string, ...interface{}) (pgconn.CommandTag, error)
-	Query(context.Context, string, ...interface{}) (pgx.Rows, error)
-	QueryRow(context.Context, string, ...interface{}) pgx.Row
+	Exec(context.Context, string, ...any) (pgconn.CommandTag, error)
+	Query(context.Context, string, ...any) (pgx.Rows, error)
+	QueryRow(context.Context, string, ...any) pgx.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/ddl_drop_table_if_exists/postgresql/stdlib/go/db.go
+++ b/internal/endtoend/testdata/ddl_drop_table_if_exists/postgresql/stdlib/go/db.go
@@ -10,10 +10,10 @@ import (
 )
 
 type DBTX interface {
-	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
 	PrepareContext(context.Context, string) (*sql.Stmt, error)
-	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
-	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/ddl_drop_table_if_exists/sqlite/go/db.go
+++ b/internal/endtoend/testdata/ddl_drop_table_if_exists/sqlite/go/db.go
@@ -10,10 +10,10 @@ import (
 )
 
 type DBTX interface {
-	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
 	PrepareContext(context.Context, string) (*sql.Stmt, error)
-	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
-	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/ddl_drop_table_in_schema/postgresql/pgx/v4/go/db.go
+++ b/internal/endtoend/testdata/ddl_drop_table_in_schema/postgresql/pgx/v4/go/db.go
@@ -12,9 +12,9 @@ import (
 )
 
 type DBTX interface {
-	Exec(context.Context, string, ...interface{}) (pgconn.CommandTag, error)
-	Query(context.Context, string, ...interface{}) (pgx.Rows, error)
-	QueryRow(context.Context, string, ...interface{}) pgx.Row
+	Exec(context.Context, string, ...any) (pgconn.CommandTag, error)
+	Query(context.Context, string, ...any) (pgx.Rows, error)
+	QueryRow(context.Context, string, ...any) pgx.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/ddl_drop_table_in_schema/postgresql/pgx/v5/go/db.go
+++ b/internal/endtoend/testdata/ddl_drop_table_in_schema/postgresql/pgx/v5/go/db.go
@@ -12,9 +12,9 @@ import (
 )
 
 type DBTX interface {
-	Exec(context.Context, string, ...interface{}) (pgconn.CommandTag, error)
-	Query(context.Context, string, ...interface{}) (pgx.Rows, error)
-	QueryRow(context.Context, string, ...interface{}) pgx.Row
+	Exec(context.Context, string, ...any) (pgconn.CommandTag, error)
+	Query(context.Context, string, ...any) (pgx.Rows, error)
+	QueryRow(context.Context, string, ...any) pgx.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/ddl_drop_table_in_schema/postgresql/stdlib/go/db.go
+++ b/internal/endtoend/testdata/ddl_drop_table_in_schema/postgresql/stdlib/go/db.go
@@ -10,10 +10,10 @@ import (
 )
 
 type DBTX interface {
-	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
 	PrepareContext(context.Context, string) (*sql.Stmt, error)
-	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
-	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/ddl_drop_type/postgresql/pgx/v4/go/db.go
+++ b/internal/endtoend/testdata/ddl_drop_type/postgresql/pgx/v4/go/db.go
@@ -12,9 +12,9 @@ import (
 )
 
 type DBTX interface {
-	Exec(context.Context, string, ...interface{}) (pgconn.CommandTag, error)
-	Query(context.Context, string, ...interface{}) (pgx.Rows, error)
-	QueryRow(context.Context, string, ...interface{}) pgx.Row
+	Exec(context.Context, string, ...any) (pgconn.CommandTag, error)
+	Query(context.Context, string, ...any) (pgx.Rows, error)
+	QueryRow(context.Context, string, ...any) pgx.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/ddl_drop_type/postgresql/pgx/v5/go/db.go
+++ b/internal/endtoend/testdata/ddl_drop_type/postgresql/pgx/v5/go/db.go
@@ -12,9 +12,9 @@ import (
 )
 
 type DBTX interface {
-	Exec(context.Context, string, ...interface{}) (pgconn.CommandTag, error)
-	Query(context.Context, string, ...interface{}) (pgx.Rows, error)
-	QueryRow(context.Context, string, ...interface{}) pgx.Row
+	Exec(context.Context, string, ...any) (pgconn.CommandTag, error)
+	Query(context.Context, string, ...any) (pgx.Rows, error)
+	QueryRow(context.Context, string, ...any) pgx.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/ddl_drop_type/postgresql/stdlib/go/db.go
+++ b/internal/endtoend/testdata/ddl_drop_type/postgresql/stdlib/go/db.go
@@ -10,10 +10,10 @@ import (
 )
 
 type DBTX interface {
-	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
 	PrepareContext(context.Context, string) (*sql.Stmt, error)
-	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
-	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/ddl_drop_type_if_exists/postgresql/pgx/v4/go/db.go
+++ b/internal/endtoend/testdata/ddl_drop_type_if_exists/postgresql/pgx/v4/go/db.go
@@ -12,9 +12,9 @@ import (
 )
 
 type DBTX interface {
-	Exec(context.Context, string, ...interface{}) (pgconn.CommandTag, error)
-	Query(context.Context, string, ...interface{}) (pgx.Rows, error)
-	QueryRow(context.Context, string, ...interface{}) pgx.Row
+	Exec(context.Context, string, ...any) (pgconn.CommandTag, error)
+	Query(context.Context, string, ...any) (pgx.Rows, error)
+	QueryRow(context.Context, string, ...any) pgx.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/ddl_drop_type_if_exists/postgresql/pgx/v5/go/db.go
+++ b/internal/endtoend/testdata/ddl_drop_type_if_exists/postgresql/pgx/v5/go/db.go
@@ -12,9 +12,9 @@ import (
 )
 
 type DBTX interface {
-	Exec(context.Context, string, ...interface{}) (pgconn.CommandTag, error)
-	Query(context.Context, string, ...interface{}) (pgx.Rows, error)
-	QueryRow(context.Context, string, ...interface{}) pgx.Row
+	Exec(context.Context, string, ...any) (pgconn.CommandTag, error)
+	Query(context.Context, string, ...any) (pgx.Rows, error)
+	QueryRow(context.Context, string, ...any) pgx.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/ddl_drop_type_if_exists/postgresql/stdlib/go/db.go
+++ b/internal/endtoend/testdata/ddl_drop_type_if_exists/postgresql/stdlib/go/db.go
@@ -10,10 +10,10 @@ import (
 )
 
 type DBTX interface {
-	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
 	PrepareContext(context.Context, string) (*sql.Stmt, error)
-	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
-	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/ddl_drop_type_in_schema/postgresql/pgx/v4/go/db.go
+++ b/internal/endtoend/testdata/ddl_drop_type_in_schema/postgresql/pgx/v4/go/db.go
@@ -12,9 +12,9 @@ import (
 )
 
 type DBTX interface {
-	Exec(context.Context, string, ...interface{}) (pgconn.CommandTag, error)
-	Query(context.Context, string, ...interface{}) (pgx.Rows, error)
-	QueryRow(context.Context, string, ...interface{}) pgx.Row
+	Exec(context.Context, string, ...any) (pgconn.CommandTag, error)
+	Query(context.Context, string, ...any) (pgx.Rows, error)
+	QueryRow(context.Context, string, ...any) pgx.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/ddl_drop_type_in_schema/postgresql/pgx/v5/go/db.go
+++ b/internal/endtoend/testdata/ddl_drop_type_in_schema/postgresql/pgx/v5/go/db.go
@@ -12,9 +12,9 @@ import (
 )
 
 type DBTX interface {
-	Exec(context.Context, string, ...interface{}) (pgconn.CommandTag, error)
-	Query(context.Context, string, ...interface{}) (pgx.Rows, error)
-	QueryRow(context.Context, string, ...interface{}) pgx.Row
+	Exec(context.Context, string, ...any) (pgconn.CommandTag, error)
+	Query(context.Context, string, ...any) (pgx.Rows, error)
+	QueryRow(context.Context, string, ...any) pgx.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/ddl_drop_type_in_schema/postgresql/stdlib/go/db.go
+++ b/internal/endtoend/testdata/ddl_drop_type_in_schema/postgresql/stdlib/go/db.go
@@ -10,10 +10,10 @@ import (
 )
 
 type DBTX interface {
-	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
 	PrepareContext(context.Context, string) (*sql.Stmt, error)
-	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
-	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/ddl_generated_columns/postgresql/pgx/v4/go/db.go
+++ b/internal/endtoend/testdata/ddl_generated_columns/postgresql/pgx/v4/go/db.go
@@ -12,9 +12,9 @@ import (
 )
 
 type DBTX interface {
-	Exec(context.Context, string, ...interface{}) (pgconn.CommandTag, error)
-	Query(context.Context, string, ...interface{}) (pgx.Rows, error)
-	QueryRow(context.Context, string, ...interface{}) pgx.Row
+	Exec(context.Context, string, ...any) (pgconn.CommandTag, error)
+	Query(context.Context, string, ...any) (pgx.Rows, error)
+	QueryRow(context.Context, string, ...any) pgx.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/ddl_generated_columns/postgresql/pgx/v5/go/db.go
+++ b/internal/endtoend/testdata/ddl_generated_columns/postgresql/pgx/v5/go/db.go
@@ -12,9 +12,9 @@ import (
 )
 
 type DBTX interface {
-	Exec(context.Context, string, ...interface{}) (pgconn.CommandTag, error)
-	Query(context.Context, string, ...interface{}) (pgx.Rows, error)
-	QueryRow(context.Context, string, ...interface{}) pgx.Row
+	Exec(context.Context, string, ...any) (pgconn.CommandTag, error)
+	Query(context.Context, string, ...any) (pgx.Rows, error)
+	QueryRow(context.Context, string, ...any) pgx.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/ddl_generated_columns/postgresql/stdlib/go/db.go
+++ b/internal/endtoend/testdata/ddl_generated_columns/postgresql/stdlib/go/db.go
@@ -10,10 +10,10 @@ import (
 )
 
 type DBTX interface {
-	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
 	PrepareContext(context.Context, string) (*sql.Stmt, error)
-	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
-	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/ddl_pg_temp/postgresql/pgx/v4/go/db.go
+++ b/internal/endtoend/testdata/ddl_pg_temp/postgresql/pgx/v4/go/db.go
@@ -12,9 +12,9 @@ import (
 )
 
 type DBTX interface {
-	Exec(context.Context, string, ...interface{}) (pgconn.CommandTag, error)
-	Query(context.Context, string, ...interface{}) (pgx.Rows, error)
-	QueryRow(context.Context, string, ...interface{}) pgx.Row
+	Exec(context.Context, string, ...any) (pgconn.CommandTag, error)
+	Query(context.Context, string, ...any) (pgx.Rows, error)
+	QueryRow(context.Context, string, ...any) pgx.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/ddl_pg_temp/postgresql/pgx/v5/go/db.go
+++ b/internal/endtoend/testdata/ddl_pg_temp/postgresql/pgx/v5/go/db.go
@@ -12,9 +12,9 @@ import (
 )
 
 type DBTX interface {
-	Exec(context.Context, string, ...interface{}) (pgconn.CommandTag, error)
-	Query(context.Context, string, ...interface{}) (pgx.Rows, error)
-	QueryRow(context.Context, string, ...interface{}) pgx.Row
+	Exec(context.Context, string, ...any) (pgconn.CommandTag, error)
+	Query(context.Context, string, ...any) (pgx.Rows, error)
+	QueryRow(context.Context, string, ...any) pgx.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/ddl_pg_temp/postgresql/stdlib/go/db.go
+++ b/internal/endtoend/testdata/ddl_pg_temp/postgresql/stdlib/go/db.go
@@ -10,10 +10,10 @@ import (
 )
 
 type DBTX interface {
-	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
 	PrepareContext(context.Context, string) (*sql.Stmt, error)
-	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
-	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/ddl_rename_drop_materialized_views/postgresql/pgx/v4/go/db.go
+++ b/internal/endtoend/testdata/ddl_rename_drop_materialized_views/postgresql/pgx/v4/go/db.go
@@ -12,9 +12,9 @@ import (
 )
 
 type DBTX interface {
-	Exec(context.Context, string, ...interface{}) (pgconn.CommandTag, error)
-	Query(context.Context, string, ...interface{}) (pgx.Rows, error)
-	QueryRow(context.Context, string, ...interface{}) pgx.Row
+	Exec(context.Context, string, ...any) (pgconn.CommandTag, error)
+	Query(context.Context, string, ...any) (pgx.Rows, error)
+	QueryRow(context.Context, string, ...any) pgx.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/ddl_rename_drop_materialized_views/postgresql/pgx/v5/go/db.go
+++ b/internal/endtoend/testdata/ddl_rename_drop_materialized_views/postgresql/pgx/v5/go/db.go
@@ -12,9 +12,9 @@ import (
 )
 
 type DBTX interface {
-	Exec(context.Context, string, ...interface{}) (pgconn.CommandTag, error)
-	Query(context.Context, string, ...interface{}) (pgx.Rows, error)
-	QueryRow(context.Context, string, ...interface{}) pgx.Row
+	Exec(context.Context, string, ...any) (pgconn.CommandTag, error)
+	Query(context.Context, string, ...any) (pgx.Rows, error)
+	QueryRow(context.Context, string, ...any) pgx.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/delete_from/mysql/go/db.go
+++ b/internal/endtoend/testdata/delete_from/mysql/go/db.go
@@ -10,10 +10,10 @@ import (
 )
 
 type DBTX interface {
-	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
 	PrepareContext(context.Context, string) (*sql.Stmt, error)
-	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
-	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/delete_from/postgresql/pgx/v4/go/db.go
+++ b/internal/endtoend/testdata/delete_from/postgresql/pgx/v4/go/db.go
@@ -12,9 +12,9 @@ import (
 )
 
 type DBTX interface {
-	Exec(context.Context, string, ...interface{}) (pgconn.CommandTag, error)
-	Query(context.Context, string, ...interface{}) (pgx.Rows, error)
-	QueryRow(context.Context, string, ...interface{}) pgx.Row
+	Exec(context.Context, string, ...any) (pgconn.CommandTag, error)
+	Query(context.Context, string, ...any) (pgx.Rows, error)
+	QueryRow(context.Context, string, ...any) pgx.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/delete_from/postgresql/pgx/v5/go/db.go
+++ b/internal/endtoend/testdata/delete_from/postgresql/pgx/v5/go/db.go
@@ -12,9 +12,9 @@ import (
 )
 
 type DBTX interface {
-	Exec(context.Context, string, ...interface{}) (pgconn.CommandTag, error)
-	Query(context.Context, string, ...interface{}) (pgx.Rows, error)
-	QueryRow(context.Context, string, ...interface{}) pgx.Row
+	Exec(context.Context, string, ...any) (pgconn.CommandTag, error)
+	Query(context.Context, string, ...any) (pgx.Rows, error)
+	QueryRow(context.Context, string, ...any) pgx.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/delete_from/postgresql/stdlib/go/db.go
+++ b/internal/endtoend/testdata/delete_from/postgresql/stdlib/go/db.go
@@ -10,10 +10,10 @@ import (
 )
 
 type DBTX interface {
-	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
 	PrepareContext(context.Context, string) (*sql.Stmt, error)
-	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
-	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/delete_from/sqlite/go/db.go
+++ b/internal/endtoend/testdata/delete_from/sqlite/go/db.go
@@ -10,10 +10,10 @@ import (
 )
 
 type DBTX interface {
-	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
 	PrepareContext(context.Context, string) (*sql.Stmt, error)
-	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
-	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/delete_inner_join/mysql/go/db.go
+++ b/internal/endtoend/testdata/delete_inner_join/mysql/go/db.go
@@ -10,10 +10,10 @@ import (
 )
 
 type DBTX interface {
-	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
 	PrepareContext(context.Context, string) (*sql.Stmt, error)
-	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
-	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/delete_join/mysql/db/db.go
+++ b/internal/endtoend/testdata/delete_join/mysql/db/db.go
@@ -10,10 +10,10 @@ import (
 )
 
 type DBTX interface {
-	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
 	PrepareContext(context.Context, string) (*sql.Stmt, error)
-	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
-	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/delete_using/postgresql/pgx/go/db.go
+++ b/internal/endtoend/testdata/delete_using/postgresql/pgx/go/db.go
@@ -12,9 +12,9 @@ import (
 )
 
 type DBTX interface {
-	Exec(context.Context, string, ...interface{}) (pgconn.CommandTag, error)
-	Query(context.Context, string, ...interface{}) (pgx.Rows, error)
-	QueryRow(context.Context, string, ...interface{}) pgx.Row
+	Exec(context.Context, string, ...any) (pgconn.CommandTag, error)
+	Query(context.Context, string, ...any) (pgx.Rows, error)
+	QueryRow(context.Context, string, ...any) pgx.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/diff_no_output/go/db.go
+++ b/internal/endtoend/testdata/diff_no_output/go/db.go
@@ -10,10 +10,10 @@ import (
 )
 
 type DBTX interface {
-	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
 	PrepareContext(context.Context, string) (*sql.Stmt, error)
-	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
-	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/diff_output/go/db.go
+++ b/internal/endtoend/testdata/diff_output/go/db.go
@@ -10,10 +10,10 @@ import (
 )
 
 type DBTX interface {
-	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
 	PrepareContext(context.Context, string) (*sql.Stmt, error)
-	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
-	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/do/postgresql/pgx/db/db.go
+++ b/internal/endtoend/testdata/do/postgresql/pgx/db/db.go
@@ -12,9 +12,9 @@ import (
 )
 
 type DBTX interface {
-	Exec(context.Context, string, ...interface{}) (pgconn.CommandTag, error)
-	Query(context.Context, string, ...interface{}) (pgx.Rows, error)
-	QueryRow(context.Context, string, ...interface{}) pgx.Row
+	Exec(context.Context, string, ...any) (pgconn.CommandTag, error)
+	Query(context.Context, string, ...any) (pgx.Rows, error)
+	QueryRow(context.Context, string, ...any) pgx.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/do/postgresql/pq/db/db.go
+++ b/internal/endtoend/testdata/do/postgresql/pq/db/db.go
@@ -10,10 +10,10 @@ import (
 )
 
 type DBTX interface {
-	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
 	PrepareContext(context.Context, string) (*sql.Stmt, error)
-	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
-	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/emit_db_and_json_tags/mysql/go/db.go
+++ b/internal/endtoend/testdata/emit_db_and_json_tags/mysql/go/db.go
@@ -10,10 +10,10 @@ import (
 )
 
 type DBTX interface {
-	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
 	PrepareContext(context.Context, string) (*sql.Stmt, error)
-	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
-	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/emit_db_and_json_tags/postgresql/pgx/v4/go/db.go
+++ b/internal/endtoend/testdata/emit_db_and_json_tags/postgresql/pgx/v4/go/db.go
@@ -12,9 +12,9 @@ import (
 )
 
 type DBTX interface {
-	Exec(context.Context, string, ...interface{}) (pgconn.CommandTag, error)
-	Query(context.Context, string, ...interface{}) (pgx.Rows, error)
-	QueryRow(context.Context, string, ...interface{}) pgx.Row
+	Exec(context.Context, string, ...any) (pgconn.CommandTag, error)
+	Query(context.Context, string, ...any) (pgx.Rows, error)
+	QueryRow(context.Context, string, ...any) pgx.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/emit_db_and_json_tags/postgresql/pgx/v5/go/db.go
+++ b/internal/endtoend/testdata/emit_db_and_json_tags/postgresql/pgx/v5/go/db.go
@@ -12,9 +12,9 @@ import (
 )
 
 type DBTX interface {
-	Exec(context.Context, string, ...interface{}) (pgconn.CommandTag, error)
-	Query(context.Context, string, ...interface{}) (pgx.Rows, error)
-	QueryRow(context.Context, string, ...interface{}) pgx.Row
+	Exec(context.Context, string, ...any) (pgconn.CommandTag, error)
+	Query(context.Context, string, ...any) (pgx.Rows, error)
+	QueryRow(context.Context, string, ...any) pgx.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/emit_db_and_json_tags/postgresql/stdlib/go/db.go
+++ b/internal/endtoend/testdata/emit_db_and_json_tags/postgresql/stdlib/go/db.go
@@ -10,10 +10,10 @@ import (
 )
 
 type DBTX interface {
-	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
 	PrepareContext(context.Context, string) (*sql.Stmt, error)
-	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
-	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/emit_db_and_json_tags/sqlite/go/db.go
+++ b/internal/endtoend/testdata/emit_db_and_json_tags/sqlite/go/db.go
@@ -10,10 +10,10 @@ import (
 )
 
 type DBTX interface {
-	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
 	PrepareContext(context.Context, string) (*sql.Stmt, error)
-	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
-	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/emit_db_tags/mysql/go/db.go
+++ b/internal/endtoend/testdata/emit_db_tags/mysql/go/db.go
@@ -10,10 +10,10 @@ import (
 )
 
 type DBTX interface {
-	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
 	PrepareContext(context.Context, string) (*sql.Stmt, error)
-	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
-	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/emit_db_tags/postgresql/pgx/v4/go/db.go
+++ b/internal/endtoend/testdata/emit_db_tags/postgresql/pgx/v4/go/db.go
@@ -12,9 +12,9 @@ import (
 )
 
 type DBTX interface {
-	Exec(context.Context, string, ...interface{}) (pgconn.CommandTag, error)
-	Query(context.Context, string, ...interface{}) (pgx.Rows, error)
-	QueryRow(context.Context, string, ...interface{}) pgx.Row
+	Exec(context.Context, string, ...any) (pgconn.CommandTag, error)
+	Query(context.Context, string, ...any) (pgx.Rows, error)
+	QueryRow(context.Context, string, ...any) pgx.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/emit_db_tags/postgresql/pgx/v5/go/db.go
+++ b/internal/endtoend/testdata/emit_db_tags/postgresql/pgx/v5/go/db.go
@@ -12,9 +12,9 @@ import (
 )
 
 type DBTX interface {
-	Exec(context.Context, string, ...interface{}) (pgconn.CommandTag, error)
-	Query(context.Context, string, ...interface{}) (pgx.Rows, error)
-	QueryRow(context.Context, string, ...interface{}) pgx.Row
+	Exec(context.Context, string, ...any) (pgconn.CommandTag, error)
+	Query(context.Context, string, ...any) (pgx.Rows, error)
+	QueryRow(context.Context, string, ...any) pgx.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/emit_db_tags/postgresql/stdlib/go/db.go
+++ b/internal/endtoend/testdata/emit_db_tags/postgresql/stdlib/go/db.go
@@ -10,10 +10,10 @@ import (
 )
 
 type DBTX interface {
-	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
 	PrepareContext(context.Context, string) (*sql.Stmt, error)
-	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
-	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/emit_db_tags/sqlite/go/db.go
+++ b/internal/endtoend/testdata/emit_db_tags/sqlite/go/db.go
@@ -10,10 +10,10 @@ import (
 )
 
 type DBTX interface {
-	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
 	PrepareContext(context.Context, string) (*sql.Stmt, error)
-	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
-	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/emit_empty_slices/pgx/v4/go/db.go
+++ b/internal/endtoend/testdata/emit_empty_slices/pgx/v4/go/db.go
@@ -12,9 +12,9 @@ import (
 )
 
 type DBTX interface {
-	Exec(context.Context, string, ...interface{}) (pgconn.CommandTag, error)
-	Query(context.Context, string, ...interface{}) (pgx.Rows, error)
-	QueryRow(context.Context, string, ...interface{}) pgx.Row
+	Exec(context.Context, string, ...any) (pgconn.CommandTag, error)
+	Query(context.Context, string, ...any) (pgx.Rows, error)
+	QueryRow(context.Context, string, ...any) pgx.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/emit_empty_slices/pgx/v5/go/db.go
+++ b/internal/endtoend/testdata/emit_empty_slices/pgx/v5/go/db.go
@@ -12,9 +12,9 @@ import (
 )
 
 type DBTX interface {
-	Exec(context.Context, string, ...interface{}) (pgconn.CommandTag, error)
-	Query(context.Context, string, ...interface{}) (pgx.Rows, error)
-	QueryRow(context.Context, string, ...interface{}) pgx.Row
+	Exec(context.Context, string, ...any) (pgconn.CommandTag, error)
+	Query(context.Context, string, ...any) (pgx.Rows, error)
+	QueryRow(context.Context, string, ...any) pgx.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/emit_empty_slices/stdlib/go/db.go
+++ b/internal/endtoend/testdata/emit_empty_slices/stdlib/go/db.go
@@ -10,10 +10,10 @@ import (
 )
 
 type DBTX interface {
-	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
 	PrepareContext(context.Context, string) (*sql.Stmt, error)
-	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
-	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/emit_enum_valid_and_values/go/db.go
+++ b/internal/endtoend/testdata/emit_enum_valid_and_values/go/db.go
@@ -12,9 +12,9 @@ import (
 )
 
 type DBTX interface {
-	Exec(context.Context, string, ...interface{}) (pgconn.CommandTag, error)
-	Query(context.Context, string, ...interface{}) (pgx.Rows, error)
-	QueryRow(context.Context, string, ...interface{}) pgx.Row
+	Exec(context.Context, string, ...any) (pgconn.CommandTag, error)
+	Query(context.Context, string, ...any) (pgx.Rows, error)
+	QueryRow(context.Context, string, ...any) pgx.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/emit_enum_valid_and_values/go/models.go
+++ b/internal/endtoend/testdata/emit_enum_valid_and_values/go/models.go
@@ -17,7 +17,7 @@ const (
 	IpProtocolIcmp IPProtocol = "icmp"
 )
 
-func (e *IPProtocol) Scan(src interface{}) error {
+func (e *IPProtocol) Scan(src any) error {
 	switch s := src.(type) {
 	case []byte:
 		*e = IPProtocol(s)
@@ -35,7 +35,7 @@ type NullIPProtocol struct {
 }
 
 // Scan implements the Scanner interface.
-func (ns *NullIPProtocol) Scan(value interface{}) error {
+func (ns *NullIPProtocol) Scan(value any) error {
 	if value == nil {
 		ns.IPProtocol, ns.Valid = "", false
 		return nil

--- a/internal/endtoend/testdata/emit_exported_queries/pgx/v4/go/db.go
+++ b/internal/endtoend/testdata/emit_exported_queries/pgx/v4/go/db.go
@@ -12,9 +12,9 @@ import (
 )
 
 type DBTX interface {
-	Exec(context.Context, string, ...interface{}) (pgconn.CommandTag, error)
-	Query(context.Context, string, ...interface{}) (pgx.Rows, error)
-	QueryRow(context.Context, string, ...interface{}) pgx.Row
+	Exec(context.Context, string, ...any) (pgconn.CommandTag, error)
+	Query(context.Context, string, ...any) (pgx.Rows, error)
+	QueryRow(context.Context, string, ...any) pgx.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/emit_exported_queries/pgx/v5/go/db.go
+++ b/internal/endtoend/testdata/emit_exported_queries/pgx/v5/go/db.go
@@ -12,9 +12,9 @@ import (
 )
 
 type DBTX interface {
-	Exec(context.Context, string, ...interface{}) (pgconn.CommandTag, error)
-	Query(context.Context, string, ...interface{}) (pgx.Rows, error)
-	QueryRow(context.Context, string, ...interface{}) pgx.Row
+	Exec(context.Context, string, ...any) (pgconn.CommandTag, error)
+	Query(context.Context, string, ...any) (pgx.Rows, error)
+	QueryRow(context.Context, string, ...any) pgx.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/emit_exported_queries/stdlib/go/db.go
+++ b/internal/endtoend/testdata/emit_exported_queries/stdlib/go/db.go
@@ -10,10 +10,10 @@ import (
 )
 
 type DBTX interface {
-	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
 	PrepareContext(context.Context, string) (*sql.Stmt, error)
-	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
-	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/emit_methods_with_db_argument/mysql/go/db.go
+++ b/internal/endtoend/testdata/emit_methods_with_db_argument/mysql/go/db.go
@@ -10,10 +10,10 @@ import (
 )
 
 type DBTX interface {
-	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
 	PrepareContext(context.Context, string) (*sql.Stmt, error)
-	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
-	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
 }
 
 func New() *Queries {

--- a/internal/endtoend/testdata/emit_methods_with_db_argument/postgresql/pgx/v4/go/db.go
+++ b/internal/endtoend/testdata/emit_methods_with_db_argument/postgresql/pgx/v4/go/db.go
@@ -12,9 +12,9 @@ import (
 )
 
 type DBTX interface {
-	Exec(context.Context, string, ...interface{}) (pgconn.CommandTag, error)
-	Query(context.Context, string, ...interface{}) (pgx.Rows, error)
-	QueryRow(context.Context, string, ...interface{}) pgx.Row
+	Exec(context.Context, string, ...any) (pgconn.CommandTag, error)
+	Query(context.Context, string, ...any) (pgx.Rows, error)
+	QueryRow(context.Context, string, ...any) pgx.Row
 }
 
 func New() *Queries {

--- a/internal/endtoend/testdata/emit_methods_with_db_argument/postgresql/pgx/v5/go/db.go
+++ b/internal/endtoend/testdata/emit_methods_with_db_argument/postgresql/pgx/v5/go/db.go
@@ -12,9 +12,9 @@ import (
 )
 
 type DBTX interface {
-	Exec(context.Context, string, ...interface{}) (pgconn.CommandTag, error)
-	Query(context.Context, string, ...interface{}) (pgx.Rows, error)
-	QueryRow(context.Context, string, ...interface{}) pgx.Row
+	Exec(context.Context, string, ...any) (pgconn.CommandTag, error)
+	Query(context.Context, string, ...any) (pgx.Rows, error)
+	QueryRow(context.Context, string, ...any) pgx.Row
 }
 
 func New() *Queries {

--- a/internal/endtoend/testdata/emit_methods_with_db_argument/postgresql/stdlib/go/db.go
+++ b/internal/endtoend/testdata/emit_methods_with_db_argument/postgresql/stdlib/go/db.go
@@ -10,10 +10,10 @@ import (
 )
 
 type DBTX interface {
-	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
 	PrepareContext(context.Context, string) (*sql.Stmt, error)
-	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
-	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
 }
 
 func New() *Queries {

--- a/internal/endtoend/testdata/emit_methods_with_db_argument/sqlite/go/db.go
+++ b/internal/endtoend/testdata/emit_methods_with_db_argument/sqlite/go/db.go
@@ -10,10 +10,10 @@ import (
 )
 
 type DBTX interface {
-	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
 	PrepareContext(context.Context, string) (*sql.Stmt, error)
-	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
-	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
 }
 
 func New() *Queries {

--- a/internal/endtoend/testdata/emit_pointers_for_null_enum_types/optin/pgx/v5/go/db.go
+++ b/internal/endtoend/testdata/emit_pointers_for_null_enum_types/optin/pgx/v5/go/db.go
@@ -12,9 +12,9 @@ import (
 )
 
 type DBTX interface {
-	Exec(context.Context, string, ...interface{}) (pgconn.CommandTag, error)
-	Query(context.Context, string, ...interface{}) (pgx.Rows, error)
-	QueryRow(context.Context, string, ...interface{}) pgx.Row
+	Exec(context.Context, string, ...any) (pgconn.CommandTag, error)
+	Query(context.Context, string, ...any) (pgx.Rows, error)
+	QueryRow(context.Context, string, ...any) pgx.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/emit_pointers_for_null_enum_types/optin/pgx/v5/go/models.go
+++ b/internal/endtoend/testdata/emit_pointers_for_null_enum_types/optin/pgx/v5/go/models.go
@@ -18,7 +18,7 @@ const (
 	UserRoleUser  UserRole = "user"
 )
 
-func (e *UserRole) Scan(src interface{}) error {
+func (e *UserRole) Scan(src any) error {
 	switch s := src.(type) {
 	case []byte:
 		*e = UserRole(s)
@@ -36,7 +36,7 @@ type NullUserRole struct {
 }
 
 // Scan implements the Scanner interface.
-func (ns *NullUserRole) Scan(value interface{}) error {
+func (ns *NullUserRole) Scan(value any) error {
 	if value == nil {
 		ns.UserRole, ns.Valid = "", false
 		return nil

--- a/internal/endtoend/testdata/emit_pointers_for_null_enum_types/optout/pgx/v5/go/db.go
+++ b/internal/endtoend/testdata/emit_pointers_for_null_enum_types/optout/pgx/v5/go/db.go
@@ -12,9 +12,9 @@ import (
 )
 
 type DBTX interface {
-	Exec(context.Context, string, ...interface{}) (pgconn.CommandTag, error)
-	Query(context.Context, string, ...interface{}) (pgx.Rows, error)
-	QueryRow(context.Context, string, ...interface{}) pgx.Row
+	Exec(context.Context, string, ...any) (pgconn.CommandTag, error)
+	Query(context.Context, string, ...any) (pgx.Rows, error)
+	QueryRow(context.Context, string, ...any) pgx.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/emit_pointers_for_null_enum_types/optout/pgx/v5/go/models.go
+++ b/internal/endtoend/testdata/emit_pointers_for_null_enum_types/optout/pgx/v5/go/models.go
@@ -16,7 +16,7 @@ const (
 	UserRoleUser  UserRole = "user"
 )
 
-func (e *UserRole) Scan(src interface{}) error {
+func (e *UserRole) Scan(src any) error {
 	switch s := src.(type) {
 	case []byte:
 		*e = UserRole(s)
@@ -34,7 +34,7 @@ type NullUserRole struct {
 }
 
 // Scan implements the Scanner interface.
-func (ns *NullUserRole) Scan(value interface{}) error {
+func (ns *NullUserRole) Scan(value any) error {
 	if value == nil {
 		ns.UserRole, ns.Valid = "", false
 		return nil

--- a/internal/endtoend/testdata/emit_pointers_for_null_enum_types/pgx/v4/go/db.go
+++ b/internal/endtoend/testdata/emit_pointers_for_null_enum_types/pgx/v4/go/db.go
@@ -12,9 +12,9 @@ import (
 )
 
 type DBTX interface {
-	Exec(context.Context, string, ...interface{}) (pgconn.CommandTag, error)
-	Query(context.Context, string, ...interface{}) (pgx.Rows, error)
-	QueryRow(context.Context, string, ...interface{}) pgx.Row
+	Exec(context.Context, string, ...any) (pgconn.CommandTag, error)
+	Query(context.Context, string, ...any) (pgx.Rows, error)
+	QueryRow(context.Context, string, ...any) pgx.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/emit_pointers_for_null_enum_types/pgx/v4/go/models.go
+++ b/internal/endtoend/testdata/emit_pointers_for_null_enum_types/pgx/v4/go/models.go
@@ -16,7 +16,7 @@ const (
 	UserRoleUser  UserRole = "user"
 )
 
-func (e *UserRole) Scan(src interface{}) error {
+func (e *UserRole) Scan(src any) error {
 	switch s := src.(type) {
 	case []byte:
 		*e = UserRole(s)
@@ -34,7 +34,7 @@ type NullUserRole struct {
 }
 
 // Scan implements the Scanner interface.
-func (ns *NullUserRole) Scan(value interface{}) error {
+func (ns *NullUserRole) Scan(value any) error {
 	if value == nil {
 		ns.UserRole, ns.Valid = "", false
 		return nil

--- a/internal/endtoend/testdata/emit_pointers_for_null_enum_types/pgx/v5/go/db.go
+++ b/internal/endtoend/testdata/emit_pointers_for_null_enum_types/pgx/v5/go/db.go
@@ -12,9 +12,9 @@ import (
 )
 
 type DBTX interface {
-	Exec(context.Context, string, ...interface{}) (pgconn.CommandTag, error)
-	Query(context.Context, string, ...interface{}) (pgx.Rows, error)
-	QueryRow(context.Context, string, ...interface{}) pgx.Row
+	Exec(context.Context, string, ...any) (pgconn.CommandTag, error)
+	Query(context.Context, string, ...any) (pgx.Rows, error)
+	QueryRow(context.Context, string, ...any) pgx.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/emit_pointers_for_null_enum_types/pgx/v5/go/models.go
+++ b/internal/endtoend/testdata/emit_pointers_for_null_enum_types/pgx/v5/go/models.go
@@ -16,7 +16,7 @@ const (
 	FooStatusInactive FooStatus = "inactive"
 )
 
-func (e *FooStatus) Scan(src interface{}) error {
+func (e *FooStatus) Scan(src any) error {
 	switch s := src.(type) {
 	case []byte:
 		*e = FooStatus(s)
@@ -34,7 +34,7 @@ type NullFooStatus struct {
 }
 
 // Scan implements the Scanner interface.
-func (ns *NullFooStatus) Scan(value interface{}) error {
+func (ns *NullFooStatus) Scan(value any) error {
 	if value == nil {
 		ns.FooStatus, ns.Valid = "", false
 		return nil
@@ -58,7 +58,7 @@ const (
 	UserRoleUser  UserRole = "user"
 )
 
-func (e *UserRole) Scan(src interface{}) error {
+func (e *UserRole) Scan(src any) error {
 	switch s := src.(type) {
 	case []byte:
 		*e = UserRole(s)
@@ -76,7 +76,7 @@ type NullUserRole struct {
 }
 
 // Scan implements the Scanner interface.
-func (ns *NullUserRole) Scan(value interface{}) error {
+func (ns *NullUserRole) Scan(value any) error {
 	if value == nil {
 		ns.UserRole, ns.Valid = "", false
 		return nil

--- a/internal/endtoend/testdata/emit_pointers_for_null_types/pgx/v4/go/db.go
+++ b/internal/endtoend/testdata/emit_pointers_for_null_types/pgx/v4/go/db.go
@@ -12,9 +12,9 @@ import (
 )
 
 type DBTX interface {
-	Exec(context.Context, string, ...interface{}) (pgconn.CommandTag, error)
-	Query(context.Context, string, ...interface{}) (pgx.Rows, error)
-	QueryRow(context.Context, string, ...interface{}) pgx.Row
+	Exec(context.Context, string, ...any) (pgconn.CommandTag, error)
+	Query(context.Context, string, ...any) (pgx.Rows, error)
+	QueryRow(context.Context, string, ...any) pgx.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/emit_pointers_for_null_types/pgx/v5/go/db.go
+++ b/internal/endtoend/testdata/emit_pointers_for_null_types/pgx/v5/go/db.go
@@ -12,9 +12,9 @@ import (
 )
 
 type DBTX interface {
-	Exec(context.Context, string, ...interface{}) (pgconn.CommandTag, error)
-	Query(context.Context, string, ...interface{}) (pgx.Rows, error)
-	QueryRow(context.Context, string, ...interface{}) pgx.Row
+	Exec(context.Context, string, ...any) (pgconn.CommandTag, error)
+	Query(context.Context, string, ...any) (pgx.Rows, error)
+	QueryRow(context.Context, string, ...any) pgx.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/emit_pointers_for_null_types/sqlite/go/db.go
+++ b/internal/endtoend/testdata/emit_pointers_for_null_types/sqlite/go/db.go
@@ -10,10 +10,10 @@ import (
 )
 
 type DBTX interface {
-	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
 	PrepareContext(context.Context, string) (*sql.Stmt, error)
-	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
-	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/emit_pointers_for_null_types/stdlib/go/db.go
+++ b/internal/endtoend/testdata/emit_pointers_for_null_types/stdlib/go/db.go
@@ -10,10 +10,10 @@ import (
 )
 
 type DBTX interface {
-	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
 	PrepareContext(context.Context, string) (*sql.Stmt, error)
-	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
-	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/emit_pointers_for_null_types/stdlib/go/models.go
+++ b/internal/endtoend/testdata/emit_pointers_for_null_types/stdlib/go/models.go
@@ -94,19 +94,19 @@ type DtNumericNotNull struct {
 }
 
 type DtRange struct {
-	A interface{}
-	B interface{}
-	C interface{}
-	D interface{}
-	E interface{}
-	F interface{}
+	A any
+	B any
+	C any
+	D any
+	E any
+	F any
 }
 
 type DtRangeNotNull struct {
-	A interface{}
-	B interface{}
-	C interface{}
-	D interface{}
-	E interface{}
-	F interface{}
+	A any
+	B any
+	C any
+	D any
+	E any
+	F any
 }

--- a/internal/endtoend/testdata/emit_result_and_params_struct_pointers/mysql/go/db.go
+++ b/internal/endtoend/testdata/emit_result_and_params_struct_pointers/mysql/go/db.go
@@ -10,10 +10,10 @@ import (
 )
 
 type DBTX interface {
-	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
 	PrepareContext(context.Context, string) (*sql.Stmt, error)
-	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
-	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/emit_result_and_params_struct_pointers/postgresql/pgx/v4/go/batch.go
+++ b/internal/endtoend/testdata/emit_result_and_params_struct_pointers/postgresql/pgx/v4/go/batch.go
@@ -38,7 +38,7 @@ type InsertValuesParams struct {
 func (q *Queries) InsertValues(ctx context.Context, arg []*InsertValuesParams) *InsertValuesBatchResults {
 	batch := &pgx.Batch{}
 	for _, a := range arg {
-		vals := []interface{}{
+		vals := []any{
 			a.A,
 			a.B,
 		}

--- a/internal/endtoend/testdata/emit_result_and_params_struct_pointers/postgresql/pgx/v4/go/db.go
+++ b/internal/endtoend/testdata/emit_result_and_params_struct_pointers/postgresql/pgx/v4/go/db.go
@@ -12,9 +12,9 @@ import (
 )
 
 type DBTX interface {
-	Exec(context.Context, string, ...interface{}) (pgconn.CommandTag, error)
-	Query(context.Context, string, ...interface{}) (pgx.Rows, error)
-	QueryRow(context.Context, string, ...interface{}) pgx.Row
+	Exec(context.Context, string, ...any) (pgconn.CommandTag, error)
+	Query(context.Context, string, ...any) (pgx.Rows, error)
+	QueryRow(context.Context, string, ...any) pgx.Row
 	SendBatch(context.Context, *pgx.Batch) pgx.BatchResults
 }
 

--- a/internal/endtoend/testdata/emit_result_and_params_struct_pointers/postgresql/pgx/v5/go/batch.go
+++ b/internal/endtoend/testdata/emit_result_and_params_struct_pointers/postgresql/pgx/v5/go/batch.go
@@ -38,7 +38,7 @@ type InsertValuesParams struct {
 func (q *Queries) InsertValues(ctx context.Context, arg []*InsertValuesParams) *InsertValuesBatchResults {
 	batch := &pgx.Batch{}
 	for _, a := range arg {
-		vals := []interface{}{
+		vals := []any{
 			a.A,
 			a.B,
 		}

--- a/internal/endtoend/testdata/emit_result_and_params_struct_pointers/postgresql/pgx/v5/go/db.go
+++ b/internal/endtoend/testdata/emit_result_and_params_struct_pointers/postgresql/pgx/v5/go/db.go
@@ -12,9 +12,9 @@ import (
 )
 
 type DBTX interface {
-	Exec(context.Context, string, ...interface{}) (pgconn.CommandTag, error)
-	Query(context.Context, string, ...interface{}) (pgx.Rows, error)
-	QueryRow(context.Context, string, ...interface{}) pgx.Row
+	Exec(context.Context, string, ...any) (pgconn.CommandTag, error)
+	Query(context.Context, string, ...any) (pgx.Rows, error)
+	QueryRow(context.Context, string, ...any) pgx.Row
 	SendBatch(context.Context, *pgx.Batch) pgx.BatchResults
 }
 

--- a/internal/endtoend/testdata/emit_sql_as_comment/stdlib/go/db.go
+++ b/internal/endtoend/testdata/emit_sql_as_comment/stdlib/go/db.go
@@ -10,10 +10,10 @@ import (
 )
 
 type DBTX interface {
-	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
 	PrepareContext(context.Context, string) (*sql.Stmt, error)
-	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
-	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/enum/mysql/go/db.go
+++ b/internal/endtoend/testdata/enum/mysql/go/db.go
@@ -10,10 +10,10 @@ import (
 )
 
 type DBTX interface {
-	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
 	PrepareContext(context.Context, string) (*sql.Stmt, error)
-	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
-	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
 }
 
 func New() *Queries {

--- a/internal/endtoend/testdata/enum/mysql/go/models.go
+++ b/internal/endtoend/testdata/enum/mysql/go/models.go
@@ -20,7 +20,7 @@ const (
 	UsersShirtSizeXLarge UsersShirtSize = "x-large"
 )
 
-func (e *UsersShirtSize) Scan(src interface{}) error {
+func (e *UsersShirtSize) Scan(src any) error {
 	switch s := src.(type) {
 	case []byte:
 		*e = UsersShirtSize(s)
@@ -38,7 +38,7 @@ type NullUsersShirtSize struct {
 }
 
 // Scan implements the Scanner interface.
-func (ns *NullUsersShirtSize) Scan(value interface{}) error {
+func (ns *NullUsersShirtSize) Scan(value any) error {
 	if value == nil {
 		ns.UsersShirtSize, ns.Valid = "", false
 		return nil
@@ -65,7 +65,7 @@ const (
 	UsersShoeSizeXLarge UsersShoeSize = "x-large"
 )
 
-func (e *UsersShoeSize) Scan(src interface{}) error {
+func (e *UsersShoeSize) Scan(src any) error {
 	switch s := src.(type) {
 	case []byte:
 		*e = UsersShoeSize(s)
@@ -83,7 +83,7 @@ type NullUsersShoeSize struct {
 }
 
 // Scan implements the Scanner interface.
-func (ns *NullUsersShoeSize) Scan(value interface{}) error {
+func (ns *NullUsersShoeSize) Scan(value any) error {
 	if value == nil {
 		ns.UsersShoeSize, ns.Valid = "", false
 		return nil

--- a/internal/endtoend/testdata/enum/postgresql/pgx/v4/go/db.go
+++ b/internal/endtoend/testdata/enum/postgresql/pgx/v4/go/db.go
@@ -12,9 +12,9 @@ import (
 )
 
 type DBTX interface {
-	Exec(context.Context, string, ...interface{}) (pgconn.CommandTag, error)
-	Query(context.Context, string, ...interface{}) (pgx.Rows, error)
-	QueryRow(context.Context, string, ...interface{}) pgx.Row
+	Exec(context.Context, string, ...any) (pgconn.CommandTag, error)
+	Query(context.Context, string, ...any) (pgx.Rows, error)
+	QueryRow(context.Context, string, ...any) pgx.Row
 }
 
 func New() *Queries {

--- a/internal/endtoend/testdata/enum/postgresql/pgx/v4/go/models.go
+++ b/internal/endtoend/testdata/enum/postgresql/pgx/v4/go/models.go
@@ -20,7 +20,7 @@ const (
 	SizeXLarge Size = "x-large"
 )
 
-func (e *Size) Scan(src interface{}) error {
+func (e *Size) Scan(src any) error {
 	switch s := src.(type) {
 	case []byte:
 		*e = Size(s)
@@ -38,7 +38,7 @@ type NullSize struct {
 }
 
 // Scan implements the Scanner interface.
-func (ns *NullSize) Scan(value interface{}) error {
+func (ns *NullSize) Scan(value any) error {
 	if value == nil {
 		ns.Size, ns.Valid = "", false
 		return nil

--- a/internal/endtoend/testdata/enum/postgresql/pgx/v5/go/db.go
+++ b/internal/endtoend/testdata/enum/postgresql/pgx/v5/go/db.go
@@ -12,9 +12,9 @@ import (
 )
 
 type DBTX interface {
-	Exec(context.Context, string, ...interface{}) (pgconn.CommandTag, error)
-	Query(context.Context, string, ...interface{}) (pgx.Rows, error)
-	QueryRow(context.Context, string, ...interface{}) pgx.Row
+	Exec(context.Context, string, ...any) (pgconn.CommandTag, error)
+	Query(context.Context, string, ...any) (pgx.Rows, error)
+	QueryRow(context.Context, string, ...any) pgx.Row
 }
 
 func New() *Queries {

--- a/internal/endtoend/testdata/enum/postgresql/pgx/v5/go/models.go
+++ b/internal/endtoend/testdata/enum/postgresql/pgx/v5/go/models.go
@@ -21,7 +21,7 @@ const (
 	SizeXLarge Size = "x-large"
 )
 
-func (e *Size) Scan(src interface{}) error {
+func (e *Size) Scan(src any) error {
 	switch s := src.(type) {
 	case []byte:
 		*e = Size(s)
@@ -39,7 +39,7 @@ type NullSize struct {
 }
 
 // Scan implements the Scanner interface.
-func (ns *NullSize) Scan(value interface{}) error {
+func (ns *NullSize) Scan(value any) error {
 	if value == nil {
 		ns.Size, ns.Valid = "", false
 		return nil

--- a/internal/endtoend/testdata/enum/postgresql/stdlib/go/db.go
+++ b/internal/endtoend/testdata/enum/postgresql/stdlib/go/db.go
@@ -10,10 +10,10 @@ import (
 )
 
 type DBTX interface {
-	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
 	PrepareContext(context.Context, string) (*sql.Stmt, error)
-	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
-	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
 }
 
 func New() *Queries {

--- a/internal/endtoend/testdata/enum/postgresql/stdlib/go/models.go
+++ b/internal/endtoend/testdata/enum/postgresql/stdlib/go/models.go
@@ -20,7 +20,7 @@ const (
 	SizeXLarge Size = "x-large"
 )
 
-func (e *Size) Scan(src interface{}) error {
+func (e *Size) Scan(src any) error {
 	switch s := src.(type) {
 	case []byte:
 		*e = Size(s)
@@ -38,7 +38,7 @@ type NullSize struct {
 }
 
 // Scan implements the Scanner interface.
-func (ns *NullSize) Scan(value interface{}) error {
+func (ns *NullSize) Scan(value any) error {
 	if value == nil {
 		ns.Size, ns.Valid = "", false
 		return nil

--- a/internal/endtoend/testdata/enum_column/mysql/go/db.go
+++ b/internal/endtoend/testdata/enum_column/mysql/go/db.go
@@ -10,10 +10,10 @@ import (
 )
 
 type DBTX interface {
-	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
 	PrepareContext(context.Context, string) (*sql.Stmt, error)
-	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
-	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/enum_column/mysql/go/models.go
+++ b/internal/endtoend/testdata/enum_column/mysql/go/models.go
@@ -16,7 +16,7 @@ const (
 	AuthorsAddItemAdded AuthorsAddItem = "added"
 )
 
-func (e *AuthorsAddItem) Scan(src interface{}) error {
+func (e *AuthorsAddItem) Scan(src any) error {
 	switch s := src.(type) {
 	case []byte:
 		*e = AuthorsAddItem(s)
@@ -34,7 +34,7 @@ type NullAuthorsAddItem struct {
 }
 
 // Scan implements the Scanner interface.
-func (ns *NullAuthorsAddItem) Scan(value interface{}) error {
+func (ns *NullAuthorsAddItem) Scan(value any) error {
 	if value == nil {
 		ns.AuthorsAddItem, ns.Valid = "", false
 		return nil
@@ -57,7 +57,7 @@ const (
 	AuthorsAddedOk AuthorsAdded = "ok"
 )
 
-func (e *AuthorsAdded) Scan(src interface{}) error {
+func (e *AuthorsAdded) Scan(src any) error {
 	switch s := src.(type) {
 	case []byte:
 		*e = AuthorsAdded(s)
@@ -75,7 +75,7 @@ type NullAuthorsAdded struct {
 }
 
 // Scan implements the Scanner interface.
-func (ns *NullAuthorsAdded) Scan(value interface{}) error {
+func (ns *NullAuthorsAdded) Scan(value any) error {
 	if value == nil {
 		ns.AuthorsAdded, ns.Valid = "", false
 		return nil
@@ -98,7 +98,7 @@ const (
 	AuthorsBarOk AuthorsBar = "ok"
 )
 
-func (e *AuthorsBar) Scan(src interface{}) error {
+func (e *AuthorsBar) Scan(src any) error {
 	switch s := src.(type) {
 	case []byte:
 		*e = AuthorsBar(s)
@@ -116,7 +116,7 @@ type NullAuthorsBar struct {
 }
 
 // Scan implements the Scanner interface.
-func (ns *NullAuthorsBar) Scan(value interface{}) error {
+func (ns *NullAuthorsBar) Scan(value any) error {
 	if value == nil {
 		ns.AuthorsBar, ns.Valid = "", false
 		return nil
@@ -139,7 +139,7 @@ const (
 	AuthorsFooOk AuthorsFoo = "ok"
 )
 
-func (e *AuthorsFoo) Scan(src interface{}) error {
+func (e *AuthorsFoo) Scan(src any) error {
 	switch s := src.(type) {
 	case []byte:
 		*e = AuthorsFoo(s)
@@ -157,7 +157,7 @@ type NullAuthorsFoo struct {
 }
 
 // Scan implements the Scanner interface.
-func (ns *NullAuthorsFoo) Scan(value interface{}) error {
+func (ns *NullAuthorsFoo) Scan(value any) error {
 	if value == nil {
 		ns.AuthorsFoo, ns.Valid = "", false
 		return nil
@@ -180,7 +180,7 @@ const (
 	AuthorsRemoveItemOk AuthorsRemoveItem = "ok"
 )
 
-func (e *AuthorsRemoveItem) Scan(src interface{}) error {
+func (e *AuthorsRemoveItem) Scan(src any) error {
 	switch s := src.(type) {
 	case []byte:
 		*e = AuthorsRemoveItem(s)
@@ -198,7 +198,7 @@ type NullAuthorsRemoveItem struct {
 }
 
 // Scan implements the Scanner interface.
-func (ns *NullAuthorsRemoveItem) Scan(value interface{}) error {
+func (ns *NullAuthorsRemoveItem) Scan(value any) error {
 	if value == nil {
 		ns.AuthorsRemoveItem, ns.Valid = "", false
 		return nil
@@ -221,7 +221,7 @@ const (
 	BooksFooOk BooksFoo = "ok"
 )
 
-func (e *BooksFoo) Scan(src interface{}) error {
+func (e *BooksFoo) Scan(src any) error {
 	switch s := src.(type) {
 	case []byte:
 		*e = BooksFoo(s)
@@ -239,7 +239,7 @@ type NullBooksFoo struct {
 }
 
 // Scan implements the Scanner interface.
-func (ns *NullBooksFoo) Scan(value interface{}) error {
+func (ns *NullBooksFoo) Scan(value any) error {
 	if value == nil {
 		ns.BooksFoo, ns.Valid = "", false
 		return nil

--- a/internal/endtoend/testdata/enum_ordering/postgresql/stdlib/go/db.go
+++ b/internal/endtoend/testdata/enum_ordering/postgresql/stdlib/go/db.go
@@ -10,10 +10,10 @@ import (
 )
 
 type DBTX interface {
-	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
 	PrepareContext(context.Context, string) (*sql.Stmt, error)
-	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
-	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/enum_ordering/postgresql/stdlib/go/models.go
+++ b/internal/endtoend/testdata/enum_ordering/postgresql/stdlib/go/models.go
@@ -22,7 +22,7 @@ const (
 	EnumTypeAfterlast   EnumType = "afterlast"
 )
 
-func (e *EnumType) Scan(src interface{}) error {
+func (e *EnumType) Scan(src any) error {
 	switch s := src.(type) {
 	case []byte:
 		*e = EnumType(s)
@@ -40,7 +40,7 @@ type NullEnumType struct {
 }
 
 // Scan implements the Scanner interface.
-func (ns *NullEnumType) Scan(value interface{}) error {
+func (ns *NullEnumType) Scan(value any) error {
 	if value == nil {
 		ns.EnumType, ns.Valid = "", false
 		return nil

--- a/internal/endtoend/testdata/exec_create_table/mysql/db/db.go
+++ b/internal/endtoend/testdata/exec_create_table/mysql/db/db.go
@@ -10,10 +10,10 @@ import (
 )
 
 type DBTX interface {
-	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
 	PrepareContext(context.Context, string) (*sql.Stmt, error)
-	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
-	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/exec_create_table/postgresql/db/db.go
+++ b/internal/endtoend/testdata/exec_create_table/postgresql/db/db.go
@@ -10,10 +10,10 @@ import (
 )
 
 type DBTX interface {
-	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
 	PrepareContext(context.Context, string) (*sql.Stmt, error)
-	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
-	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/exec_create_table/sqlite/db/db.go
+++ b/internal/endtoend/testdata/exec_create_table/sqlite/db/db.go
@@ -10,10 +10,10 @@ import (
 )
 
 type DBTX interface {
-	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
 	PrepareContext(context.Context, string) (*sql.Stmt, error)
-	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
-	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/exec_imports/pgx/v4/go/db.go
+++ b/internal/endtoend/testdata/exec_imports/pgx/v4/go/db.go
@@ -12,9 +12,9 @@ import (
 )
 
 type DBTX interface {
-	Exec(context.Context, string, ...interface{}) (pgconn.CommandTag, error)
-	Query(context.Context, string, ...interface{}) (pgx.Rows, error)
-	QueryRow(context.Context, string, ...interface{}) pgx.Row
+	Exec(context.Context, string, ...any) (pgconn.CommandTag, error)
+	Query(context.Context, string, ...any) (pgx.Rows, error)
+	QueryRow(context.Context, string, ...any) pgx.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/exec_imports/pgx/v5/go/db.go
+++ b/internal/endtoend/testdata/exec_imports/pgx/v5/go/db.go
@@ -12,9 +12,9 @@ import (
 )
 
 type DBTX interface {
-	Exec(context.Context, string, ...interface{}) (pgconn.CommandTag, error)
-	Query(context.Context, string, ...interface{}) (pgx.Rows, error)
-	QueryRow(context.Context, string, ...interface{}) pgx.Row
+	Exec(context.Context, string, ...any) (pgconn.CommandTag, error)
+	Query(context.Context, string, ...any) (pgx.Rows, error)
+	QueryRow(context.Context, string, ...any) pgx.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/exec_imports/stdlib/go/db.go
+++ b/internal/endtoend/testdata/exec_imports/stdlib/go/db.go
@@ -10,10 +10,10 @@ import (
 )
 
 type DBTX interface {
-	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
 	PrepareContext(context.Context, string) (*sql.Stmt, error)
-	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
-	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/exec_lastid/go_postgresql_stdlib/go/db.go
+++ b/internal/endtoend/testdata/exec_lastid/go_postgresql_stdlib/go/db.go
@@ -10,10 +10,10 @@ import (
 )
 
 type DBTX interface {
-	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
 	PrepareContext(context.Context, string) (*sql.Stmt, error)
-	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
-	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/exec_no_return_struct/postgresql/pgx/go/db.go
+++ b/internal/endtoend/testdata/exec_no_return_struct/postgresql/pgx/go/db.go
@@ -12,9 +12,9 @@ import (
 )
 
 type DBTX interface {
-	Exec(context.Context, string, ...interface{}) (pgconn.CommandTag, error)
-	Query(context.Context, string, ...interface{}) (pgx.Rows, error)
-	QueryRow(context.Context, string, ...interface{}) pgx.Row
+	Exec(context.Context, string, ...any) (pgconn.CommandTag, error)
+	Query(context.Context, string, ...any) (pgx.Rows, error)
+	QueryRow(context.Context, string, ...any) pgx.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/exec_result/go_postgresql_pgx/v4/go/db.go
+++ b/internal/endtoend/testdata/exec_result/go_postgresql_pgx/v4/go/db.go
@@ -12,9 +12,9 @@ import (
 )
 
 type DBTX interface {
-	Exec(context.Context, string, ...interface{}) (pgconn.CommandTag, error)
-	Query(context.Context, string, ...interface{}) (pgx.Rows, error)
-	QueryRow(context.Context, string, ...interface{}) pgx.Row
+	Exec(context.Context, string, ...any) (pgconn.CommandTag, error)
+	Query(context.Context, string, ...any) (pgx.Rows, error)
+	QueryRow(context.Context, string, ...any) pgx.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/exec_result/go_postgresql_pgx/v5/go/db.go
+++ b/internal/endtoend/testdata/exec_result/go_postgresql_pgx/v5/go/db.go
@@ -12,9 +12,9 @@ import (
 )
 
 type DBTX interface {
-	Exec(context.Context, string, ...interface{}) (pgconn.CommandTag, error)
-	Query(context.Context, string, ...interface{}) (pgx.Rows, error)
-	QueryRow(context.Context, string, ...interface{}) pgx.Row
+	Exec(context.Context, string, ...any) (pgconn.CommandTag, error)
+	Query(context.Context, string, ...any) (pgx.Rows, error)
+	QueryRow(context.Context, string, ...any) pgx.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/exec_result/go_postgresql_stdlib/go/db.go
+++ b/internal/endtoend/testdata/exec_result/go_postgresql_stdlib/go/db.go
@@ -10,10 +10,10 @@ import (
 )
 
 type DBTX interface {
-	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
 	PrepareContext(context.Context, string) (*sql.Stmt, error)
-	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
-	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/exec_rows/go_postgresql_pgx/v4/go/db.go
+++ b/internal/endtoend/testdata/exec_rows/go_postgresql_pgx/v4/go/db.go
@@ -12,9 +12,9 @@ import (
 )
 
 type DBTX interface {
-	Exec(context.Context, string, ...interface{}) (pgconn.CommandTag, error)
-	Query(context.Context, string, ...interface{}) (pgx.Rows, error)
-	QueryRow(context.Context, string, ...interface{}) pgx.Row
+	Exec(context.Context, string, ...any) (pgconn.CommandTag, error)
+	Query(context.Context, string, ...any) (pgx.Rows, error)
+	QueryRow(context.Context, string, ...any) pgx.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/exec_rows/go_postgresql_pgx/v5/go/db.go
+++ b/internal/endtoend/testdata/exec_rows/go_postgresql_pgx/v5/go/db.go
@@ -12,9 +12,9 @@ import (
 )
 
 type DBTX interface {
-	Exec(context.Context, string, ...interface{}) (pgconn.CommandTag, error)
-	Query(context.Context, string, ...interface{}) (pgx.Rows, error)
-	QueryRow(context.Context, string, ...interface{}) pgx.Row
+	Exec(context.Context, string, ...any) (pgconn.CommandTag, error)
+	Query(context.Context, string, ...any) (pgx.Rows, error)
+	QueryRow(context.Context, string, ...any) pgx.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/exec_rows/go_postgresql_stdlib/go/db.go
+++ b/internal/endtoend/testdata/exec_rows/go_postgresql_stdlib/go/db.go
@@ -10,10 +10,10 @@ import (
 )
 
 type DBTX interface {
-	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
 	PrepareContext(context.Context, string) (*sql.Stmt, error)
-	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
-	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/experiment_coreanalyzer/mysql/go/db.go
+++ b/internal/endtoend/testdata/experiment_coreanalyzer/mysql/go/db.go
@@ -10,10 +10,10 @@ import (
 )
 
 type DBTX interface {
-	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
 	PrepareContext(context.Context, string) (*sql.Stmt, error)
-	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
-	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/experiment_coreanalyzer/postgresql/stdlib/go/db.go
+++ b/internal/endtoend/testdata/experiment_coreanalyzer/postgresql/stdlib/go/db.go
@@ -10,10 +10,10 @@ import (
 )
 
 type DBTX interface {
-	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
 	PrepareContext(context.Context, string) (*sql.Stmt, error)
-	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
-	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/experiment_coreanalyzer/sqlite/go/db.go
+++ b/internal/endtoend/testdata/experiment_coreanalyzer/sqlite/go/db.go
@@ -10,10 +10,10 @@ import (
 )
 
 type DBTX interface {
-	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
 	PrepareContext(context.Context, string) (*sql.Stmt, error)
-	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
-	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/full_outer_join/sqlite/go/db.go
+++ b/internal/endtoend/testdata/full_outer_join/sqlite/go/db.go
@@ -10,10 +10,10 @@ import (
 )
 
 type DBTX interface {
-	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
 	PrepareContext(context.Context, string) (*sql.Stmt, error)
-	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
-	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/func_aggregate/pganalyze/go/db.go
+++ b/internal/endtoend/testdata/func_aggregate/pganalyze/go/db.go
@@ -10,10 +10,10 @@ import (
 )
 
 type DBTX interface {
-	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
 	PrepareContext(context.Context, string) (*sql.Stmt, error)
-	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
-	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/func_aggregate/postgresql/go/db.go
+++ b/internal/endtoend/testdata/func_aggregate/postgresql/go/db.go
@@ -10,10 +10,10 @@ import (
 )
 
 type DBTX interface {
-	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
 	PrepareContext(context.Context, string) (*sql.Stmt, error)
-	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
-	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/func_aggregate/postgresql/go/query.sql.go
+++ b/internal/endtoend/testdata/func_aggregate/postgresql/go/query.sql.go
@@ -14,9 +14,9 @@ select percentile_disc(0.5) within group (order by authors.name)
 from authors
 `
 
-func (q *Queries) Percentile(ctx context.Context) (interface{}, error) {
+func (q *Queries) Percentile(ctx context.Context) (any, error) {
 	row := q.db.QueryRowContext(ctx, percentile)
-	var percentile_disc interface{}
+	var percentile_disc any
 	err := row.Scan(&percentile_disc)
 	return percentile_disc, err
 }

--- a/internal/endtoend/testdata/func_args/pgx/v4/go/db.go
+++ b/internal/endtoend/testdata/func_args/pgx/v4/go/db.go
@@ -12,9 +12,9 @@ import (
 )
 
 type DBTX interface {
-	Exec(context.Context, string, ...interface{}) (pgconn.CommandTag, error)
-	Query(context.Context, string, ...interface{}) (pgx.Rows, error)
-	QueryRow(context.Context, string, ...interface{}) pgx.Row
+	Exec(context.Context, string, ...any) (pgconn.CommandTag, error)
+	Query(context.Context, string, ...any) (pgx.Rows, error)
+	QueryRow(context.Context, string, ...any) pgx.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/func_args/pgx/v5/go/db.go
+++ b/internal/endtoend/testdata/func_args/pgx/v5/go/db.go
@@ -12,9 +12,9 @@ import (
 )
 
 type DBTX interface {
-	Exec(context.Context, string, ...interface{}) (pgconn.CommandTag, error)
-	Query(context.Context, string, ...interface{}) (pgx.Rows, error)
-	QueryRow(context.Context, string, ...interface{}) pgx.Row
+	Exec(context.Context, string, ...any) (pgconn.CommandTag, error)
+	Query(context.Context, string, ...any) (pgx.Rows, error)
+	QueryRow(context.Context, string, ...any) pgx.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/func_args/stdlib/go/db.go
+++ b/internal/endtoend/testdata/func_args/stdlib/go/db.go
@@ -10,10 +10,10 @@ import (
 )
 
 type DBTX interface {
-	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
 	PrepareContext(context.Context, string) (*sql.Stmt, error)
-	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
-	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/func_args_typecast/pgx/v4/go/db.go
+++ b/internal/endtoend/testdata/func_args_typecast/pgx/v4/go/db.go
@@ -12,9 +12,9 @@ import (
 )
 
 type DBTX interface {
-	Exec(context.Context, string, ...interface{}) (pgconn.CommandTag, error)
-	Query(context.Context, string, ...interface{}) (pgx.Rows, error)
-	QueryRow(context.Context, string, ...interface{}) pgx.Row
+	Exec(context.Context, string, ...any) (pgconn.CommandTag, error)
+	Query(context.Context, string, ...any) (pgx.Rows, error)
+	QueryRow(context.Context, string, ...any) pgx.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/func_args_typecast/pgx/v5/go/db.go
+++ b/internal/endtoend/testdata/func_args_typecast/pgx/v5/go/db.go
@@ -12,9 +12,9 @@ import (
 )
 
 type DBTX interface {
-	Exec(context.Context, string, ...interface{}) (pgconn.CommandTag, error)
-	Query(context.Context, string, ...interface{}) (pgx.Rows, error)
-	QueryRow(context.Context, string, ...interface{}) pgx.Row
+	Exec(context.Context, string, ...any) (pgconn.CommandTag, error)
+	Query(context.Context, string, ...any) (pgx.Rows, error)
+	QueryRow(context.Context, string, ...any) pgx.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/func_args_typecast/stdlib/go/db.go
+++ b/internal/endtoend/testdata/func_args_typecast/stdlib/go/db.go
@@ -10,10 +10,10 @@ import (
 )
 
 type DBTX interface {
-	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
 	PrepareContext(context.Context, string) (*sql.Stmt, error)
-	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
-	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/func_call_cast/mysql/go/db.go
+++ b/internal/endtoend/testdata/func_call_cast/mysql/go/db.go
@@ -10,10 +10,10 @@ import (
 )
 
 type DBTX interface {
-	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
 	PrepareContext(context.Context, string) (*sql.Stmt, error)
-	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
-	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/func_call_cast/postgresql/pgx/v4/go/db.go
+++ b/internal/endtoend/testdata/func_call_cast/postgresql/pgx/v4/go/db.go
@@ -12,9 +12,9 @@ import (
 )
 
 type DBTX interface {
-	Exec(context.Context, string, ...interface{}) (pgconn.CommandTag, error)
-	Query(context.Context, string, ...interface{}) (pgx.Rows, error)
-	QueryRow(context.Context, string, ...interface{}) pgx.Row
+	Exec(context.Context, string, ...any) (pgconn.CommandTag, error)
+	Query(context.Context, string, ...any) (pgx.Rows, error)
+	QueryRow(context.Context, string, ...any) pgx.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/func_call_cast/postgresql/pgx/v5/go/db.go
+++ b/internal/endtoend/testdata/func_call_cast/postgresql/pgx/v5/go/db.go
@@ -12,9 +12,9 @@ import (
 )
 
 type DBTX interface {
-	Exec(context.Context, string, ...interface{}) (pgconn.CommandTag, error)
-	Query(context.Context, string, ...interface{}) (pgx.Rows, error)
-	QueryRow(context.Context, string, ...interface{}) pgx.Row
+	Exec(context.Context, string, ...any) (pgconn.CommandTag, error)
+	Query(context.Context, string, ...any) (pgx.Rows, error)
+	QueryRow(context.Context, string, ...any) pgx.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/func_call_cast/postgresql/stdlib/go/db.go
+++ b/internal/endtoend/testdata/func_call_cast/postgresql/stdlib/go/db.go
@@ -10,10 +10,10 @@ import (
 )
 
 type DBTX interface {
-	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
 	PrepareContext(context.Context, string) (*sql.Stmt, error)
-	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
-	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/func_call_cast/sqlite/go/db.go
+++ b/internal/endtoend/testdata/func_call_cast/sqlite/go/db.go
@@ -10,10 +10,10 @@ import (
 )
 
 type DBTX interface {
-	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
 	PrepareContext(context.Context, string) (*sql.Stmt, error)
-	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
-	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/func_match_types/mysql/go/db.go
+++ b/internal/endtoend/testdata/func_match_types/mysql/go/db.go
@@ -10,10 +10,10 @@ import (
 )
 
 type DBTX interface {
-	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
 	PrepareContext(context.Context, string) (*sql.Stmt, error)
-	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
-	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/func_match_types/mysql/go/query.sql.go
+++ b/internal/endtoend/testdata/func_match_types/mysql/go/query.sql.go
@@ -18,7 +18,7 @@ group by author
 type AuthorPagesRow struct {
 	Author     string
 	NumBooks   int64
-	TotalPages interface{}
+	TotalPages any
 }
 
 func (q *Queries) AuthorPages(ctx context.Context) ([]AuthorPagesRow, error) {

--- a/internal/endtoend/testdata/func_match_types/postgresql/go/db.go
+++ b/internal/endtoend/testdata/func_match_types/postgresql/go/db.go
@@ -10,10 +10,10 @@ import (
 )
 
 type DBTX interface {
-	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
 	PrepareContext(context.Context, string) (*sql.Stmt, error)
-	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
-	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/func_match_types/sqlite/go/db.go
+++ b/internal/endtoend/testdata/func_match_types/sqlite/go/db.go
@@ -10,10 +10,10 @@ import (
 )
 
 type DBTX interface {
-	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
 	PrepareContext(context.Context, string) (*sql.Stmt, error)
-	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
-	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/func_out_param/pgx/go/db.go
+++ b/internal/endtoend/testdata/func_out_param/pgx/go/db.go
@@ -12,9 +12,9 @@ import (
 )
 
 type DBTX interface {
-	Exec(context.Context, string, ...interface{}) (pgconn.CommandTag, error)
-	Query(context.Context, string, ...interface{}) (pgx.Rows, error)
-	QueryRow(context.Context, string, ...interface{}) pgx.Row
+	Exec(context.Context, string, ...any) (pgconn.CommandTag, error)
+	Query(context.Context, string, ...any) (pgx.Rows, error)
+	QueryRow(context.Context, string, ...any) pgx.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/func_return_date/postgresql/pganalyze/go/db.go
+++ b/internal/endtoend/testdata/func_return_date/postgresql/pganalyze/go/db.go
@@ -12,9 +12,9 @@ import (
 )
 
 type DBTX interface {
-	Exec(context.Context, string, ...interface{}) (pgconn.CommandTag, error)
-	Query(context.Context, string, ...interface{}) (pgx.Rows, error)
-	QueryRow(context.Context, string, ...interface{}) pgx.Row
+	Exec(context.Context, string, ...any) (pgconn.CommandTag, error)
+	Query(context.Context, string, ...any) (pgx.Rows, error)
+	QueryRow(context.Context, string, ...any) pgx.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/func_return_date/postgresql/pgx/v5/go/db.go
+++ b/internal/endtoend/testdata/func_return_date/postgresql/pgx/v5/go/db.go
@@ -12,9 +12,9 @@ import (
 )
 
 type DBTX interface {
-	Exec(context.Context, string, ...interface{}) (pgconn.CommandTag, error)
-	Query(context.Context, string, ...interface{}) (pgx.Rows, error)
-	QueryRow(context.Context, string, ...interface{}) pgx.Row
+	Exec(context.Context, string, ...any) (pgconn.CommandTag, error)
+	Query(context.Context, string, ...any) (pgx.Rows, error)
+	QueryRow(context.Context, string, ...any) pgx.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/func_return_date/postgresql/stdlib/go/db.go
+++ b/internal/endtoend/testdata/func_return_date/postgresql/stdlib/go/db.go
@@ -10,10 +10,10 @@ import (
 )
 
 type DBTX interface {
-	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
 	PrepareContext(context.Context, string) (*sql.Stmt, error)
-	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
-	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/func_return_record/postgresql/pgx/go/db.go
+++ b/internal/endtoend/testdata/func_return_record/postgresql/pgx/go/db.go
@@ -12,9 +12,9 @@ import (
 )
 
 type DBTX interface {
-	Exec(context.Context, string, ...interface{}) (pgconn.CommandTag, error)
-	Query(context.Context, string, ...interface{}) (pgx.Rows, error)
-	QueryRow(context.Context, string, ...interface{}) pgx.Row
+	Exec(context.Context, string, ...any) (pgconn.CommandTag, error)
+	Query(context.Context, string, ...any) (pgx.Rows, error)
+	QueryRow(context.Context, string, ...any) pgx.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/func_return_series/postgresql/pgx/v4/go/db.go
+++ b/internal/endtoend/testdata/func_return_series/postgresql/pgx/v4/go/db.go
@@ -12,9 +12,9 @@ import (
 )
 
 type DBTX interface {
-	Exec(context.Context, string, ...interface{}) (pgconn.CommandTag, error)
-	Query(context.Context, string, ...interface{}) (pgx.Rows, error)
-	QueryRow(context.Context, string, ...interface{}) pgx.Row
+	Exec(context.Context, string, ...any) (pgconn.CommandTag, error)
+	Query(context.Context, string, ...any) (pgx.Rows, error)
+	QueryRow(context.Context, string, ...any) pgx.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/func_return_series/postgresql/pgx/v5/go/db.go
+++ b/internal/endtoend/testdata/func_return_series/postgresql/pgx/v5/go/db.go
@@ -12,9 +12,9 @@ import (
 )
 
 type DBTX interface {
-	Exec(context.Context, string, ...interface{}) (pgconn.CommandTag, error)
-	Query(context.Context, string, ...interface{}) (pgx.Rows, error)
-	QueryRow(context.Context, string, ...interface{}) pgx.Row
+	Exec(context.Context, string, ...any) (pgconn.CommandTag, error)
+	Query(context.Context, string, ...any) (pgx.Rows, error)
+	QueryRow(context.Context, string, ...any) pgx.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/func_return_series/postgresql/stdlib/go/db.go
+++ b/internal/endtoend/testdata/func_return_series/postgresql/stdlib/go/db.go
@@ -10,10 +10,10 @@ import (
 )
 
 type DBTX interface {
-	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
 	PrepareContext(context.Context, string) (*sql.Stmt, error)
-	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
-	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/func_return_table/postgresql/pgx/go/db.go
+++ b/internal/endtoend/testdata/func_return_table/postgresql/pgx/go/db.go
@@ -12,9 +12,9 @@ import (
 )
 
 type DBTX interface {
-	Exec(context.Context, string, ...interface{}) (pgconn.CommandTag, error)
-	Query(context.Context, string, ...interface{}) (pgx.Rows, error)
-	QueryRow(context.Context, string, ...interface{}) pgx.Row
+	Exec(context.Context, string, ...any) (pgconn.CommandTag, error)
+	Query(context.Context, string, ...any) (pgx.Rows, error)
+	QueryRow(context.Context, string, ...any) pgx.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/func_return_table_columns/postgresql/pgx/go/db.go
+++ b/internal/endtoend/testdata/func_return_table_columns/postgresql/pgx/go/db.go
@@ -12,9 +12,9 @@ import (
 )
 
 type DBTX interface {
-	Exec(context.Context, string, ...interface{}) (pgconn.CommandTag, error)
-	Query(context.Context, string, ...interface{}) (pgx.Rows, error)
-	QueryRow(context.Context, string, ...interface{}) pgx.Row
+	Exec(context.Context, string, ...any) (pgconn.CommandTag, error)
+	Query(context.Context, string, ...any) (pgx.Rows, error)
+	QueryRow(context.Context, string, ...any) pgx.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/func_star_expansion/postgresql/pgx/go/db.go
+++ b/internal/endtoend/testdata/func_star_expansion/postgresql/pgx/go/db.go
@@ -12,9 +12,9 @@ import (
 )
 
 type DBTX interface {
-	Exec(context.Context, string, ...interface{}) (pgconn.CommandTag, error)
-	Query(context.Context, string, ...interface{}) (pgx.Rows, error)
-	QueryRow(context.Context, string, ...interface{}) pgx.Row
+	Exec(context.Context, string, ...any) (pgconn.CommandTag, error)
+	Query(context.Context, string, ...any) (pgx.Rows, error)
+	QueryRow(context.Context, string, ...any) pgx.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/func_star_expansion/postgresql/pgx/go/query.sql.go
+++ b/internal/endtoend/testdata/func_star_expansion/postgresql/pgx/go/query.sql.go
@@ -26,9 +26,9 @@ const testFuncSelectBlog = `-- name: TestFuncSelectBlog :one
 select test_func_select_blog from test_func_select_blog($1)
 `
 
-func (q *Queries) TestFuncSelectBlog(ctx context.Context, pID int32) (interface{}, error) {
+func (q *Queries) TestFuncSelectBlog(ctx context.Context, pID int32) (any, error) {
 	row := q.db.QueryRow(ctx, testFuncSelectBlog, pID)
-	var test_func_select_blog interface{}
+	var test_func_select_blog any
 	err := row.Scan(&test_func_select_blog)
 	return test_func_select_blog, err
 }

--- a/internal/endtoend/testdata/func_variadic/postgresql/stdlib/go/db.go
+++ b/internal/endtoend/testdata/func_variadic/postgresql/stdlib/go/db.go
@@ -10,10 +10,10 @@ import (
 )
 
 type DBTX interface {
-	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
 	PrepareContext(context.Context, string) (*sql.Stmt, error)
-	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
-	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/geometric/pgx/v4/go/db.go
+++ b/internal/endtoend/testdata/geometric/pgx/v4/go/db.go
@@ -12,9 +12,9 @@ import (
 )
 
 type DBTX interface {
-	Exec(context.Context, string, ...interface{}) (pgconn.CommandTag, error)
-	Query(context.Context, string, ...interface{}) (pgx.Rows, error)
-	QueryRow(context.Context, string, ...interface{}) pgx.Row
+	Exec(context.Context, string, ...any) (pgconn.CommandTag, error)
+	Query(context.Context, string, ...any) (pgx.Rows, error)
+	QueryRow(context.Context, string, ...any) pgx.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/geometric/pgx/v5/go/db.go
+++ b/internal/endtoend/testdata/geometric/pgx/v5/go/db.go
@@ -12,9 +12,9 @@ import (
 )
 
 type DBTX interface {
-	Exec(context.Context, string, ...interface{}) (pgconn.CommandTag, error)
-	Query(context.Context, string, ...interface{}) (pgx.Rows, error)
-	QueryRow(context.Context, string, ...interface{}) pgx.Row
+	Exec(context.Context, string, ...any) (pgconn.CommandTag, error)
+	Query(context.Context, string, ...any) (pgx.Rows, error)
+	QueryRow(context.Context, string, ...any) pgx.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/golang_initialisms_empty/db/db.go
+++ b/internal/endtoend/testdata/golang_initialisms_empty/db/db.go
@@ -10,10 +10,10 @@ import (
 )
 
 type DBTX interface {
-	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
 	PrepareContext(context.Context, string) (*sql.Stmt, error)
-	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
-	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/golang_initialisms_url/db/db.go
+++ b/internal/endtoend/testdata/golang_initialisms_url/db/db.go
@@ -10,10 +10,10 @@ import (
 )
 
 type DBTX interface {
-	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
 	PrepareContext(context.Context, string) (*sql.Stmt, error)
-	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
-	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/golang_invalid_sql_driver/db/db.go
+++ b/internal/endtoend/testdata/golang_invalid_sql_driver/db/db.go
@@ -10,10 +10,10 @@ import (
 )
 
 type DBTX interface {
-	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
 	PrepareContext(context.Context, string) (*sql.Stmt, error)
-	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
-	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/golang_invalid_sql_package/db/db.go
+++ b/internal/endtoend/testdata/golang_invalid_sql_package/db/db.go
@@ -10,10 +10,10 @@ import (
 )
 
 type DBTX interface {
-	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
 	PrepareContext(context.Context, string) (*sql.Stmt, error)
-	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
-	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/having/mysql/go/db.go
+++ b/internal/endtoend/testdata/having/mysql/go/db.go
@@ -10,10 +10,10 @@ import (
 )
 
 type DBTX interface {
-	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
 	PrepareContext(context.Context, string) (*sql.Stmt, error)
-	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
-	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/having/postgresql/go/db.go
+++ b/internal/endtoend/testdata/having/postgresql/go/db.go
@@ -10,10 +10,10 @@ import (
 )
 
 type DBTX interface {
-	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
 	PrepareContext(context.Context, string) (*sql.Stmt, error)
-	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
-	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/hstore/pgx/v4/go/db.go
+++ b/internal/endtoend/testdata/hstore/pgx/v4/go/db.go
@@ -12,9 +12,9 @@ import (
 )
 
 type DBTX interface {
-	Exec(context.Context, string, ...interface{}) (pgconn.CommandTag, error)
-	Query(context.Context, string, ...interface{}) (pgx.Rows, error)
-	QueryRow(context.Context, string, ...interface{}) pgx.Row
+	Exec(context.Context, string, ...any) (pgconn.CommandTag, error)
+	Query(context.Context, string, ...any) (pgx.Rows, error)
+	QueryRow(context.Context, string, ...any) pgx.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/hstore/pgx/v5/go/db.go
+++ b/internal/endtoend/testdata/hstore/pgx/v5/go/db.go
@@ -12,9 +12,9 @@ import (
 )
 
 type DBTX interface {
-	Exec(context.Context, string, ...interface{}) (pgconn.CommandTag, error)
-	Query(context.Context, string, ...interface{}) (pgx.Rows, error)
-	QueryRow(context.Context, string, ...interface{}) pgx.Row
+	Exec(context.Context, string, ...any) (pgconn.CommandTag, error)
+	Query(context.Context, string, ...any) (pgx.Rows, error)
+	QueryRow(context.Context, string, ...any) pgx.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/hstore/stdlib/go/db.go
+++ b/internal/endtoend/testdata/hstore/stdlib/go/db.go
@@ -10,10 +10,10 @@ import (
 )
 
 type DBTX interface {
-	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
 	PrepareContext(context.Context, string) (*sql.Stmt, error)
-	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
-	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/hstore/stdlib/go/hstore.sql.go
+++ b/internal/endtoend/testdata/hstore/stdlib/go/hstore.sql.go
@@ -13,15 +13,15 @@ const listBar = `-- name: ListBar :many
 SELECT bar FROM foo
 `
 
-func (q *Queries) ListBar(ctx context.Context) ([]interface{}, error) {
+func (q *Queries) ListBar(ctx context.Context) ([]any, error) {
 	rows, err := q.db.QueryContext(ctx, listBar)
 	if err != nil {
 		return nil, err
 	}
 	defer rows.Close()
-	var items []interface{}
+	var items []any
 	for rows.Next() {
-		var bar interface{}
+		var bar any
 		if err := rows.Scan(&bar); err != nil {
 			return nil, err
 		}
@@ -40,15 +40,15 @@ const listBaz = `-- name: ListBaz :many
 SELECT baz FROM foo
 `
 
-func (q *Queries) ListBaz(ctx context.Context) ([]interface{}, error) {
+func (q *Queries) ListBaz(ctx context.Context) ([]any, error) {
 	rows, err := q.db.QueryContext(ctx, listBaz)
 	if err != nil {
 		return nil, err
 	}
 	defer rows.Close()
-	var items []interface{}
+	var items []any
 	for rows.Next() {
-		var baz interface{}
+		var baz any
 		if err := rows.Scan(&baz); err != nil {
 			return nil, err
 		}

--- a/internal/endtoend/testdata/hstore/stdlib/go/models.go
+++ b/internal/endtoend/testdata/hstore/stdlib/go/models.go
@@ -5,6 +5,6 @@
 package hstore
 
 type Foo struct {
-	Bar interface{}
-	Baz interface{}
+	Bar any
+	Baz any
 }

--- a/internal/endtoend/testdata/identical_tables/mysql/go/db.go
+++ b/internal/endtoend/testdata/identical_tables/mysql/go/db.go
@@ -10,10 +10,10 @@ import (
 )
 
 type DBTX interface {
-	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
 	PrepareContext(context.Context, string) (*sql.Stmt, error)
-	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
-	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/identical_tables/postgresql/pgx/v4/go/db.go
+++ b/internal/endtoend/testdata/identical_tables/postgresql/pgx/v4/go/db.go
@@ -12,9 +12,9 @@ import (
 )
 
 type DBTX interface {
-	Exec(context.Context, string, ...interface{}) (pgconn.CommandTag, error)
-	Query(context.Context, string, ...interface{}) (pgx.Rows, error)
-	QueryRow(context.Context, string, ...interface{}) pgx.Row
+	Exec(context.Context, string, ...any) (pgconn.CommandTag, error)
+	Query(context.Context, string, ...any) (pgx.Rows, error)
+	QueryRow(context.Context, string, ...any) pgx.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/identical_tables/postgresql/pgx/v5/go/db.go
+++ b/internal/endtoend/testdata/identical_tables/postgresql/pgx/v5/go/db.go
@@ -12,9 +12,9 @@ import (
 )
 
 type DBTX interface {
-	Exec(context.Context, string, ...interface{}) (pgconn.CommandTag, error)
-	Query(context.Context, string, ...interface{}) (pgx.Rows, error)
-	QueryRow(context.Context, string, ...interface{}) pgx.Row
+	Exec(context.Context, string, ...any) (pgconn.CommandTag, error)
+	Query(context.Context, string, ...any) (pgx.Rows, error)
+	QueryRow(context.Context, string, ...any) pgx.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/identical_tables/postgresql/stdlib/go/db.go
+++ b/internal/endtoend/testdata/identical_tables/postgresql/stdlib/go/db.go
@@ -10,10 +10,10 @@ import (
 )
 
 type DBTX interface {
-	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
 	PrepareContext(context.Context, string) (*sql.Stmt, error)
-	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
-	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/identical_tables/sqlite/go/db.go
+++ b/internal/endtoend/testdata/identical_tables/sqlite/go/db.go
@@ -10,10 +10,10 @@ import (
 )
 
 type DBTX interface {
-	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
 	PrepareContext(context.Context, string) (*sql.Stmt, error)
-	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
-	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/identifier_case_sensitivity/db/db.go
+++ b/internal/endtoend/testdata/identifier_case_sensitivity/db/db.go
@@ -10,10 +10,10 @@ import (
 )
 
 type DBTX interface {
-	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
 	PrepareContext(context.Context, string) (*sql.Stmt, error)
-	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
-	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/identifier_dollar_sign/db/db.go
+++ b/internal/endtoend/testdata/identifier_dollar_sign/db/db.go
@@ -10,10 +10,10 @@ import (
 )
 
 type DBTX interface {
-	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
 	PrepareContext(context.Context, string) (*sql.Stmt, error)
-	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
-	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/in_union/mysql/go/db.go
+++ b/internal/endtoend/testdata/in_union/mysql/go/db.go
@@ -10,10 +10,10 @@ import (
 )
 
 type DBTX interface {
-	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
 	PrepareContext(context.Context, string) (*sql.Stmt, error)
-	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
-	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/inflection/mysql/go/db.go
+++ b/internal/endtoend/testdata/inflection/mysql/go/db.go
@@ -10,10 +10,10 @@ import (
 )
 
 type DBTX interface {
-	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
 	PrepareContext(context.Context, string) (*sql.Stmt, error)
-	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
-	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/inflection/postgresql/pgx/v4/go/db.go
+++ b/internal/endtoend/testdata/inflection/postgresql/pgx/v4/go/db.go
@@ -12,9 +12,9 @@ import (
 )
 
 type DBTX interface {
-	Exec(context.Context, string, ...interface{}) (pgconn.CommandTag, error)
-	Query(context.Context, string, ...interface{}) (pgx.Rows, error)
-	QueryRow(context.Context, string, ...interface{}) pgx.Row
+	Exec(context.Context, string, ...any) (pgconn.CommandTag, error)
+	Query(context.Context, string, ...any) (pgx.Rows, error)
+	QueryRow(context.Context, string, ...any) pgx.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/inflection/postgresql/pgx/v5/go/db.go
+++ b/internal/endtoend/testdata/inflection/postgresql/pgx/v5/go/db.go
@@ -12,9 +12,9 @@ import (
 )
 
 type DBTX interface {
-	Exec(context.Context, string, ...interface{}) (pgconn.CommandTag, error)
-	Query(context.Context, string, ...interface{}) (pgx.Rows, error)
-	QueryRow(context.Context, string, ...interface{}) pgx.Row
+	Exec(context.Context, string, ...any) (pgconn.CommandTag, error)
+	Query(context.Context, string, ...any) (pgx.Rows, error)
+	QueryRow(context.Context, string, ...any) pgx.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/inflection/postgresql/stdlib/go/db.go
+++ b/internal/endtoend/testdata/inflection/postgresql/stdlib/go/db.go
@@ -10,10 +10,10 @@ import (
 )
 
 type DBTX interface {
-	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
 	PrepareContext(context.Context, string) (*sql.Stmt, error)
-	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
-	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/inflection/sqlite/go/db.go
+++ b/internal/endtoend/testdata/inflection/sqlite/go/db.go
@@ -10,10 +10,10 @@ import (
 )
 
 type DBTX interface {
-	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
 	PrepareContext(context.Context, string) (*sql.Stmt, error)
-	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
-	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/inflection_exclude_table_names/postgresql/pgx/v4/go/db.go
+++ b/internal/endtoend/testdata/inflection_exclude_table_names/postgresql/pgx/v4/go/db.go
@@ -12,9 +12,9 @@ import (
 )
 
 type DBTX interface {
-	Exec(context.Context, string, ...interface{}) (pgconn.CommandTag, error)
-	Query(context.Context, string, ...interface{}) (pgx.Rows, error)
-	QueryRow(context.Context, string, ...interface{}) pgx.Row
+	Exec(context.Context, string, ...any) (pgconn.CommandTag, error)
+	Query(context.Context, string, ...any) (pgx.Rows, error)
+	QueryRow(context.Context, string, ...any) pgx.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/inflection_exclude_table_names/postgresql/pgx/v5/go/db.go
+++ b/internal/endtoend/testdata/inflection_exclude_table_names/postgresql/pgx/v5/go/db.go
@@ -12,9 +12,9 @@ import (
 )
 
 type DBTX interface {
-	Exec(context.Context, string, ...interface{}) (pgconn.CommandTag, error)
-	Query(context.Context, string, ...interface{}) (pgx.Rows, error)
-	QueryRow(context.Context, string, ...interface{}) pgx.Row
+	Exec(context.Context, string, ...any) (pgconn.CommandTag, error)
+	Query(context.Context, string, ...any) (pgx.Rows, error)
+	QueryRow(context.Context, string, ...any) pgx.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/insert_cte/pgx/v4/go/db.go
+++ b/internal/endtoend/testdata/insert_cte/pgx/v4/go/db.go
@@ -12,9 +12,9 @@ import (
 )
 
 type DBTX interface {
-	Exec(context.Context, string, ...interface{}) (pgconn.CommandTag, error)
-	Query(context.Context, string, ...interface{}) (pgx.Rows, error)
-	QueryRow(context.Context, string, ...interface{}) pgx.Row
+	Exec(context.Context, string, ...any) (pgconn.CommandTag, error)
+	Query(context.Context, string, ...any) (pgx.Rows, error)
+	QueryRow(context.Context, string, ...any) pgx.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/insert_cte/pgx/v5/go/db.go
+++ b/internal/endtoend/testdata/insert_cte/pgx/v5/go/db.go
@@ -12,9 +12,9 @@ import (
 )
 
 type DBTX interface {
-	Exec(context.Context, string, ...interface{}) (pgconn.CommandTag, error)
-	Query(context.Context, string, ...interface{}) (pgx.Rows, error)
-	QueryRow(context.Context, string, ...interface{}) pgx.Row
+	Exec(context.Context, string, ...any) (pgconn.CommandTag, error)
+	Query(context.Context, string, ...any) (pgx.Rows, error)
+	QueryRow(context.Context, string, ...any) pgx.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/insert_cte/stdlib/go/db.go
+++ b/internal/endtoend/testdata/insert_cte/stdlib/go/db.go
@@ -10,10 +10,10 @@ import (
 )
 
 type DBTX interface {
-	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
 	PrepareContext(context.Context, string) (*sql.Stmt, error)
-	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
-	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/insert_default_values/sqlite/go/db.go
+++ b/internal/endtoend/testdata/insert_default_values/sqlite/go/db.go
@@ -10,10 +10,10 @@ import (
 )
 
 type DBTX interface {
-	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
 	PrepareContext(context.Context, string) (*sql.Stmt, error)
-	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
-	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/insert_select/mysql/go/db.go
+++ b/internal/endtoend/testdata/insert_select/mysql/go/db.go
@@ -10,10 +10,10 @@ import (
 )
 
 type DBTX interface {
-	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
 	PrepareContext(context.Context, string) (*sql.Stmt, error)
-	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
-	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/insert_select/postgresql/pgx/v4/go/db.go
+++ b/internal/endtoend/testdata/insert_select/postgresql/pgx/v4/go/db.go
@@ -12,9 +12,9 @@ import (
 )
 
 type DBTX interface {
-	Exec(context.Context, string, ...interface{}) (pgconn.CommandTag, error)
-	Query(context.Context, string, ...interface{}) (pgx.Rows, error)
-	QueryRow(context.Context, string, ...interface{}) pgx.Row
+	Exec(context.Context, string, ...any) (pgconn.CommandTag, error)
+	Query(context.Context, string, ...any) (pgx.Rows, error)
+	QueryRow(context.Context, string, ...any) pgx.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/insert_select/postgresql/pgx/v5/go/db.go
+++ b/internal/endtoend/testdata/insert_select/postgresql/pgx/v5/go/db.go
@@ -12,9 +12,9 @@ import (
 )
 
 type DBTX interface {
-	Exec(context.Context, string, ...interface{}) (pgconn.CommandTag, error)
-	Query(context.Context, string, ...interface{}) (pgx.Rows, error)
-	QueryRow(context.Context, string, ...interface{}) pgx.Row
+	Exec(context.Context, string, ...any) (pgconn.CommandTag, error)
+	Query(context.Context, string, ...any) (pgx.Rows, error)
+	QueryRow(context.Context, string, ...any) pgx.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/insert_select/postgresql/stdlib/go/db.go
+++ b/internal/endtoend/testdata/insert_select/postgresql/stdlib/go/db.go
@@ -10,10 +10,10 @@ import (
 )
 
 type DBTX interface {
-	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
 	PrepareContext(context.Context, string) (*sql.Stmt, error)
-	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
-	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/insert_select/sqlite/go/db.go
+++ b/internal/endtoend/testdata/insert_select/sqlite/go/db.go
@@ -10,10 +10,10 @@ import (
 )
 
 type DBTX interface {
-	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
 	PrepareContext(context.Context, string) (*sql.Stmt, error)
-	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
-	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/insert_select_case/postgresql/pgx/go/db.go
+++ b/internal/endtoend/testdata/insert_select_case/postgresql/pgx/go/db.go
@@ -12,9 +12,9 @@ import (
 )
 
 type DBTX interface {
-	Exec(context.Context, string, ...interface{}) (pgconn.CommandTag, error)
-	Query(context.Context, string, ...interface{}) (pgx.Rows, error)
-	QueryRow(context.Context, string, ...interface{}) pgx.Row
+	Exec(context.Context, string, ...any) (pgconn.CommandTag, error)
+	Query(context.Context, string, ...any) (pgx.Rows, error)
+	QueryRow(context.Context, string, ...any) pgx.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/insert_select_param/postgresql/pgx/go/db.go
+++ b/internal/endtoend/testdata/insert_select_param/postgresql/pgx/go/db.go
@@ -12,9 +12,9 @@ import (
 )
 
 type DBTX interface {
-	Exec(context.Context, string, ...interface{}) (pgconn.CommandTag, error)
-	Query(context.Context, string, ...interface{}) (pgx.Rows, error)
-	QueryRow(context.Context, string, ...interface{}) pgx.Row
+	Exec(context.Context, string, ...any) (pgconn.CommandTag, error)
+	Query(context.Context, string, ...any) (pgx.Rows, error)
+	QueryRow(context.Context, string, ...any) pgx.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/insert_values/mysql/go/db.go
+++ b/internal/endtoend/testdata/insert_values/mysql/go/db.go
@@ -10,10 +10,10 @@ import (
 )
 
 type DBTX interface {
-	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
 	PrepareContext(context.Context, string) (*sql.Stmt, error)
-	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
-	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/insert_values/postgresql/pgx/v4/go/db.go
+++ b/internal/endtoend/testdata/insert_values/postgresql/pgx/v4/go/db.go
@@ -12,9 +12,9 @@ import (
 )
 
 type DBTX interface {
-	Exec(context.Context, string, ...interface{}) (pgconn.CommandTag, error)
-	Query(context.Context, string, ...interface{}) (pgx.Rows, error)
-	QueryRow(context.Context, string, ...interface{}) pgx.Row
+	Exec(context.Context, string, ...any) (pgconn.CommandTag, error)
+	Query(context.Context, string, ...any) (pgx.Rows, error)
+	QueryRow(context.Context, string, ...any) pgx.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/insert_values/postgresql/pgx/v5/go/db.go
+++ b/internal/endtoend/testdata/insert_values/postgresql/pgx/v5/go/db.go
@@ -12,9 +12,9 @@ import (
 )
 
 type DBTX interface {
-	Exec(context.Context, string, ...interface{}) (pgconn.CommandTag, error)
-	Query(context.Context, string, ...interface{}) (pgx.Rows, error)
-	QueryRow(context.Context, string, ...interface{}) pgx.Row
+	Exec(context.Context, string, ...any) (pgconn.CommandTag, error)
+	Query(context.Context, string, ...any) (pgx.Rows, error)
+	QueryRow(context.Context, string, ...any) pgx.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/insert_values/postgresql/stdlib/go/db.go
+++ b/internal/endtoend/testdata/insert_values/postgresql/stdlib/go/db.go
@@ -10,10 +10,10 @@ import (
 )
 
 type DBTX interface {
-	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
 	PrepareContext(context.Context, string) (*sql.Stmt, error)
-	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
-	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/insert_values/sqlite/go/db.go
+++ b/internal/endtoend/testdata/insert_values/sqlite/go/db.go
@@ -10,10 +10,10 @@ import (
 )
 
 type DBTX interface {
-	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
 	PrepareContext(context.Context, string) (*sql.Stmt, error)
-	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
-	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/insert_values_only/postgresql/pgx/go/db.go
+++ b/internal/endtoend/testdata/insert_values_only/postgresql/pgx/go/db.go
@@ -12,9 +12,9 @@ import (
 )
 
 type DBTX interface {
-	Exec(context.Context, string, ...interface{}) (pgconn.CommandTag, error)
-	Query(context.Context, string, ...interface{}) (pgx.Rows, error)
-	QueryRow(context.Context, string, ...interface{}) pgx.Row
+	Exec(context.Context, string, ...any) (pgconn.CommandTag, error)
+	Query(context.Context, string, ...any) (pgx.Rows, error)
+	QueryRow(context.Context, string, ...any) pgx.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/insert_values_public/mysql/go/db.go
+++ b/internal/endtoend/testdata/insert_values_public/mysql/go/db.go
@@ -10,10 +10,10 @@ import (
 )
 
 type DBTX interface {
-	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
 	PrepareContext(context.Context, string) (*sql.Stmt, error)
-	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
-	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/insert_values_public/postgresql/pgx/v4/go/db.go
+++ b/internal/endtoend/testdata/insert_values_public/postgresql/pgx/v4/go/db.go
@@ -12,9 +12,9 @@ import (
 )
 
 type DBTX interface {
-	Exec(context.Context, string, ...interface{}) (pgconn.CommandTag, error)
-	Query(context.Context, string, ...interface{}) (pgx.Rows, error)
-	QueryRow(context.Context, string, ...interface{}) pgx.Row
+	Exec(context.Context, string, ...any) (pgconn.CommandTag, error)
+	Query(context.Context, string, ...any) (pgx.Rows, error)
+	QueryRow(context.Context, string, ...any) pgx.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/insert_values_public/postgresql/pgx/v5/go/db.go
+++ b/internal/endtoend/testdata/insert_values_public/postgresql/pgx/v5/go/db.go
@@ -12,9 +12,9 @@ import (
 )
 
 type DBTX interface {
-	Exec(context.Context, string, ...interface{}) (pgconn.CommandTag, error)
-	Query(context.Context, string, ...interface{}) (pgx.Rows, error)
-	QueryRow(context.Context, string, ...interface{}) pgx.Row
+	Exec(context.Context, string, ...any) (pgconn.CommandTag, error)
+	Query(context.Context, string, ...any) (pgx.Rows, error)
+	QueryRow(context.Context, string, ...any) pgx.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/insert_values_public/postgresql/stdlib/go/db.go
+++ b/internal/endtoend/testdata/insert_values_public/postgresql/stdlib/go/db.go
@@ -10,10 +10,10 @@ import (
 )
 
 type DBTX interface {
-	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
 	PrepareContext(context.Context, string) (*sql.Stmt, error)
-	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
-	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/interval/pgx/v4/go/db.go
+++ b/internal/endtoend/testdata/interval/pgx/v4/go/db.go
@@ -12,9 +12,9 @@ import (
 )
 
 type DBTX interface {
-	Exec(context.Context, string, ...interface{}) (pgconn.CommandTag, error)
-	Query(context.Context, string, ...interface{}) (pgx.Rows, error)
-	QueryRow(context.Context, string, ...interface{}) pgx.Row
+	Exec(context.Context, string, ...any) (pgconn.CommandTag, error)
+	Query(context.Context, string, ...any) (pgx.Rows, error)
+	QueryRow(context.Context, string, ...any) pgx.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/interval/pgx/v5/go/db.go
+++ b/internal/endtoend/testdata/interval/pgx/v5/go/db.go
@@ -12,9 +12,9 @@ import (
 )
 
 type DBTX interface {
-	Exec(context.Context, string, ...interface{}) (pgconn.CommandTag, error)
-	Query(context.Context, string, ...interface{}) (pgx.Rows, error)
-	QueryRow(context.Context, string, ...interface{}) pgx.Row
+	Exec(context.Context, string, ...any) (pgconn.CommandTag, error)
+	Query(context.Context, string, ...any) (pgx.Rows, error)
+	QueryRow(context.Context, string, ...any) pgx.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/interval/stdlib/go/db.go
+++ b/internal/endtoend/testdata/interval/stdlib/go/db.go
@@ -10,10 +10,10 @@ import (
 )
 
 type DBTX interface {
-	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
 	PrepareContext(context.Context, string) (*sql.Stmt, error)
-	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
-	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/invalid_insert_unknown_column/postgresql/pgx/db/db.go
+++ b/internal/endtoend/testdata/invalid_insert_unknown_column/postgresql/pgx/db/db.go
@@ -12,9 +12,9 @@ import (
 )
 
 type DBTX interface {
-	Exec(context.Context, string, ...interface{}) (pgconn.CommandTag, error)
-	Query(context.Context, string, ...interface{}) (pgx.Rows, error)
-	QueryRow(context.Context, string, ...interface{}) pgx.Row
+	Exec(context.Context, string, ...any) (pgconn.CommandTag, error)
+	Query(context.Context, string, ...any) (pgx.Rows, error)
+	QueryRow(context.Context, string, ...any) pgx.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/join_alias/mysql/go/db.go
+++ b/internal/endtoend/testdata/join_alias/mysql/go/db.go
@@ -10,10 +10,10 @@ import (
 )
 
 type DBTX interface {
-	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
 	PrepareContext(context.Context, string) (*sql.Stmt, error)
-	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
-	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/join_alias/postgresql/pgx/v4/go/db.go
+++ b/internal/endtoend/testdata/join_alias/postgresql/pgx/v4/go/db.go
@@ -12,9 +12,9 @@ import (
 )
 
 type DBTX interface {
-	Exec(context.Context, string, ...interface{}) (pgconn.CommandTag, error)
-	Query(context.Context, string, ...interface{}) (pgx.Rows, error)
-	QueryRow(context.Context, string, ...interface{}) pgx.Row
+	Exec(context.Context, string, ...any) (pgconn.CommandTag, error)
+	Query(context.Context, string, ...any) (pgx.Rows, error)
+	QueryRow(context.Context, string, ...any) pgx.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/join_alias/postgresql/pgx/v5/go/db.go
+++ b/internal/endtoend/testdata/join_alias/postgresql/pgx/v5/go/db.go
@@ -12,9 +12,9 @@ import (
 )
 
 type DBTX interface {
-	Exec(context.Context, string, ...interface{}) (pgconn.CommandTag, error)
-	Query(context.Context, string, ...interface{}) (pgx.Rows, error)
-	QueryRow(context.Context, string, ...interface{}) pgx.Row
+	Exec(context.Context, string, ...any) (pgconn.CommandTag, error)
+	Query(context.Context, string, ...any) (pgx.Rows, error)
+	QueryRow(context.Context, string, ...any) pgx.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/join_alias/postgresql/stdlib/go/db.go
+++ b/internal/endtoend/testdata/join_alias/postgresql/stdlib/go/db.go
@@ -10,10 +10,10 @@ import (
 )
 
 type DBTX interface {
-	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
 	PrepareContext(context.Context, string) (*sql.Stmt, error)
-	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
-	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/join_alias/sqlite/go/db.go
+++ b/internal/endtoend/testdata/join_alias/sqlite/go/db.go
@@ -10,10 +10,10 @@ import (
 )
 
 type DBTX interface {
-	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
 	PrepareContext(context.Context, string) (*sql.Stmt, error)
-	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
-	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/join_clauses_order/postgresql/go/db.go
+++ b/internal/endtoend/testdata/join_clauses_order/postgresql/go/db.go
@@ -10,10 +10,10 @@ import (
 )
 
 type DBTX interface {
-	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
 	PrepareContext(context.Context, string) (*sql.Stmt, error)
-	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
-	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/join_from/mysql/go/db.go
+++ b/internal/endtoend/testdata/join_from/mysql/go/db.go
@@ -10,10 +10,10 @@ import (
 )
 
 type DBTX interface {
-	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
 	PrepareContext(context.Context, string) (*sql.Stmt, error)
-	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
-	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/join_from/postgresql/pgx/v4/go/db.go
+++ b/internal/endtoend/testdata/join_from/postgresql/pgx/v4/go/db.go
@@ -12,9 +12,9 @@ import (
 )
 
 type DBTX interface {
-	Exec(context.Context, string, ...interface{}) (pgconn.CommandTag, error)
-	Query(context.Context, string, ...interface{}) (pgx.Rows, error)
-	QueryRow(context.Context, string, ...interface{}) pgx.Row
+	Exec(context.Context, string, ...any) (pgconn.CommandTag, error)
+	Query(context.Context, string, ...any) (pgx.Rows, error)
+	QueryRow(context.Context, string, ...any) pgx.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/join_from/postgresql/pgx/v5/go/db.go
+++ b/internal/endtoend/testdata/join_from/postgresql/pgx/v5/go/db.go
@@ -12,9 +12,9 @@ import (
 )
 
 type DBTX interface {
-	Exec(context.Context, string, ...interface{}) (pgconn.CommandTag, error)
-	Query(context.Context, string, ...interface{}) (pgx.Rows, error)
-	QueryRow(context.Context, string, ...interface{}) pgx.Row
+	Exec(context.Context, string, ...any) (pgconn.CommandTag, error)
+	Query(context.Context, string, ...any) (pgx.Rows, error)
+	QueryRow(context.Context, string, ...any) pgx.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/join_from/postgresql/stdlib/go/db.go
+++ b/internal/endtoend/testdata/join_from/postgresql/stdlib/go/db.go
@@ -10,10 +10,10 @@ import (
 )
 
 type DBTX interface {
-	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
 	PrepareContext(context.Context, string) (*sql.Stmt, error)
-	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
-	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/join_from/sqlite/go/db.go
+++ b/internal/endtoend/testdata/join_from/sqlite/go/db.go
@@ -10,10 +10,10 @@ import (
 )
 
 type DBTX interface {
-	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
 	PrepareContext(context.Context, string) (*sql.Stmt, error)
-	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
-	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/join_full/postgresql/go/db.go
+++ b/internal/endtoend/testdata/join_full/postgresql/go/db.go
@@ -10,10 +10,10 @@ import (
 )
 
 type DBTX interface {
-	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
 	PrepareContext(context.Context, string) (*sql.Stmt, error)
-	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
-	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/join_group_by_alias/postgresql/stdlib/go/db.go
+++ b/internal/endtoend/testdata/join_group_by_alias/postgresql/stdlib/go/db.go
@@ -10,10 +10,10 @@ import (
 )
 
 type DBTX interface {
-	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
 	PrepareContext(context.Context, string) (*sql.Stmt, error)
-	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
-	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/join_inner/postgresql/go/db.go
+++ b/internal/endtoend/testdata/join_inner/postgresql/go/db.go
@@ -10,10 +10,10 @@ import (
 )
 
 type DBTX interface {
-	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
 	PrepareContext(context.Context, string) (*sql.Stmt, error)
-	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
-	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/join_left/mysql/go/db.go
+++ b/internal/endtoend/testdata/join_left/mysql/go/db.go
@@ -10,10 +10,10 @@ import (
 )
 
 type DBTX interface {
-	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
 	PrepareContext(context.Context, string) (*sql.Stmt, error)
-	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
-	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/join_left/postgresql/go/db.go
+++ b/internal/endtoend/testdata/join_left/postgresql/go/db.go
@@ -10,10 +10,10 @@ import (
 )
 
 type DBTX interface {
-	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
 	PrepareContext(context.Context, string) (*sql.Stmt, error)
-	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
-	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/join_left/sqlite/go/db.go
+++ b/internal/endtoend/testdata/join_left/sqlite/go/db.go
@@ -10,10 +10,10 @@ import (
 )
 
 type DBTX interface {
-	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
 	PrepareContext(context.Context, string) (*sql.Stmt, error)
-	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
-	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/join_left_same_table/mysql/go/db.go
+++ b/internal/endtoend/testdata/join_left_same_table/mysql/go/db.go
@@ -10,10 +10,10 @@ import (
 )
 
 type DBTX interface {
-	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
 	PrepareContext(context.Context, string) (*sql.Stmt, error)
-	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
-	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/join_left_same_table/postgres/go/db.go
+++ b/internal/endtoend/testdata/join_left_same_table/postgres/go/db.go
@@ -10,10 +10,10 @@ import (
 )
 
 type DBTX interface {
-	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
 	PrepareContext(context.Context, string) (*sql.Stmt, error)
-	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
-	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/join_left_same_table/sqlite/go/db.go
+++ b/internal/endtoend/testdata/join_left_same_table/sqlite/go/db.go
@@ -10,10 +10,10 @@ import (
 )
 
 type DBTX interface {
-	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
 	PrepareContext(context.Context, string) (*sql.Stmt, error)
-	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
-	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/join_left_table_alias/postgresql/pgx/go/db.go
+++ b/internal/endtoend/testdata/join_left_table_alias/postgresql/pgx/go/db.go
@@ -12,9 +12,9 @@ import (
 )
 
 type DBTX interface {
-	Exec(context.Context, string, ...interface{}) (pgconn.CommandTag, error)
-	Query(context.Context, string, ...interface{}) (pgx.Rows, error)
-	QueryRow(context.Context, string, ...interface{}) pgx.Row
+	Exec(context.Context, string, ...any) (pgconn.CommandTag, error)
+	Query(context.Context, string, ...any) (pgx.Rows, error)
+	QueryRow(context.Context, string, ...any) pgx.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/join_order_by/postgresql/pgx/go/db.go
+++ b/internal/endtoend/testdata/join_order_by/postgresql/pgx/go/db.go
@@ -12,9 +12,9 @@ import (
 )
 
 type DBTX interface {
-	Exec(context.Context, string, ...interface{}) (pgconn.CommandTag, error)
-	Query(context.Context, string, ...interface{}) (pgx.Rows, error)
-	QueryRow(context.Context, string, ...interface{}) pgx.Row
+	Exec(context.Context, string, ...any) (pgconn.CommandTag, error)
+	Query(context.Context, string, ...any) (pgx.Rows, error)
+	QueryRow(context.Context, string, ...any) pgx.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/join_order_by_alias/postgresql/stdlib/go/db.go
+++ b/internal/endtoend/testdata/join_order_by_alias/postgresql/stdlib/go/db.go
@@ -10,10 +10,10 @@ import (
 )
 
 type DBTX interface {
-	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
 	PrepareContext(context.Context, string) (*sql.Stmt, error)
-	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
-	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/join_right/mysql/go/db.go
+++ b/internal/endtoend/testdata/join_right/mysql/go/db.go
@@ -10,10 +10,10 @@ import (
 )
 
 type DBTX interface {
-	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
 	PrepareContext(context.Context, string) (*sql.Stmt, error)
-	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
-	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/join_right/postgresql/go/db.go
+++ b/internal/endtoend/testdata/join_right/postgresql/go/db.go
@@ -10,10 +10,10 @@ import (
 )
 
 type DBTX interface {
-	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
 	PrepareContext(context.Context, string) (*sql.Stmt, error)
-	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
-	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/join_table_name/mysql/go/db.go
+++ b/internal/endtoend/testdata/join_table_name/mysql/go/db.go
@@ -10,10 +10,10 @@ import (
 )
 
 type DBTX interface {
-	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
 	PrepareContext(context.Context, string) (*sql.Stmt, error)
-	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
-	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/join_table_name/postgresql/pgx/v4/go/db.go
+++ b/internal/endtoend/testdata/join_table_name/postgresql/pgx/v4/go/db.go
@@ -12,9 +12,9 @@ import (
 )
 
 type DBTX interface {
-	Exec(context.Context, string, ...interface{}) (pgconn.CommandTag, error)
-	Query(context.Context, string, ...interface{}) (pgx.Rows, error)
-	QueryRow(context.Context, string, ...interface{}) pgx.Row
+	Exec(context.Context, string, ...any) (pgconn.CommandTag, error)
+	Query(context.Context, string, ...any) (pgx.Rows, error)
+	QueryRow(context.Context, string, ...any) pgx.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/join_table_name/postgresql/pgx/v5/go/db.go
+++ b/internal/endtoend/testdata/join_table_name/postgresql/pgx/v5/go/db.go
@@ -12,9 +12,9 @@ import (
 )
 
 type DBTX interface {
-	Exec(context.Context, string, ...interface{}) (pgconn.CommandTag, error)
-	Query(context.Context, string, ...interface{}) (pgx.Rows, error)
-	QueryRow(context.Context, string, ...interface{}) pgx.Row
+	Exec(context.Context, string, ...any) (pgconn.CommandTag, error)
+	Query(context.Context, string, ...any) (pgx.Rows, error)
+	QueryRow(context.Context, string, ...any) pgx.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/join_table_name/postgresql/stdlib/go/db.go
+++ b/internal/endtoend/testdata/join_table_name/postgresql/stdlib/go/db.go
@@ -10,10 +10,10 @@ import (
 )
 
 type DBTX interface {
-	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
 	PrepareContext(context.Context, string) (*sql.Stmt, error)
-	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
-	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/join_table_name/sqlite/go/db.go
+++ b/internal/endtoend/testdata/join_table_name/sqlite/go/db.go
@@ -10,10 +10,10 @@ import (
 )
 
 type DBTX interface {
-	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
 	PrepareContext(context.Context, string) (*sql.Stmt, error)
-	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
-	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/join_two_tables/mysql/go/db.go
+++ b/internal/endtoend/testdata/join_two_tables/mysql/go/db.go
@@ -10,10 +10,10 @@ import (
 )
 
 type DBTX interface {
-	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
 	PrepareContext(context.Context, string) (*sql.Stmt, error)
-	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
-	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/join_two_tables/postgresql/pgx/v4/go/db.go
+++ b/internal/endtoend/testdata/join_two_tables/postgresql/pgx/v4/go/db.go
@@ -12,9 +12,9 @@ import (
 )
 
 type DBTX interface {
-	Exec(context.Context, string, ...interface{}) (pgconn.CommandTag, error)
-	Query(context.Context, string, ...interface{}) (pgx.Rows, error)
-	QueryRow(context.Context, string, ...interface{}) pgx.Row
+	Exec(context.Context, string, ...any) (pgconn.CommandTag, error)
+	Query(context.Context, string, ...any) (pgx.Rows, error)
+	QueryRow(context.Context, string, ...any) pgx.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/join_two_tables/postgresql/pgx/v5/go/db.go
+++ b/internal/endtoend/testdata/join_two_tables/postgresql/pgx/v5/go/db.go
@@ -12,9 +12,9 @@ import (
 )
 
 type DBTX interface {
-	Exec(context.Context, string, ...interface{}) (pgconn.CommandTag, error)
-	Query(context.Context, string, ...interface{}) (pgx.Rows, error)
-	QueryRow(context.Context, string, ...interface{}) pgx.Row
+	Exec(context.Context, string, ...any) (pgconn.CommandTag, error)
+	Query(context.Context, string, ...any) (pgx.Rows, error)
+	QueryRow(context.Context, string, ...any) pgx.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/join_two_tables/postgresql/stdlib/go/db.go
+++ b/internal/endtoend/testdata/join_two_tables/postgresql/stdlib/go/db.go
@@ -10,10 +10,10 @@ import (
 )
 
 type DBTX interface {
-	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
 	PrepareContext(context.Context, string) (*sql.Stmt, error)
-	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
-	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/join_two_tables/sqlite/go/db.go
+++ b/internal/endtoend/testdata/join_two_tables/sqlite/go/db.go
@@ -10,10 +10,10 @@ import (
 )
 
 type DBTX interface {
-	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
 	PrepareContext(context.Context, string) (*sql.Stmt, error)
-	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
-	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/join_update/postgresql/pgx/go/db.go
+++ b/internal/endtoend/testdata/join_update/postgresql/pgx/go/db.go
@@ -12,9 +12,9 @@ import (
 )
 
 type DBTX interface {
-	Exec(context.Context, string, ...interface{}) (pgconn.CommandTag, error)
-	Query(context.Context, string, ...interface{}) (pgx.Rows, error)
-	QueryRow(context.Context, string, ...interface{}) pgx.Row
+	Exec(context.Context, string, ...any) (pgconn.CommandTag, error)
+	Query(context.Context, string, ...any) (pgx.Rows, error)
+	QueryRow(context.Context, string, ...any) pgx.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/join_using/postgresql/pgx/go/db.go
+++ b/internal/endtoend/testdata/join_using/postgresql/pgx/go/db.go
@@ -12,9 +12,9 @@ import (
 )
 
 type DBTX interface {
-	Exec(context.Context, string, ...interface{}) (pgconn.CommandTag, error)
-	Query(context.Context, string, ...interface{}) (pgx.Rows, error)
-	QueryRow(context.Context, string, ...interface{}) pgx.Row
+	Exec(context.Context, string, ...any) (pgconn.CommandTag, error)
+	Query(context.Context, string, ...any) (pgx.Rows, error)
+	QueryRow(context.Context, string, ...any) pgx.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/join_where_clause/mysql/go/db.go
+++ b/internal/endtoend/testdata/join_where_clause/mysql/go/db.go
@@ -10,10 +10,10 @@ import (
 )
 
 type DBTX interface {
-	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
 	PrepareContext(context.Context, string) (*sql.Stmt, error)
-	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
-	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/join_where_clause/postgresql/pgx/v4/go/db.go
+++ b/internal/endtoend/testdata/join_where_clause/postgresql/pgx/v4/go/db.go
@@ -12,9 +12,9 @@ import (
 )
 
 type DBTX interface {
-	Exec(context.Context, string, ...interface{}) (pgconn.CommandTag, error)
-	Query(context.Context, string, ...interface{}) (pgx.Rows, error)
-	QueryRow(context.Context, string, ...interface{}) pgx.Row
+	Exec(context.Context, string, ...any) (pgconn.CommandTag, error)
+	Query(context.Context, string, ...any) (pgx.Rows, error)
+	QueryRow(context.Context, string, ...any) pgx.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/join_where_clause/postgresql/pgx/v5/go/db.go
+++ b/internal/endtoend/testdata/join_where_clause/postgresql/pgx/v5/go/db.go
@@ -12,9 +12,9 @@ import (
 )
 
 type DBTX interface {
-	Exec(context.Context, string, ...interface{}) (pgconn.CommandTag, error)
-	Query(context.Context, string, ...interface{}) (pgx.Rows, error)
-	QueryRow(context.Context, string, ...interface{}) pgx.Row
+	Exec(context.Context, string, ...any) (pgconn.CommandTag, error)
+	Query(context.Context, string, ...any) (pgx.Rows, error)
+	QueryRow(context.Context, string, ...any) pgx.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/join_where_clause/postgresql/stdlib/go/db.go
+++ b/internal/endtoend/testdata/join_where_clause/postgresql/stdlib/go/db.go
@@ -10,10 +10,10 @@ import (
 )
 
 type DBTX interface {
-	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
 	PrepareContext(context.Context, string) (*sql.Stmt, error)
-	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
-	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/join_where_clause/sqlite/go/db.go
+++ b/internal/endtoend/testdata/join_where_clause/sqlite/go/db.go
@@ -10,10 +10,10 @@ import (
 )
 
 type DBTX interface {
-	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
 	PrepareContext(context.Context, string) (*sql.Stmt, error)
-	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
-	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/json/mysql/go/db.go
+++ b/internal/endtoend/testdata/json/mysql/go/db.go
@@ -10,10 +10,10 @@ import (
 )
 
 type DBTX interface {
-	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
 	PrepareContext(context.Context, string) (*sql.Stmt, error)
-	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
-	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/json/postgresql/pgx/v4/go/db.go
+++ b/internal/endtoend/testdata/json/postgresql/pgx/v4/go/db.go
@@ -12,9 +12,9 @@ import (
 )
 
 type DBTX interface {
-	Exec(context.Context, string, ...interface{}) (pgconn.CommandTag, error)
-	Query(context.Context, string, ...interface{}) (pgx.Rows, error)
-	QueryRow(context.Context, string, ...interface{}) pgx.Row
+	Exec(context.Context, string, ...any) (pgconn.CommandTag, error)
+	Query(context.Context, string, ...any) (pgx.Rows, error)
+	QueryRow(context.Context, string, ...any) pgx.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/json/postgresql/pgx/v5/go/db.go
+++ b/internal/endtoend/testdata/json/postgresql/pgx/v5/go/db.go
@@ -12,9 +12,9 @@ import (
 )
 
 type DBTX interface {
-	Exec(context.Context, string, ...interface{}) (pgconn.CommandTag, error)
-	Query(context.Context, string, ...interface{}) (pgx.Rows, error)
-	QueryRow(context.Context, string, ...interface{}) pgx.Row
+	Exec(context.Context, string, ...any) (pgconn.CommandTag, error)
+	Query(context.Context, string, ...any) (pgx.Rows, error)
+	QueryRow(context.Context, string, ...any) pgx.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/json/postgresql/stdlib/go/db.go
+++ b/internal/endtoend/testdata/json/postgresql/stdlib/go/db.go
@@ -10,10 +10,10 @@ import (
 )
 
 type DBTX interface {
-	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
 	PrepareContext(context.Context, string) (*sql.Stmt, error)
-	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
-	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/json_array_elements/postgresql/pgx/go/db.go
+++ b/internal/endtoend/testdata/json_array_elements/postgresql/pgx/go/db.go
@@ -12,9 +12,9 @@ import (
 )
 
 type DBTX interface {
-	Exec(context.Context, string, ...interface{}) (pgconn.CommandTag, error)
-	Query(context.Context, string, ...interface{}) (pgx.Rows, error)
-	QueryRow(context.Context, string, ...interface{}) pgx.Row
+	Exec(context.Context, string, ...any) (pgconn.CommandTag, error)
+	Query(context.Context, string, ...any) (pgx.Rows, error)
+	QueryRow(context.Context, string, ...any) pgx.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/json_build/postgresql/pgx/v4/go/db.go
+++ b/internal/endtoend/testdata/json_build/postgresql/pgx/v4/go/db.go
@@ -12,9 +12,9 @@ import (
 )
 
 type DBTX interface {
-	Exec(context.Context, string, ...interface{}) (pgconn.CommandTag, error)
-	Query(context.Context, string, ...interface{}) (pgx.Rows, error)
-	QueryRow(context.Context, string, ...interface{}) pgx.Row
+	Exec(context.Context, string, ...any) (pgconn.CommandTag, error)
+	Query(context.Context, string, ...any) (pgx.Rows, error)
+	QueryRow(context.Context, string, ...any) pgx.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/json_build/postgresql/pgx/v5/go/db.go
+++ b/internal/endtoend/testdata/json_build/postgresql/pgx/v5/go/db.go
@@ -12,9 +12,9 @@ import (
 )
 
 type DBTX interface {
-	Exec(context.Context, string, ...interface{}) (pgconn.CommandTag, error)
-	Query(context.Context, string, ...interface{}) (pgx.Rows, error)
-	QueryRow(context.Context, string, ...interface{}) pgx.Row
+	Exec(context.Context, string, ...any) (pgconn.CommandTag, error)
+	Query(context.Context, string, ...any) (pgx.Rows, error)
+	QueryRow(context.Context, string, ...any) pgx.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/json_build/postgresql/stdlib/go/db.go
+++ b/internal/endtoend/testdata/json_build/postgresql/stdlib/go/db.go
@@ -10,10 +10,10 @@ import (
 )
 
 type DBTX interface {
-	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
 	PrepareContext(context.Context, string) (*sql.Stmt, error)
-	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
-	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/json_param_type/postgresql/pgx/go/db.go
+++ b/internal/endtoend/testdata/json_param_type/postgresql/pgx/go/db.go
@@ -12,9 +12,9 @@ import (
 )
 
 type DBTX interface {
-	Exec(context.Context, string, ...interface{}) (pgconn.CommandTag, error)
-	Query(context.Context, string, ...interface{}) (pgx.Rows, error)
-	QueryRow(context.Context, string, ...interface{}) pgx.Row
+	Exec(context.Context, string, ...any) (pgconn.CommandTag, error)
+	Query(context.Context, string, ...any) (pgx.Rows, error)
+	QueryRow(context.Context, string, ...any) pgx.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/json_param_type/sqlite/go/db.go
+++ b/internal/endtoend/testdata/json_param_type/sqlite/go/db.go
@@ -10,10 +10,10 @@ import (
 )
 
 type DBTX interface {
-	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
 	PrepareContext(context.Context, string) (*sql.Stmt, error)
-	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
-	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/json_tags/camel_case/postgresql/pgx/v4/go/db.go
+++ b/internal/endtoend/testdata/json_tags/camel_case/postgresql/pgx/v4/go/db.go
@@ -12,9 +12,9 @@ import (
 )
 
 type DBTX interface {
-	Exec(context.Context, string, ...interface{}) (pgconn.CommandTag, error)
-	Query(context.Context, string, ...interface{}) (pgx.Rows, error)
-	QueryRow(context.Context, string, ...interface{}) pgx.Row
+	Exec(context.Context, string, ...any) (pgconn.CommandTag, error)
+	Query(context.Context, string, ...any) (pgx.Rows, error)
+	QueryRow(context.Context, string, ...any) pgx.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/json_tags/camel_case/postgresql/pgx/v5/go/db.go
+++ b/internal/endtoend/testdata/json_tags/camel_case/postgresql/pgx/v5/go/db.go
@@ -12,9 +12,9 @@ import (
 )
 
 type DBTX interface {
-	Exec(context.Context, string, ...interface{}) (pgconn.CommandTag, error)
-	Query(context.Context, string, ...interface{}) (pgx.Rows, error)
-	QueryRow(context.Context, string, ...interface{}) pgx.Row
+	Exec(context.Context, string, ...any) (pgconn.CommandTag, error)
+	Query(context.Context, string, ...any) (pgx.Rows, error)
+	QueryRow(context.Context, string, ...any) pgx.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/json_tags/camel_case/postgresql/stdlib/go/db.go
+++ b/internal/endtoend/testdata/json_tags/camel_case/postgresql/stdlib/go/db.go
@@ -10,10 +10,10 @@ import (
 )
 
 type DBTX interface {
-	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
 	PrepareContext(context.Context, string) (*sql.Stmt, error)
-	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
-	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/json_tags/pascal_case/postgresql/pgx/v4/go/db.go
+++ b/internal/endtoend/testdata/json_tags/pascal_case/postgresql/pgx/v4/go/db.go
@@ -12,9 +12,9 @@ import (
 )
 
 type DBTX interface {
-	Exec(context.Context, string, ...interface{}) (pgconn.CommandTag, error)
-	Query(context.Context, string, ...interface{}) (pgx.Rows, error)
-	QueryRow(context.Context, string, ...interface{}) pgx.Row
+	Exec(context.Context, string, ...any) (pgconn.CommandTag, error)
+	Query(context.Context, string, ...any) (pgx.Rows, error)
+	QueryRow(context.Context, string, ...any) pgx.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/json_tags/pascal_case/postgresql/pgx/v5/go/db.go
+++ b/internal/endtoend/testdata/json_tags/pascal_case/postgresql/pgx/v5/go/db.go
@@ -12,9 +12,9 @@ import (
 )
 
 type DBTX interface {
-	Exec(context.Context, string, ...interface{}) (pgconn.CommandTag, error)
-	Query(context.Context, string, ...interface{}) (pgx.Rows, error)
-	QueryRow(context.Context, string, ...interface{}) pgx.Row
+	Exec(context.Context, string, ...any) (pgconn.CommandTag, error)
+	Query(context.Context, string, ...any) (pgx.Rows, error)
+	QueryRow(context.Context, string, ...any) pgx.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/json_tags/pascal_case/postgresql/stdlib/go/db.go
+++ b/internal/endtoend/testdata/json_tags/pascal_case/postgresql/stdlib/go/db.go
@@ -10,10 +10,10 @@ import (
 )
 
 type DBTX interface {
-	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
 	PrepareContext(context.Context, string) (*sql.Stmt, error)
-	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
-	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/json_tags/snake_case/postgresql/pgx/v4/go/db.go
+++ b/internal/endtoend/testdata/json_tags/snake_case/postgresql/pgx/v4/go/db.go
@@ -12,9 +12,9 @@ import (
 )
 
 type DBTX interface {
-	Exec(context.Context, string, ...interface{}) (pgconn.CommandTag, error)
-	Query(context.Context, string, ...interface{}) (pgx.Rows, error)
-	QueryRow(context.Context, string, ...interface{}) pgx.Row
+	Exec(context.Context, string, ...any) (pgconn.CommandTag, error)
+	Query(context.Context, string, ...any) (pgx.Rows, error)
+	QueryRow(context.Context, string, ...any) pgx.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/json_tags/snake_case/postgresql/pgx/v5/go/db.go
+++ b/internal/endtoend/testdata/json_tags/snake_case/postgresql/pgx/v5/go/db.go
@@ -12,9 +12,9 @@ import (
 )
 
 type DBTX interface {
-	Exec(context.Context, string, ...interface{}) (pgconn.CommandTag, error)
-	Query(context.Context, string, ...interface{}) (pgx.Rows, error)
-	QueryRow(context.Context, string, ...interface{}) pgx.Row
+	Exec(context.Context, string, ...any) (pgconn.CommandTag, error)
+	Query(context.Context, string, ...any) (pgx.Rows, error)
+	QueryRow(context.Context, string, ...any) pgx.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/json_tags/snake_case/postgresql/stdlib/go/db.go
+++ b/internal/endtoend/testdata/json_tags/snake_case/postgresql/stdlib/go/db.go
@@ -10,10 +10,10 @@ import (
 )
 
 type DBTX interface {
-	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
 	PrepareContext(context.Context, string) (*sql.Stmt, error)
-	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
-	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/json_tags_null_enum/camel_case/postgresql/stdlib/go/db.go
+++ b/internal/endtoend/testdata/json_tags_null_enum/camel_case/postgresql/stdlib/go/db.go
@@ -10,10 +10,10 @@ import (
 )
 
 type DBTX interface {
-	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
 	PrepareContext(context.Context, string) (*sql.Stmt, error)
-	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
-	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/json_tags_null_enum/camel_case/postgresql/stdlib/go/models.go
+++ b/internal/endtoend/testdata/json_tags_null_enum/camel_case/postgresql/stdlib/go/models.go
@@ -18,7 +18,7 @@ const (
 	JobPostLocationTypeHybrid   JobPostLocationType = "hybrid"
 )
 
-func (e *JobPostLocationType) Scan(src interface{}) error {
+func (e *JobPostLocationType) Scan(src any) error {
 	switch s := src.(type) {
 	case []byte:
 		*e = JobPostLocationType(s)
@@ -36,7 +36,7 @@ type NullJobPostLocationType struct {
 }
 
 // Scan implements the Scanner interface.
-func (ns *NullJobPostLocationType) Scan(value interface{}) error {
+func (ns *NullJobPostLocationType) Scan(value any) error {
 	if value == nil {
 		ns.JobPostLocationType, ns.Valid = "", false
 		return nil

--- a/internal/endtoend/testdata/json_tags_null_enum/none/postgresql/stdlib/go/db.go
+++ b/internal/endtoend/testdata/json_tags_null_enum/none/postgresql/stdlib/go/db.go
@@ -10,10 +10,10 @@ import (
 )
 
 type DBTX interface {
-	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
 	PrepareContext(context.Context, string) (*sql.Stmt, error)
-	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
-	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/json_tags_null_enum/none/postgresql/stdlib/go/models.go
+++ b/internal/endtoend/testdata/json_tags_null_enum/none/postgresql/stdlib/go/models.go
@@ -18,7 +18,7 @@ const (
 	JobPostLocationTypeHybrid   JobPostLocationType = "hybrid"
 )
 
-func (e *JobPostLocationType) Scan(src interface{}) error {
+func (e *JobPostLocationType) Scan(src any) error {
 	switch s := src.(type) {
 	case []byte:
 		*e = JobPostLocationType(s)
@@ -36,7 +36,7 @@ type NullJobPostLocationType struct {
 }
 
 // Scan implements the Scanner interface.
-func (ns *NullJobPostLocationType) Scan(value interface{}) error {
+func (ns *NullJobPostLocationType) Scan(value any) error {
 	if value == nil {
 		ns.JobPostLocationType, ns.Valid = "", false
 		return nil

--- a/internal/endtoend/testdata/json_tags_null_enum/pascal_case/postgresql/stdlib/go/db.go
+++ b/internal/endtoend/testdata/json_tags_null_enum/pascal_case/postgresql/stdlib/go/db.go
@@ -10,10 +10,10 @@ import (
 )
 
 type DBTX interface {
-	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
 	PrepareContext(context.Context, string) (*sql.Stmt, error)
-	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
-	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/json_tags_null_enum/pascal_case/postgresql/stdlib/go/models.go
+++ b/internal/endtoend/testdata/json_tags_null_enum/pascal_case/postgresql/stdlib/go/models.go
@@ -18,7 +18,7 @@ const (
 	JobPostLocationTypeHybrid   JobPostLocationType = "hybrid"
 )
 
-func (e *JobPostLocationType) Scan(src interface{}) error {
+func (e *JobPostLocationType) Scan(src any) error {
 	switch s := src.(type) {
 	case []byte:
 		*e = JobPostLocationType(s)
@@ -36,7 +36,7 @@ type NullJobPostLocationType struct {
 }
 
 // Scan implements the Scanner interface.
-func (ns *NullJobPostLocationType) Scan(value interface{}) error {
+func (ns *NullJobPostLocationType) Scan(value any) error {
 	if value == nil {
 		ns.JobPostLocationType, ns.Valid = "", false
 		return nil

--- a/internal/endtoend/testdata/json_tags_null_enum/snake_case/postgresql/stdlib/go/db.go
+++ b/internal/endtoend/testdata/json_tags_null_enum/snake_case/postgresql/stdlib/go/db.go
@@ -10,10 +10,10 @@ import (
 )
 
 type DBTX interface {
-	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
 	PrepareContext(context.Context, string) (*sql.Stmt, error)
-	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
-	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/json_tags_null_enum/snake_case/postgresql/stdlib/go/models.go
+++ b/internal/endtoend/testdata/json_tags_null_enum/snake_case/postgresql/stdlib/go/models.go
@@ -18,7 +18,7 @@ const (
 	JobPostLocationTypeHybrid   JobPostLocationType = "hybrid"
 )
 
-func (e *JobPostLocationType) Scan(src interface{}) error {
+func (e *JobPostLocationType) Scan(src any) error {
 	switch s := src.(type) {
 	case []byte:
 		*e = JobPostLocationType(s)
@@ -36,7 +36,7 @@ type NullJobPostLocationType struct {
 }
 
 // Scan implements the Scanner interface.
-func (ns *NullJobPostLocationType) Scan(value interface{}) error {
+func (ns *NullJobPostLocationType) Scan(value any) error {
 	if value == nil {
 		ns.JobPostLocationType, ns.Valid = "", false
 		return nil

--- a/internal/endtoend/testdata/json_tags_null_enum/v2_config/postgresql/stdlib/go/db.go
+++ b/internal/endtoend/testdata/json_tags_null_enum/v2_config/postgresql/stdlib/go/db.go
@@ -10,10 +10,10 @@ import (
 )
 
 type DBTX interface {
-	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
 	PrepareContext(context.Context, string) (*sql.Stmt, error)
-	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
-	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/json_tags_null_enum/v2_config/postgresql/stdlib/go/models.go
+++ b/internal/endtoend/testdata/json_tags_null_enum/v2_config/postgresql/stdlib/go/models.go
@@ -18,7 +18,7 @@ const (
 	JobPostLocationTypeHybrid   JobPostLocationType = "hybrid"
 )
 
-func (e *JobPostLocationType) Scan(src interface{}) error {
+func (e *JobPostLocationType) Scan(src any) error {
 	switch s := src.(type) {
 	case []byte:
 		*e = JobPostLocationType(s)
@@ -36,7 +36,7 @@ type NullJobPostLocationType struct {
 }
 
 // Scan implements the Scanner interface.
-func (ns *NullJobPostLocationType) Scan(value interface{}) error {
+func (ns *NullJobPostLocationType) Scan(value any) error {
 	if value == nil {
 		ns.JobPostLocationType, ns.Valid = "", false
 		return nil

--- a/internal/endtoend/testdata/jsonb/pgx/go/db.go
+++ b/internal/endtoend/testdata/jsonb/pgx/go/db.go
@@ -12,9 +12,9 @@ import (
 )
 
 type DBTX interface {
-	Exec(context.Context, string, ...interface{}) (pgconn.CommandTag, error)
-	Query(context.Context, string, ...interface{}) (pgx.Rows, error)
-	QueryRow(context.Context, string, ...interface{}) pgx.Row
+	Exec(context.Context, string, ...any) (pgconn.CommandTag, error)
+	Query(context.Context, string, ...any) (pgx.Rows, error)
+	QueryRow(context.Context, string, ...any) pgx.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/jsonb/sqlite/go/db.go
+++ b/internal/endtoend/testdata/jsonb/sqlite/go/db.go
@@ -10,10 +10,10 @@ import (
 )
 
 type DBTX interface {
-	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
 	PrepareContext(context.Context, string) (*sql.Stmt, error)
-	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
-	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/limit/mysql/go/db.go
+++ b/internal/endtoend/testdata/limit/mysql/go/db.go
@@ -10,10 +10,10 @@ import (
 )
 
 type DBTX interface {
-	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
 	PrepareContext(context.Context, string) (*sql.Stmt, error)
-	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
-	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/limit/pgx/v4/go/db.go
+++ b/internal/endtoend/testdata/limit/pgx/v4/go/db.go
@@ -12,9 +12,9 @@ import (
 )
 
 type DBTX interface {
-	Exec(context.Context, string, ...interface{}) (pgconn.CommandTag, error)
-	Query(context.Context, string, ...interface{}) (pgx.Rows, error)
-	QueryRow(context.Context, string, ...interface{}) pgx.Row
+	Exec(context.Context, string, ...any) (pgconn.CommandTag, error)
+	Query(context.Context, string, ...any) (pgx.Rows, error)
+	QueryRow(context.Context, string, ...any) pgx.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/limit/pgx/v5/go/db.go
+++ b/internal/endtoend/testdata/limit/pgx/v5/go/db.go
@@ -12,9 +12,9 @@ import (
 )
 
 type DBTX interface {
-	Exec(context.Context, string, ...interface{}) (pgconn.CommandTag, error)
-	Query(context.Context, string, ...interface{}) (pgx.Rows, error)
-	QueryRow(context.Context, string, ...interface{}) pgx.Row
+	Exec(context.Context, string, ...any) (pgconn.CommandTag, error)
+	Query(context.Context, string, ...any) (pgx.Rows, error)
+	QueryRow(context.Context, string, ...any) pgx.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/limit/sqlite/go/db.go
+++ b/internal/endtoend/testdata/limit/sqlite/go/db.go
@@ -10,10 +10,10 @@ import (
 )
 
 type DBTX interface {
-	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
 	PrepareContext(context.Context, string) (*sql.Stmt, error)
-	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
-	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/limit/stdlib/go/db.go
+++ b/internal/endtoend/testdata/limit/stdlib/go/db.go
@@ -10,10 +10,10 @@ import (
 )
 
 type DBTX interface {
-	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
 	PrepareContext(context.Context, string) (*sql.Stmt, error)
-	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
-	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/lower/pgx/v4/go/db.go
+++ b/internal/endtoend/testdata/lower/pgx/v4/go/db.go
@@ -12,9 +12,9 @@ import (
 )
 
 type DBTX interface {
-	Exec(context.Context, string, ...interface{}) (pgconn.CommandTag, error)
-	Query(context.Context, string, ...interface{}) (pgx.Rows, error)
-	QueryRow(context.Context, string, ...interface{}) pgx.Row
+	Exec(context.Context, string, ...any) (pgconn.CommandTag, error)
+	Query(context.Context, string, ...any) (pgx.Rows, error)
+	QueryRow(context.Context, string, ...any) pgx.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/lower/pgx/v5/go/db.go
+++ b/internal/endtoend/testdata/lower/pgx/v5/go/db.go
@@ -12,9 +12,9 @@ import (
 )
 
 type DBTX interface {
-	Exec(context.Context, string, ...interface{}) (pgconn.CommandTag, error)
-	Query(context.Context, string, ...interface{}) (pgx.Rows, error)
-	QueryRow(context.Context, string, ...interface{}) pgx.Row
+	Exec(context.Context, string, ...any) (pgconn.CommandTag, error)
+	Query(context.Context, string, ...any) (pgx.Rows, error)
+	QueryRow(context.Context, string, ...any) pgx.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/lower/stdlib/go/db.go
+++ b/internal/endtoend/testdata/lower/stdlib/go/db.go
@@ -10,10 +10,10 @@ import (
 )
 
 type DBTX interface {
-	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
 	PrepareContext(context.Context, string) (*sql.Stmt, error)
-	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
-	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/lower_switched_order/pgx/v4/go/db.go
+++ b/internal/endtoend/testdata/lower_switched_order/pgx/v4/go/db.go
@@ -12,9 +12,9 @@ import (
 )
 
 type DBTX interface {
-	Exec(context.Context, string, ...interface{}) (pgconn.CommandTag, error)
-	Query(context.Context, string, ...interface{}) (pgx.Rows, error)
-	QueryRow(context.Context, string, ...interface{}) pgx.Row
+	Exec(context.Context, string, ...any) (pgconn.CommandTag, error)
+	Query(context.Context, string, ...any) (pgx.Rows, error)
+	QueryRow(context.Context, string, ...any) pgx.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/lower_switched_order/pgx/v5/go/db.go
+++ b/internal/endtoend/testdata/lower_switched_order/pgx/v5/go/db.go
@@ -12,9 +12,9 @@ import (
 )
 
 type DBTX interface {
-	Exec(context.Context, string, ...interface{}) (pgconn.CommandTag, error)
-	Query(context.Context, string, ...interface{}) (pgx.Rows, error)
-	QueryRow(context.Context, string, ...interface{}) pgx.Row
+	Exec(context.Context, string, ...any) (pgconn.CommandTag, error)
+	Query(context.Context, string, ...any) (pgx.Rows, error)
+	QueryRow(context.Context, string, ...any) pgx.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/lower_switched_order/stdlib/go/db.go
+++ b/internal/endtoend/testdata/lower_switched_order/stdlib/go/db.go
@@ -10,10 +10,10 @@ import (
 )
 
 type DBTX interface {
-	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
 	PrepareContext(context.Context, string) (*sql.Stmt, error)
-	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
-	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/materialized_views/postgresql/pgx/v4/go/db.go
+++ b/internal/endtoend/testdata/materialized_views/postgresql/pgx/v4/go/db.go
@@ -12,9 +12,9 @@ import (
 )
 
 type DBTX interface {
-	Exec(context.Context, string, ...interface{}) (pgconn.CommandTag, error)
-	Query(context.Context, string, ...interface{}) (pgx.Rows, error)
-	QueryRow(context.Context, string, ...interface{}) pgx.Row
+	Exec(context.Context, string, ...any) (pgconn.CommandTag, error)
+	Query(context.Context, string, ...any) (pgx.Rows, error)
+	QueryRow(context.Context, string, ...any) pgx.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/materialized_views/postgresql/pgx/v5/go/db.go
+++ b/internal/endtoend/testdata/materialized_views/postgresql/pgx/v5/go/db.go
@@ -12,9 +12,9 @@ import (
 )
 
 type DBTX interface {
-	Exec(context.Context, string, ...interface{}) (pgconn.CommandTag, error)
-	Query(context.Context, string, ...interface{}) (pgx.Rows, error)
-	QueryRow(context.Context, string, ...interface{}) pgx.Row
+	Exec(context.Context, string, ...any) (pgconn.CommandTag, error)
+	Query(context.Context, string, ...any) (pgx.Rows, error)
+	QueryRow(context.Context, string, ...any) pgx.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/materialized_views/postgresql/stdlib/go/db.go
+++ b/internal/endtoend/testdata/materialized_views/postgresql/stdlib/go/db.go
@@ -10,10 +10,10 @@ import (
 )
 
 type DBTX interface {
-	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
 	PrepareContext(context.Context, string) (*sql.Stmt, error)
-	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
-	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/mathmatical_operator/pgx/v4/go/db.go
+++ b/internal/endtoend/testdata/mathmatical_operator/pgx/v4/go/db.go
@@ -12,9 +12,9 @@ import (
 )
 
 type DBTX interface {
-	Exec(context.Context, string, ...interface{}) (pgconn.CommandTag, error)
-	Query(context.Context, string, ...interface{}) (pgx.Rows, error)
-	QueryRow(context.Context, string, ...interface{}) pgx.Row
+	Exec(context.Context, string, ...any) (pgconn.CommandTag, error)
+	Query(context.Context, string, ...any) (pgx.Rows, error)
+	QueryRow(context.Context, string, ...any) pgx.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/mathmatical_operator/pgx/v5/go/db.go
+++ b/internal/endtoend/testdata/mathmatical_operator/pgx/v5/go/db.go
@@ -12,9 +12,9 @@ import (
 )
 
 type DBTX interface {
-	Exec(context.Context, string, ...interface{}) (pgconn.CommandTag, error)
-	Query(context.Context, string, ...interface{}) (pgx.Rows, error)
-	QueryRow(context.Context, string, ...interface{}) pgx.Row
+	Exec(context.Context, string, ...any) (pgconn.CommandTag, error)
+	Query(context.Context, string, ...any) (pgx.Rows, error)
+	QueryRow(context.Context, string, ...any) pgx.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/mathmatical_operator/stdlib/go/db.go
+++ b/internal/endtoend/testdata/mathmatical_operator/stdlib/go/db.go
@@ -10,10 +10,10 @@ import (
 )
 
 type DBTX interface {
-	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
 	PrepareContext(context.Context, string) (*sql.Stmt, error)
-	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
-	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/min_max_date/postgresql/pgx/go/db.go
+++ b/internal/endtoend/testdata/min_max_date/postgresql/pgx/go/db.go
@@ -12,9 +12,9 @@ import (
 )
 
 type DBTX interface {
-	Exec(context.Context, string, ...interface{}) (pgconn.CommandTag, error)
-	Query(context.Context, string, ...interface{}) (pgx.Rows, error)
-	QueryRow(context.Context, string, ...interface{}) pgx.Row
+	Exec(context.Context, string, ...any) (pgconn.CommandTag, error)
+	Query(context.Context, string, ...any) (pgx.Rows, error)
+	QueryRow(context.Context, string, ...any) pgx.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/missing_semicolon/mysql/go/db.go
+++ b/internal/endtoend/testdata/missing_semicolon/mysql/go/db.go
@@ -10,10 +10,10 @@ import (
 )
 
 type DBTX interface {
-	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
 	PrepareContext(context.Context, string) (*sql.Stmt, error)
-	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
-	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/mix_param_types/mysql/go/db.go
+++ b/internal/endtoend/testdata/mix_param_types/mysql/go/db.go
@@ -10,10 +10,10 @@ import (
 )
 
 type DBTX interface {
-	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
 	PrepareContext(context.Context, string) (*sql.Stmt, error)
-	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
-	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/mix_param_types/postgresql/go/db.go
+++ b/internal/endtoend/testdata/mix_param_types/postgresql/go/db.go
@@ -10,10 +10,10 @@ import (
 )
 
 type DBTX interface {
-	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
 	PrepareContext(context.Context, string) (*sql.Stmt, error)
-	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
-	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/multibyte_comment/sqlite/go/db.go
+++ b/internal/endtoend/testdata/multibyte_comment/sqlite/go/db.go
@@ -10,10 +10,10 @@ import (
 )
 
 type DBTX interface {
-	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
 	PrepareContext(context.Context, string) (*sql.Stmt, error)
-	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
-	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/multidimension_array/pgx/v4/go/db.go
+++ b/internal/endtoend/testdata/multidimension_array/pgx/v4/go/db.go
@@ -12,9 +12,9 @@ import (
 )
 
 type DBTX interface {
-	Exec(context.Context, string, ...interface{}) (pgconn.CommandTag, error)
-	Query(context.Context, string, ...interface{}) (pgx.Rows, error)
-	QueryRow(context.Context, string, ...interface{}) pgx.Row
+	Exec(context.Context, string, ...any) (pgconn.CommandTag, error)
+	Query(context.Context, string, ...any) (pgx.Rows, error)
+	QueryRow(context.Context, string, ...any) pgx.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/multidimension_array/pgx/v5/go/db.go
+++ b/internal/endtoend/testdata/multidimension_array/pgx/v5/go/db.go
@@ -12,9 +12,9 @@ import (
 )
 
 type DBTX interface {
-	Exec(context.Context, string, ...interface{}) (pgconn.CommandTag, error)
-	Query(context.Context, string, ...interface{}) (pgx.Rows, error)
-	QueryRow(context.Context, string, ...interface{}) pgx.Row
+	Exec(context.Context, string, ...any) (pgconn.CommandTag, error)
+	Query(context.Context, string, ...any) (pgx.Rows, error)
+	QueryRow(context.Context, string, ...any) pgx.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/multidimension_array/stdlib/go/db.go
+++ b/internal/endtoend/testdata/multidimension_array/stdlib/go/db.go
@@ -10,10 +10,10 @@ import (
 )
 
 type DBTX interface {
-	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
 	PrepareContext(context.Context, string) (*sql.Stmt, error)
-	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
-	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/multischema/pgx/v4/go/db.go
+++ b/internal/endtoend/testdata/multischema/pgx/v4/go/db.go
@@ -12,9 +12,9 @@ import (
 )
 
 type DBTX interface {
-	Exec(context.Context, string, ...interface{}) (pgconn.CommandTag, error)
-	Query(context.Context, string, ...interface{}) (pgx.Rows, error)
-	QueryRow(context.Context, string, ...interface{}) pgx.Row
+	Exec(context.Context, string, ...any) (pgconn.CommandTag, error)
+	Query(context.Context, string, ...any) (pgx.Rows, error)
+	QueryRow(context.Context, string, ...any) pgx.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/multischema/pgx/v5/go/db.go
+++ b/internal/endtoend/testdata/multischema/pgx/v5/go/db.go
@@ -12,9 +12,9 @@ import (
 )
 
 type DBTX interface {
-	Exec(context.Context, string, ...interface{}) (pgconn.CommandTag, error)
-	Query(context.Context, string, ...interface{}) (pgx.Rows, error)
-	QueryRow(context.Context, string, ...interface{}) pgx.Row
+	Exec(context.Context, string, ...any) (pgconn.CommandTag, error)
+	Query(context.Context, string, ...any) (pgx.Rows, error)
+	QueryRow(context.Context, string, ...any) pgx.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/multischema/stdlib/go/db.go
+++ b/internal/endtoend/testdata/multischema/stdlib/go/db.go
@@ -10,10 +10,10 @@ import (
 )
 
 type DBTX interface {
-	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
 	PrepareContext(context.Context, string) (*sql.Stmt, error)
-	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
-	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/mysql_default_value/mysql/go/db.go
+++ b/internal/endtoend/testdata/mysql_default_value/mysql/go/db.go
@@ -10,10 +10,10 @@ import (
 )
 
 type DBTX interface {
-	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
 	PrepareContext(context.Context, string) (*sql.Stmt, error)
-	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
-	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/mysql_optimizer_hints/mysql/go/db.go
+++ b/internal/endtoend/testdata/mysql_optimizer_hints/mysql/go/db.go
@@ -10,10 +10,10 @@ import (
 )
 
 type DBTX interface {
-	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
 	PrepareContext(context.Context, string) (*sql.Stmt, error)
-	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
-	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/mysql_reference_manual/aggregate_functions/go/db.go
+++ b/internal/endtoend/testdata/mysql_reference_manual/aggregate_functions/go/db.go
@@ -10,10 +10,10 @@ import (
 )
 
 type DBTX interface {
-	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
 	PrepareContext(context.Context, string) (*sql.Stmt, error)
-	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
-	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/mysql_reference_manual/date_and_time_functions/go/db.go
+++ b/internal/endtoend/testdata/mysql_reference_manual/date_and_time_functions/go/db.go
@@ -10,10 +10,10 @@ import (
 )
 
 type DBTX interface {
-	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
 	PrepareContext(context.Context, string) (*sql.Stmt, error)
-	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
-	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/mysql_vector/mysql/go/db.go
+++ b/internal/endtoend/testdata/mysql_vector/mysql/go/db.go
@@ -10,10 +10,10 @@ import (
 )
 
 type DBTX interface {
-	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
 	PrepareContext(context.Context, string) (*sql.Stmt, error)
-	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
-	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/mysql_vector/mysql/go/models.go
+++ b/internal/endtoend/testdata/mysql_vector/mysql/go/models.go
@@ -6,5 +6,5 @@ package querytest
 
 type Foo struct {
 	ID        int32
-	Embedding interface{}
+	Embedding any
 }

--- a/internal/endtoend/testdata/named_param/pgx/v4/go/db.go
+++ b/internal/endtoend/testdata/named_param/pgx/v4/go/db.go
@@ -12,9 +12,9 @@ import (
 )
 
 type DBTX interface {
-	Exec(context.Context, string, ...interface{}) (pgconn.CommandTag, error)
-	Query(context.Context, string, ...interface{}) (pgx.Rows, error)
-	QueryRow(context.Context, string, ...interface{}) pgx.Row
+	Exec(context.Context, string, ...any) (pgconn.CommandTag, error)
+	Query(context.Context, string, ...any) (pgx.Rows, error)
+	QueryRow(context.Context, string, ...any) pgx.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/named_param/pgx/v5/go/db.go
+++ b/internal/endtoend/testdata/named_param/pgx/v5/go/db.go
@@ -12,9 +12,9 @@ import (
 )
 
 type DBTX interface {
-	Exec(context.Context, string, ...interface{}) (pgconn.CommandTag, error)
-	Query(context.Context, string, ...interface{}) (pgx.Rows, error)
-	QueryRow(context.Context, string, ...interface{}) pgx.Row
+	Exec(context.Context, string, ...any) (pgconn.CommandTag, error)
+	Query(context.Context, string, ...any) (pgx.Rows, error)
+	QueryRow(context.Context, string, ...any) pgx.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/named_param/sqlite/go/db.go
+++ b/internal/endtoend/testdata/named_param/sqlite/go/db.go
@@ -10,10 +10,10 @@ import (
 )
 
 type DBTX interface {
-	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
 	PrepareContext(context.Context, string) (*sql.Stmt, error)
-	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
-	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/named_param/stdlib/go/db.go
+++ b/internal/endtoend/testdata/named_param/stdlib/go/db.go
@@ -10,10 +10,10 @@ import (
 )
 
 type DBTX interface {
-	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
 	PrepareContext(context.Context, string) (*sql.Stmt, error)
-	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
-	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/nested_select/postgresql/pgx/go/db.go
+++ b/internal/endtoend/testdata/nested_select/postgresql/pgx/go/db.go
@@ -12,9 +12,9 @@ import (
 )
 
 type DBTX interface {
-	Exec(context.Context, string, ...interface{}) (pgconn.CommandTag, error)
-	Query(context.Context, string, ...interface{}) (pgx.Rows, error)
-	QueryRow(context.Context, string, ...interface{}) pgx.Row
+	Exec(context.Context, string, ...any) (pgconn.CommandTag, error)
+	Query(context.Context, string, ...any) (pgx.Rows, error)
+	QueryRow(context.Context, string, ...any) pgx.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/nextval/postgresql/go/db.go
+++ b/internal/endtoend/testdata/nextval/postgresql/go/db.go
@@ -10,10 +10,10 @@ import (
 )
 
 type DBTX interface {
-	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
 	PrepareContext(context.Context, string) (*sql.Stmt, error)
-	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
-	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/notifylisten/postgresql/pgx/v5/go/db.go
+++ b/internal/endtoend/testdata/notifylisten/postgresql/pgx/v5/go/db.go
@@ -12,9 +12,9 @@ import (
 )
 
 type DBTX interface {
-	Exec(context.Context, string, ...interface{}) (pgconn.CommandTag, error)
-	Query(context.Context, string, ...interface{}) (pgx.Rows, error)
-	QueryRow(context.Context, string, ...interface{}) pgx.Row
+	Exec(context.Context, string, ...any) (pgconn.CommandTag, error)
+	Query(context.Context, string, ...any) (pgx.Rows, error)
+	QueryRow(context.Context, string, ...any) pgx.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/null_if_type/postgresql/pganalyzer/db/db.go
+++ b/internal/endtoend/testdata/null_if_type/postgresql/pganalyzer/db/db.go
@@ -10,10 +10,10 @@ import (
 )
 
 type DBTX interface {
-	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
 	PrepareContext(context.Context, string) (*sql.Stmt, error)
-	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
-	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/null_if_type/postgresql/stdlib/db/db.go
+++ b/internal/endtoend/testdata/null_if_type/postgresql/stdlib/db/db.go
@@ -10,10 +10,10 @@ import (
 )
 
 type DBTX interface {
-	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
 	PrepareContext(context.Context, string) (*sql.Stmt, error)
-	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
-	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/omit_sqlc_version/db/db.go
+++ b/internal/endtoend/testdata/omit_sqlc_version/db/db.go
@@ -8,10 +8,10 @@ import (
 )
 
 type DBTX interface {
-	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
 	PrepareContext(context.Context, string) (*sql.Stmt, error)
-	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
-	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/omit_unused_structs/postgresql/stdlib/go/db.go
+++ b/internal/endtoend/testdata/omit_unused_structs/postgresql/stdlib/go/db.go
@@ -10,10 +10,10 @@ import (
 )
 
 type DBTX interface {
-	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
 	PrepareContext(context.Context, string) (*sql.Stmt, error)
-	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
-	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/omit_unused_structs/postgresql/stdlib/go/models.go
+++ b/internal/endtoend/testdata/omit_unused_structs/postgresql/stdlib/go/models.go
@@ -16,7 +16,7 @@ const (
 	ArrayEnumP ArrayEnum = "p"
 )
 
-func (e *ArrayEnum) Scan(src interface{}) error {
+func (e *ArrayEnum) Scan(src any) error {
 	switch s := src.(type) {
 	case []byte:
 		*e = ArrayEnum(s)
@@ -34,7 +34,7 @@ type NullArrayEnum struct {
 }
 
 // Scan implements the Scanner interface.
-func (ns *NullArrayEnum) Scan(value interface{}) error {
+func (ns *NullArrayEnum) Scan(value any) error {
 	if value == nil {
 		ns.ArrayEnum, ns.Valid = "", false
 		return nil
@@ -58,7 +58,7 @@ const (
 	QueryParamEnumTableEnumH QueryParamEnumTableEnum = "h"
 )
 
-func (e *QueryParamEnumTableEnum) Scan(src interface{}) error {
+func (e *QueryParamEnumTableEnum) Scan(src any) error {
 	switch s := src.(type) {
 	case []byte:
 		*e = QueryParamEnumTableEnum(s)
@@ -76,7 +76,7 @@ type NullQueryParamEnumTableEnum struct {
 }
 
 // Scan implements the Scanner interface.
-func (ns *NullQueryParamEnumTableEnum) Scan(value interface{}) error {
+func (ns *NullQueryParamEnumTableEnum) Scan(value any) error {
 	if value == nil {
 		ns.QueryParamEnumTableEnum, ns.Valid = "", false
 		return nil
@@ -100,7 +100,7 @@ const (
 	QueryParamStructEnumTableEnumJ QueryParamStructEnumTableEnum = "j"
 )
 
-func (e *QueryParamStructEnumTableEnum) Scan(src interface{}) error {
+func (e *QueryParamStructEnumTableEnum) Scan(src any) error {
 	switch s := src.(type) {
 	case []byte:
 		*e = QueryParamStructEnumTableEnum(s)
@@ -118,7 +118,7 @@ type NullQueryParamStructEnumTableEnum struct {
 }
 
 // Scan implements the Scanner interface.
-func (ns *NullQueryParamStructEnumTableEnum) Scan(value interface{}) error {
+func (ns *NullQueryParamStructEnumTableEnum) Scan(value any) error {
 	if value == nil {
 		ns.QueryParamStructEnumTableEnum, ns.Valid = "", false
 		return nil
@@ -142,7 +142,7 @@ const (
 	QueryReturnEnumTableEnumL QueryReturnEnumTableEnum = "l"
 )
 
-func (e *QueryReturnEnumTableEnum) Scan(src interface{}) error {
+func (e *QueryReturnEnumTableEnum) Scan(src any) error {
 	switch s := src.(type) {
 	case []byte:
 		*e = QueryReturnEnumTableEnum(s)
@@ -160,7 +160,7 @@ type NullQueryReturnEnumTableEnum struct {
 }
 
 // Scan implements the Scanner interface.
-func (ns *NullQueryReturnEnumTableEnum) Scan(value interface{}) error {
+func (ns *NullQueryReturnEnumTableEnum) Scan(value any) error {
 	if value == nil {
 		ns.QueryReturnEnumTableEnum, ns.Valid = "", false
 		return nil
@@ -184,7 +184,7 @@ const (
 	QueryReturnFullTableEnumF QueryReturnFullTableEnum = "f"
 )
 
-func (e *QueryReturnFullTableEnum) Scan(src interface{}) error {
+func (e *QueryReturnFullTableEnum) Scan(src any) error {
 	switch s := src.(type) {
 	case []byte:
 		*e = QueryReturnFullTableEnum(s)
@@ -202,7 +202,7 @@ type NullQueryReturnFullTableEnum struct {
 }
 
 // Scan implements the Scanner interface.
-func (ns *NullQueryReturnFullTableEnum) Scan(value interface{}) error {
+func (ns *NullQueryReturnFullTableEnum) Scan(value any) error {
 	if value == nil {
 		ns.QueryReturnFullTableEnum, ns.Valid = "", false
 		return nil
@@ -226,7 +226,7 @@ const (
 	QueryReturnStructEnumTableEnumL QueryReturnStructEnumTableEnum = "l"
 )
 
-func (e *QueryReturnStructEnumTableEnum) Scan(src interface{}) error {
+func (e *QueryReturnStructEnumTableEnum) Scan(src any) error {
 	switch s := src.(type) {
 	case []byte:
 		*e = QueryReturnStructEnumTableEnum(s)
@@ -244,7 +244,7 @@ type NullQueryReturnStructEnumTableEnum struct {
 }
 
 // Scan implements the Scanner interface.
-func (ns *NullQueryReturnStructEnumTableEnum) Scan(value interface{}) error {
+func (ns *NullQueryReturnStructEnumTableEnum) Scan(value any) error {
 	if value == nil {
 		ns.QueryReturnStructEnumTableEnum, ns.Valid = "", false
 		return nil
@@ -268,7 +268,7 @@ const (
 	QuerySqlcEmbedEnumN QuerySqlcEmbedEnum = "n"
 )
 
-func (e *QuerySqlcEmbedEnum) Scan(src interface{}) error {
+func (e *QuerySqlcEmbedEnum) Scan(src any) error {
 	switch s := src.(type) {
 	case []byte:
 		*e = QuerySqlcEmbedEnum(s)
@@ -286,7 +286,7 @@ type NullQuerySqlcEmbedEnum struct {
 }
 
 // Scan implements the Scanner interface.
-func (ns *NullQuerySqlcEmbedEnum) Scan(value interface{}) error {
+func (ns *NullQuerySqlcEmbedEnum) Scan(value any) error {
 	if value == nil {
 		ns.QuerySqlcEmbedEnum, ns.Valid = "", false
 		return nil

--- a/internal/endtoend/testdata/on_duplicate_key_update/mysql/db/db.go
+++ b/internal/endtoend/testdata/on_duplicate_key_update/mysql/db/db.go
@@ -10,10 +10,10 @@ import (
 )
 
 type DBTX interface {
-	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
 	PrepareContext(context.Context, string) (*sql.Stmt, error)
-	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
-	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/on_duplicate_key_update/postgresql/db/db.go
+++ b/internal/endtoend/testdata/on_duplicate_key_update/postgresql/db/db.go
@@ -10,10 +10,10 @@ import (
 )
 
 type DBTX interface {
-	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
 	PrepareContext(context.Context, string) (*sql.Stmt, error)
-	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
-	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/operator_string_concat/postgresql/pgx/v4/go/db.go
+++ b/internal/endtoend/testdata/operator_string_concat/postgresql/pgx/v4/go/db.go
@@ -12,9 +12,9 @@ import (
 )
 
 type DBTX interface {
-	Exec(context.Context, string, ...interface{}) (pgconn.CommandTag, error)
-	Query(context.Context, string, ...interface{}) (pgx.Rows, error)
-	QueryRow(context.Context, string, ...interface{}) pgx.Row
+	Exec(context.Context, string, ...any) (pgconn.CommandTag, error)
+	Query(context.Context, string, ...any) (pgx.Rows, error)
+	QueryRow(context.Context, string, ...any) pgx.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/operator_string_concat/postgresql/pgx/v5/go/db.go
+++ b/internal/endtoend/testdata/operator_string_concat/postgresql/pgx/v5/go/db.go
@@ -12,9 +12,9 @@ import (
 )
 
 type DBTX interface {
-	Exec(context.Context, string, ...interface{}) (pgconn.CommandTag, error)
-	Query(context.Context, string, ...interface{}) (pgx.Rows, error)
-	QueryRow(context.Context, string, ...interface{}) pgx.Row
+	Exec(context.Context, string, ...any) (pgconn.CommandTag, error)
+	Query(context.Context, string, ...any) (pgx.Rows, error)
+	QueryRow(context.Context, string, ...any) pgx.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/operator_string_concat/postgresql/stdlib/go/db.go
+++ b/internal/endtoend/testdata/operator_string_concat/postgresql/stdlib/go/db.go
@@ -10,10 +10,10 @@ import (
 )
 
 type DBTX interface {
-	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
 	PrepareContext(context.Context, string) (*sql.Stmt, error)
-	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
-	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/order_by_binds/mysql/go/db.go
+++ b/internal/endtoend/testdata/order_by_binds/mysql/go/db.go
@@ -10,10 +10,10 @@ import (
 )
 
 type DBTX interface {
-	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
 	PrepareContext(context.Context, string) (*sql.Stmt, error)
-	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
-	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/order_by_binds/mysql/go/query.sql.go
+++ b/internal/endtoend/testdata/order_by_binds/mysql/go/query.sql.go
@@ -17,7 +17,7 @@ ORDER   BY CASE WHEN ? = 'name' THEN name END
 
 type ListAuthorsColumnSortParams struct {
 	MinID      int64
-	SortColumn interface{}
+	SortColumn any
 }
 
 func (q *Queries) ListAuthorsColumnSort(ctx context.Context, arg ListAuthorsColumnSortParams) ([]Author, error) {

--- a/internal/endtoend/testdata/order_by_binds/pganalyze/go/db.go
+++ b/internal/endtoend/testdata/order_by_binds/pganalyze/go/db.go
@@ -10,10 +10,10 @@ import (
 )
 
 type DBTX interface {
-	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
 	PrepareContext(context.Context, string) (*sql.Stmt, error)
-	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
-	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/order_by_binds/postgresql/go/db.go
+++ b/internal/endtoend/testdata/order_by_binds/postgresql/go/db.go
@@ -10,10 +10,10 @@ import (
 )
 
 type DBTX interface {
-	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
 	PrepareContext(context.Context, string) (*sql.Stmt, error)
-	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
-	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/order_by_binds/postgresql/go/query.sql.go
+++ b/internal/endtoend/testdata/order_by_binds/postgresql/go/query.sql.go
@@ -17,7 +17,7 @@ ORDER   BY CASE WHEN $2 = 'name' THEN name END
 
 type ListAuthorsColumnSortParams struct {
 	MinID      int64
-	SortColumn interface{}
+	SortColumn any
 }
 
 func (q *Queries) ListAuthorsColumnSort(ctx context.Context, arg ListAuthorsColumnSortParams) ([]Author, error) {

--- a/internal/endtoend/testdata/order_by_union/mysql/go/db.go
+++ b/internal/endtoend/testdata/order_by_union/mysql/go/db.go
@@ -10,10 +10,10 @@ import (
 )
 
 type DBTX interface {
-	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
 	PrepareContext(context.Context, string) (*sql.Stmt, error)
-	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
-	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/order_by_union/postgresql/go/db.go
+++ b/internal/endtoend/testdata/order_by_union/postgresql/go/db.go
@@ -10,10 +10,10 @@ import (
 )
 
 type DBTX interface {
-	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
 	PrepareContext(context.Context, string) (*sql.Stmt, error)
-	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
-	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/output_file_names/pgx/v4/go/batch_gen.go
+++ b/internal/endtoend/testdata/output_file_names/pgx/v4/go/batch_gen.go
@@ -30,7 +30,7 @@ type UsersBBatchResults struct {
 func (q *Queries) UsersB(ctx context.Context, id []int64) *UsersBBatchResults {
 	batch := &pgx.Batch{}
 	for _, a := range id {
-		vals := []interface{}{
+		vals := []any{
 			a,
 		}
 		batch.Queue(usersB, vals...)

--- a/internal/endtoend/testdata/output_file_names/pgx/v4/go/copyfrom_gen.go
+++ b/internal/endtoend/testdata/output_file_names/pgx/v4/go/copyfrom_gen.go
@@ -27,8 +27,8 @@ func (r *iteratorForUsersC) Next() bool {
 	return len(r.rows) > 0
 }
 
-func (r iteratorForUsersC) Values() ([]interface{}, error) {
-	return []interface{}{
+func (r iteratorForUsersC) Values() ([]any, error) {
+	return []any{
 		r.rows[0],
 	}, nil
 }

--- a/internal/endtoend/testdata/output_file_names/pgx/v4/go/db_gen.go
+++ b/internal/endtoend/testdata/output_file_names/pgx/v4/go/db_gen.go
@@ -12,9 +12,9 @@ import (
 )
 
 type DBTX interface {
-	Exec(context.Context, string, ...interface{}) (pgconn.CommandTag, error)
-	Query(context.Context, string, ...interface{}) (pgx.Rows, error)
-	QueryRow(context.Context, string, ...interface{}) pgx.Row
+	Exec(context.Context, string, ...any) (pgconn.CommandTag, error)
+	Query(context.Context, string, ...any) (pgx.Rows, error)
+	QueryRow(context.Context, string, ...any) pgx.Row
 	CopyFrom(ctx context.Context, tableName pgx.Identifier, columnNames []string, rowSrc pgx.CopyFromSource) (int64, error)
 	SendBatch(context.Context, *pgx.Batch) pgx.BatchResults
 }

--- a/internal/endtoend/testdata/output_file_names/pgx/v5/go/batch_gen.go
+++ b/internal/endtoend/testdata/output_file_names/pgx/v5/go/batch_gen.go
@@ -30,7 +30,7 @@ type UsersBBatchResults struct {
 func (q *Queries) UsersB(ctx context.Context, id []int64) *UsersBBatchResults {
 	batch := &pgx.Batch{}
 	for _, a := range id {
-		vals := []interface{}{
+		vals := []any{
 			a,
 		}
 		batch.Queue(usersB, vals...)

--- a/internal/endtoend/testdata/output_file_names/pgx/v5/go/copyfrom_gen.go
+++ b/internal/endtoend/testdata/output_file_names/pgx/v5/go/copyfrom_gen.go
@@ -27,8 +27,8 @@ func (r *iteratorForUsersC) Next() bool {
 	return len(r.rows) > 0
 }
 
-func (r iteratorForUsersC) Values() ([]interface{}, error) {
-	return []interface{}{
+func (r iteratorForUsersC) Values() ([]any, error) {
+	return []any{
 		r.rows[0],
 	}, nil
 }

--- a/internal/endtoend/testdata/output_file_names/pgx/v5/go/db_gen.go
+++ b/internal/endtoend/testdata/output_file_names/pgx/v5/go/db_gen.go
@@ -12,9 +12,9 @@ import (
 )
 
 type DBTX interface {
-	Exec(context.Context, string, ...interface{}) (pgconn.CommandTag, error)
-	Query(context.Context, string, ...interface{}) (pgx.Rows, error)
-	QueryRow(context.Context, string, ...interface{}) pgx.Row
+	Exec(context.Context, string, ...any) (pgconn.CommandTag, error)
+	Query(context.Context, string, ...any) (pgx.Rows, error)
+	QueryRow(context.Context, string, ...any) pgx.Row
 	CopyFrom(ctx context.Context, tableName pgx.Identifier, columnNames []string, rowSrc pgx.CopyFromSource) (int64, error)
 	SendBatch(context.Context, *pgx.Batch) pgx.BatchResults
 }

--- a/internal/endtoend/testdata/output_file_names/stdlib/go/db_gen.go
+++ b/internal/endtoend/testdata/output_file_names/stdlib/go/db_gen.go
@@ -10,10 +10,10 @@ import (
 )
 
 type DBTX interface {
-	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
 	PrepareContext(context.Context, string) (*sql.Stmt, error)
-	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
-	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/output_files_suffix/pgx/v4/go/db.go
+++ b/internal/endtoend/testdata/output_files_suffix/pgx/v4/go/db.go
@@ -12,9 +12,9 @@ import (
 )
 
 type DBTX interface {
-	Exec(context.Context, string, ...interface{}) (pgconn.CommandTag, error)
-	Query(context.Context, string, ...interface{}) (pgx.Rows, error)
-	QueryRow(context.Context, string, ...interface{}) pgx.Row
+	Exec(context.Context, string, ...any) (pgconn.CommandTag, error)
+	Query(context.Context, string, ...any) (pgx.Rows, error)
+	QueryRow(context.Context, string, ...any) pgx.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/output_files_suffix/pgx/v5/go/db.go
+++ b/internal/endtoend/testdata/output_files_suffix/pgx/v5/go/db.go
@@ -12,9 +12,9 @@ import (
 )
 
 type DBTX interface {
-	Exec(context.Context, string, ...interface{}) (pgconn.CommandTag, error)
-	Query(context.Context, string, ...interface{}) (pgx.Rows, error)
-	QueryRow(context.Context, string, ...interface{}) pgx.Row
+	Exec(context.Context, string, ...any) (pgconn.CommandTag, error)
+	Query(context.Context, string, ...any) (pgx.Rows, error)
+	QueryRow(context.Context, string, ...any) pgx.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/output_files_suffix/stdlib/go/db.go
+++ b/internal/endtoend/testdata/output_files_suffix/stdlib/go/db.go
@@ -10,10 +10,10 @@ import (
 )
 
 type DBTX interface {
-	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
 	PrepareContext(context.Context, string) (*sql.Stmt, error)
-	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
-	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/output_models_path/postgresql/db/db.go
+++ b/internal/endtoend/testdata/output_models_path/postgresql/db/db.go
@@ -10,10 +10,10 @@ import (
 )
 
 type DBTX interface {
-	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
 	PrepareContext(context.Context, string) (*sql.Stmt, error)
-	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
-	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/output_models_path/postgresql/model/models.go
+++ b/internal/endtoend/testdata/output_models_path/postgresql/model/models.go
@@ -18,7 +18,7 @@ const (
 	StatusPending  Status = "pending"
 )
 
-func (e *Status) Scan(src interface{}) error {
+func (e *Status) Scan(src any) error {
 	switch s := src.(type) {
 	case []byte:
 		*e = Status(s)
@@ -36,7 +36,7 @@ type NullStatus struct {
 }
 
 // Scan implements the Scanner interface.
-func (ns *NullStatus) Scan(value interface{}) error {
+func (ns *NullStatus) Scan(value any) error {
 	if value == nil {
 		ns.Status, ns.Valid = "", false
 		return nil

--- a/internal/endtoend/testdata/output_models_shared/postgresql/model/models.go
+++ b/internal/endtoend/testdata/output_models_shared/postgresql/model/models.go
@@ -16,7 +16,7 @@ const (
 	StatusInactive Status = "inactive"
 )
 
-func (e *Status) Scan(src interface{}) error {
+func (e *Status) Scan(src any) error {
 	switch s := src.(type) {
 	case []byte:
 		*e = Status(s)
@@ -34,7 +34,7 @@ type NullStatus struct {
 }
 
 // Scan implements the Scanner interface.
-func (ns *NullStatus) Scan(value interface{}) error {
+func (ns *NullStatus) Scan(value any) error {
 	if value == nil {
 		ns.Status, ns.Valid = "", false
 		return nil

--- a/internal/endtoend/testdata/output_models_shared/postgresql/primary/db.go
+++ b/internal/endtoend/testdata/output_models_shared/postgresql/primary/db.go
@@ -10,10 +10,10 @@ import (
 )
 
 type DBTX interface {
-	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
 	PrepareContext(context.Context, string) (*sql.Stmt, error)
-	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
-	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/output_models_shared/postgresql/replica/db.go
+++ b/internal/endtoend/testdata/output_models_shared/postgresql/replica/db.go
@@ -10,10 +10,10 @@ import (
 )
 
 type DBTX interface {
-	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
 	PrepareContext(context.Context, string) (*sql.Stmt, error)
-	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
-	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/overrides/mysql/go/db.go
+++ b/internal/endtoend/testdata/overrides/mysql/go/db.go
@@ -10,10 +10,10 @@ import (
 )
 
 type DBTX interface {
-	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
 	PrepareContext(context.Context, string) (*sql.Stmt, error)
-	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
-	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/overrides/postgresql/pgx/v4/go/db.go
+++ b/internal/endtoend/testdata/overrides/postgresql/pgx/v4/go/db.go
@@ -12,9 +12,9 @@ import (
 )
 
 type DBTX interface {
-	Exec(context.Context, string, ...interface{}) (pgconn.CommandTag, error)
-	Query(context.Context, string, ...interface{}) (pgx.Rows, error)
-	QueryRow(context.Context, string, ...interface{}) pgx.Row
+	Exec(context.Context, string, ...any) (pgconn.CommandTag, error)
+	Query(context.Context, string, ...any) (pgx.Rows, error)
+	QueryRow(context.Context, string, ...any) pgx.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/overrides/postgresql/pgx/v5/go/db.go
+++ b/internal/endtoend/testdata/overrides/postgresql/pgx/v5/go/db.go
@@ -12,9 +12,9 @@ import (
 )
 
 type DBTX interface {
-	Exec(context.Context, string, ...interface{}) (pgconn.CommandTag, error)
-	Query(context.Context, string, ...interface{}) (pgx.Rows, error)
-	QueryRow(context.Context, string, ...interface{}) pgx.Row
+	Exec(context.Context, string, ...any) (pgconn.CommandTag, error)
+	Query(context.Context, string, ...any) (pgx.Rows, error)
+	QueryRow(context.Context, string, ...any) pgx.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/overrides/postgresql/stdlib/go/db.go
+++ b/internal/endtoend/testdata/overrides/postgresql/stdlib/go/db.go
@@ -10,10 +10,10 @@ import (
 )
 
 type DBTX interface {
-	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
 	PrepareContext(context.Context, string) (*sql.Stmt, error)
-	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
-	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/overrides/sqlite/go/db.go
+++ b/internal/endtoend/testdata/overrides/sqlite/go/db.go
@@ -10,10 +10,10 @@ import (
 )
 
 type DBTX interface {
-	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
 	PrepareContext(context.Context, string) (*sql.Stmt, error)
-	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
-	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/overrides_array/postgresql/pgx/v4/query/db.go
+++ b/internal/endtoend/testdata/overrides_array/postgresql/pgx/v4/query/db.go
@@ -12,9 +12,9 @@ import (
 )
 
 type DBTX interface {
-	Exec(context.Context, string, ...interface{}) (pgconn.CommandTag, error)
-	Query(context.Context, string, ...interface{}) (pgx.Rows, error)
-	QueryRow(context.Context, string, ...interface{}) pgx.Row
+	Exec(context.Context, string, ...any) (pgconn.CommandTag, error)
+	Query(context.Context, string, ...any) (pgx.Rows, error)
+	QueryRow(context.Context, string, ...any) pgx.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/overrides_array/postgresql/pgx/v5/query/db.go
+++ b/internal/endtoend/testdata/overrides_array/postgresql/pgx/v5/query/db.go
@@ -12,9 +12,9 @@ import (
 )
 
 type DBTX interface {
-	Exec(context.Context, string, ...interface{}) (pgconn.CommandTag, error)
-	Query(context.Context, string, ...interface{}) (pgx.Rows, error)
-	QueryRow(context.Context, string, ...interface{}) pgx.Row
+	Exec(context.Context, string, ...any) (pgconn.CommandTag, error)
+	Query(context.Context, string, ...any) (pgx.Rows, error)
+	QueryRow(context.Context, string, ...any) pgx.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/overrides_array/postgresql/stdlib/query/db.go
+++ b/internal/endtoend/testdata/overrides_array/postgresql/stdlib/query/db.go
@@ -10,10 +10,10 @@ import (
 )
 
 type DBTX interface {
-	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
 	PrepareContext(context.Context, string) (*sql.Stmt, error)
-	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
-	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/overrides_config/v2/yaml/global/db/db.go
+++ b/internal/endtoend/testdata/overrides_config/v2/yaml/global/db/db.go
@@ -10,10 +10,10 @@ import (
 )
 
 type DBTX interface {
-	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
 	PrepareContext(context.Context, string) (*sql.Stmt, error)
-	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
-	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/overrides_config/v2/yaml/global_and_queryset/db/db.go
+++ b/internal/endtoend/testdata/overrides_config/v2/yaml/global_and_queryset/db/db.go
@@ -10,10 +10,10 @@ import (
 )
 
 type DBTX interface {
-	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
 	PrepareContext(context.Context, string) (*sql.Stmt, error)
-	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
-	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/overrides_config/v2/yaml/queryset/db/db.go
+++ b/internal/endtoend/testdata/overrides_config/v2/yaml/queryset/db/db.go
@@ -10,10 +10,10 @@ import (
 )
 
 type DBTX interface {
-	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
 	PrepareContext(context.Context, string) (*sql.Stmt, error)
-	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
-	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/overrides_go_struct_tags/mysql/go/db.go
+++ b/internal/endtoend/testdata/overrides_go_struct_tags/mysql/go/db.go
@@ -10,10 +10,10 @@ import (
 )
 
 type DBTX interface {
-	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
 	PrepareContext(context.Context, string) (*sql.Stmt, error)
-	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
-	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/overrides_go_struct_tags/postgresql/pgx/v4/go/db.go
+++ b/internal/endtoend/testdata/overrides_go_struct_tags/postgresql/pgx/v4/go/db.go
@@ -12,9 +12,9 @@ import (
 )
 
 type DBTX interface {
-	Exec(context.Context, string, ...interface{}) (pgconn.CommandTag, error)
-	Query(context.Context, string, ...interface{}) (pgx.Rows, error)
-	QueryRow(context.Context, string, ...interface{}) pgx.Row
+	Exec(context.Context, string, ...any) (pgconn.CommandTag, error)
+	Query(context.Context, string, ...any) (pgx.Rows, error)
+	QueryRow(context.Context, string, ...any) pgx.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/overrides_go_struct_tags/postgresql/pgx/v5/go/db.go
+++ b/internal/endtoend/testdata/overrides_go_struct_tags/postgresql/pgx/v5/go/db.go
@@ -12,9 +12,9 @@ import (
 )
 
 type DBTX interface {
-	Exec(context.Context, string, ...interface{}) (pgconn.CommandTag, error)
-	Query(context.Context, string, ...interface{}) (pgx.Rows, error)
-	QueryRow(context.Context, string, ...interface{}) pgx.Row
+	Exec(context.Context, string, ...any) (pgconn.CommandTag, error)
+	Query(context.Context, string, ...any) (pgx.Rows, error)
+	QueryRow(context.Context, string, ...any) pgx.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/overrides_go_struct_tags/postgresql/stdlib/go/db.go
+++ b/internal/endtoend/testdata/overrides_go_struct_tags/postgresql/stdlib/go/db.go
@@ -10,10 +10,10 @@ import (
 )
 
 type DBTX interface {
-	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
 	PrepareContext(context.Context, string) (*sql.Stmt, error)
-	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
-	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/overrides_go_struct_tags/sqlite/go/db.go
+++ b/internal/endtoend/testdata/overrides_go_struct_tags/sqlite/go/db.go
@@ -10,10 +10,10 @@ import (
 )
 
 type DBTX interface {
-	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
 	PrepareContext(context.Context, string) (*sql.Stmt, error)
-	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
-	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/overrides_go_types/mysql/go/db.go
+++ b/internal/endtoend/testdata/overrides_go_types/mysql/go/db.go
@@ -10,10 +10,10 @@ import (
 )
 
 type DBTX interface {
-	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
 	PrepareContext(context.Context, string) (*sql.Stmt, error)
-	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
-	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/overrides_go_types/mysql/go/query.sql.go
+++ b/internal/endtoend/testdata/overrides_go_types/mysql/go/query.sql.go
@@ -18,7 +18,7 @@ SELECT other, total, retyped FROM foo WHERE retyped IN (/*SLICE:paramname*/?)
 
 func (q *Queries) TestIN(ctx context.Context, paramname []pkg.CustomType) ([]Foo, error) {
 	query := testIN
-	var queryParams []interface{}
+	var queryParams []any
 	if len(paramname) > 0 {
 		for _, v := range paramname {
 			queryParams = append(queryParams, v)

--- a/internal/endtoend/testdata/overrides_go_types/postgresql/pgx/v4/go/db.go
+++ b/internal/endtoend/testdata/overrides_go_types/postgresql/pgx/v4/go/db.go
@@ -12,9 +12,9 @@ import (
 )
 
 type DBTX interface {
-	Exec(context.Context, string, ...interface{}) (pgconn.CommandTag, error)
-	Query(context.Context, string, ...interface{}) (pgx.Rows, error)
-	QueryRow(context.Context, string, ...interface{}) pgx.Row
+	Exec(context.Context, string, ...any) (pgconn.CommandTag, error)
+	Query(context.Context, string, ...any) (pgx.Rows, error)
+	QueryRow(context.Context, string, ...any) pgx.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/overrides_go_types/postgresql/pgx/v5/go/db.go
+++ b/internal/endtoend/testdata/overrides_go_types/postgresql/pgx/v5/go/db.go
@@ -12,9 +12,9 @@ import (
 )
 
 type DBTX interface {
-	Exec(context.Context, string, ...interface{}) (pgconn.CommandTag, error)
-	Query(context.Context, string, ...interface{}) (pgx.Rows, error)
-	QueryRow(context.Context, string, ...interface{}) pgx.Row
+	Exec(context.Context, string, ...any) (pgconn.CommandTag, error)
+	Query(context.Context, string, ...any) (pgx.Rows, error)
+	QueryRow(context.Context, string, ...any) pgx.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/overrides_go_types/postgresql/stdlib/go/db.go
+++ b/internal/endtoend/testdata/overrides_go_types/postgresql/stdlib/go/db.go
@@ -10,10 +10,10 @@ import (
 )
 
 type DBTX interface {
-	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
 	PrepareContext(context.Context, string) (*sql.Stmt, error)
-	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
-	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/overrides_go_types/sqlite/go/db.go
+++ b/internal/endtoend/testdata/overrides_go_types/sqlite/go/db.go
@@ -10,10 +10,10 @@ import (
 )
 
 type DBTX interface {
-	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
 	PrepareContext(context.Context, string) (*sql.Stmt, error)
-	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
-	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/overrides_nullable/postgresql/pgx/v4/go/db.go
+++ b/internal/endtoend/testdata/overrides_nullable/postgresql/pgx/v4/go/db.go
@@ -12,9 +12,9 @@ import (
 )
 
 type DBTX interface {
-	Exec(context.Context, string, ...interface{}) (pgconn.CommandTag, error)
-	Query(context.Context, string, ...interface{}) (pgx.Rows, error)
-	QueryRow(context.Context, string, ...interface{}) pgx.Row
+	Exec(context.Context, string, ...any) (pgconn.CommandTag, error)
+	Query(context.Context, string, ...any) (pgx.Rows, error)
+	QueryRow(context.Context, string, ...any) pgx.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/overrides_nullable/postgresql/pgx/v5/go/db.go
+++ b/internal/endtoend/testdata/overrides_nullable/postgresql/pgx/v5/go/db.go
@@ -12,9 +12,9 @@ import (
 )
 
 type DBTX interface {
-	Exec(context.Context, string, ...interface{}) (pgconn.CommandTag, error)
-	Query(context.Context, string, ...interface{}) (pgx.Rows, error)
-	QueryRow(context.Context, string, ...interface{}) pgx.Row
+	Exec(context.Context, string, ...any) (pgconn.CommandTag, error)
+	Query(context.Context, string, ...any) (pgx.Rows, error)
+	QueryRow(context.Context, string, ...any) pgx.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/overrides_nullable/postgresql/stdlib/go/db.go
+++ b/internal/endtoend/testdata/overrides_nullable/postgresql/stdlib/go/db.go
@@ -10,10 +10,10 @@ import (
 )
 
 type DBTX interface {
-	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
 	PrepareContext(context.Context, string) (*sql.Stmt, error)
-	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
-	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/overrides_pointers/mysql/go/db.go
+++ b/internal/endtoend/testdata/overrides_pointers/mysql/go/db.go
@@ -10,10 +10,10 @@ import (
 )
 
 type DBTX interface {
-	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
 	PrepareContext(context.Context, string) (*sql.Stmt, error)
-	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
-	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/overrides_pointers/postgresql/pgx/v4/go/db.go
+++ b/internal/endtoend/testdata/overrides_pointers/postgresql/pgx/v4/go/db.go
@@ -12,9 +12,9 @@ import (
 )
 
 type DBTX interface {
-	Exec(context.Context, string, ...interface{}) (pgconn.CommandTag, error)
-	Query(context.Context, string, ...interface{}) (pgx.Rows, error)
-	QueryRow(context.Context, string, ...interface{}) pgx.Row
+	Exec(context.Context, string, ...any) (pgconn.CommandTag, error)
+	Query(context.Context, string, ...any) (pgx.Rows, error)
+	QueryRow(context.Context, string, ...any) pgx.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/overrides_pointers/postgresql/pgx/v5/go/db.go
+++ b/internal/endtoend/testdata/overrides_pointers/postgresql/pgx/v5/go/db.go
@@ -12,9 +12,9 @@ import (
 )
 
 type DBTX interface {
-	Exec(context.Context, string, ...interface{}) (pgconn.CommandTag, error)
-	Query(context.Context, string, ...interface{}) (pgx.Rows, error)
-	QueryRow(context.Context, string, ...interface{}) pgx.Row
+	Exec(context.Context, string, ...any) (pgconn.CommandTag, error)
+	Query(context.Context, string, ...any) (pgx.Rows, error)
+	QueryRow(context.Context, string, ...any) pgx.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/overrides_pointers/postgresql/stdlib/go/db.go
+++ b/internal/endtoend/testdata/overrides_pointers/postgresql/stdlib/go/db.go
@@ -10,10 +10,10 @@ import (
 )
 
 type DBTX interface {
-	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
 	PrepareContext(context.Context, string) (*sql.Stmt, error)
-	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
-	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/overrides_result_tag/stdlib/go/db.go
+++ b/internal/endtoend/testdata/overrides_result_tag/stdlib/go/db.go
@@ -10,10 +10,10 @@ import (
 )
 
 type DBTX interface {
-	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
 	PrepareContext(context.Context, string) (*sql.Stmt, error)
-	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
-	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/overrides_unsigned/mysql/go/db.go
+++ b/internal/endtoend/testdata/overrides_unsigned/mysql/go/db.go
@@ -10,10 +10,10 @@ import (
 )
 
 type DBTX interface {
-	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
 	PrepareContext(context.Context, string) (*sql.Stmt, error)
-	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
-	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/params_duplicate/mysql/go/db.go
+++ b/internal/endtoend/testdata/params_duplicate/mysql/go/db.go
@@ -10,10 +10,10 @@ import (
 )
 
 type DBTX interface {
-	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
 	PrepareContext(context.Context, string) (*sql.Stmt, error)
-	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
-	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/params_duplicate/mysql/go/query.sql.go
+++ b/internal/endtoend/testdata/params_duplicate/mysql/go/query.sql.go
@@ -116,7 +116,7 @@ users where (? = id OR  ? = 0)
 
 type SelectUserQuestionParams struct {
 	ID      int32
-	Column2 interface{}
+	Column2 any
 }
 
 func (q *Queries) SelectUserQuestion(ctx context.Context, arg SelectUserQuestionParams) ([]sql.NullString, error) {

--- a/internal/endtoend/testdata/params_duplicate/postgresql/go/db.go
+++ b/internal/endtoend/testdata/params_duplicate/postgresql/go/db.go
@@ -10,10 +10,10 @@ import (
 )
 
 type DBTX interface {
-	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
 	PrepareContext(context.Context, string) (*sql.Stmt, error)
-	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
-	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/params_go_keywords/postgresql/go/db.go
+++ b/internal/endtoend/testdata/params_go_keywords/postgresql/go/db.go
@@ -12,9 +12,9 @@ import (
 )
 
 type DBTX interface {
-	Exec(context.Context, string, ...interface{}) (pgconn.CommandTag, error)
-	Query(context.Context, string, ...interface{}) (pgx.Rows, error)
-	QueryRow(context.Context, string, ...interface{}) pgx.Row
+	Exec(context.Context, string, ...any) (pgconn.CommandTag, error)
+	Query(context.Context, string, ...any) (pgx.Rows, error)
+	QueryRow(context.Context, string, ...any) pgx.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/params_in_nested_func/mysql/db/db.go
+++ b/internal/endtoend/testdata/params_in_nested_func/mysql/db/db.go
@@ -10,10 +10,10 @@ import (
 )
 
 type DBTX interface {
-	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
 	PrepareContext(context.Context, string) (*sql.Stmt, error)
-	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
-	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/params_in_nested_func/mysql/db/query.sql.go
+++ b/internal/endtoend/testdata/params_in_nested_func/mysql/db/query.sql.go
@@ -22,7 +22,7 @@ WHERE
 `
 
 type GetGroupsParams struct {
-	GroupName interface{}
+	GroupName any
 	GroupId   sql.NullInt32
 }
 

--- a/internal/endtoend/testdata/params_in_nested_func/postgresql/db/db.go
+++ b/internal/endtoend/testdata/params_in_nested_func/postgresql/db/db.go
@@ -10,10 +10,10 @@ import (
 )
 
 type DBTX interface {
-	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
 	PrepareContext(context.Context, string) (*sql.Stmt, error)
-	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
-	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/params_location/mysql/go/db.go
+++ b/internal/endtoend/testdata/params_location/mysql/go/db.go
@@ -10,10 +10,10 @@ import (
 )
 
 type DBTX interface {
-	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
 	PrepareContext(context.Context, string) (*sql.Stmt, error)
-	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
-	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/params_location/postgresql/pgx/v4/go/db.go
+++ b/internal/endtoend/testdata/params_location/postgresql/pgx/v4/go/db.go
@@ -12,9 +12,9 @@ import (
 )
 
 type DBTX interface {
-	Exec(context.Context, string, ...interface{}) (pgconn.CommandTag, error)
-	Query(context.Context, string, ...interface{}) (pgx.Rows, error)
-	QueryRow(context.Context, string, ...interface{}) pgx.Row
+	Exec(context.Context, string, ...any) (pgconn.CommandTag, error)
+	Query(context.Context, string, ...any) (pgx.Rows, error)
+	QueryRow(context.Context, string, ...any) pgx.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/params_location/postgresql/pgx/v5/go/db.go
+++ b/internal/endtoend/testdata/params_location/postgresql/pgx/v5/go/db.go
@@ -12,9 +12,9 @@ import (
 )
 
 type DBTX interface {
-	Exec(context.Context, string, ...interface{}) (pgconn.CommandTag, error)
-	Query(context.Context, string, ...interface{}) (pgx.Rows, error)
-	QueryRow(context.Context, string, ...interface{}) pgx.Row
+	Exec(context.Context, string, ...any) (pgconn.CommandTag, error)
+	Query(context.Context, string, ...any) (pgx.Rows, error)
+	QueryRow(context.Context, string, ...any) pgx.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/params_location/postgresql/stdlib/go/db.go
+++ b/internal/endtoend/testdata/params_location/postgresql/stdlib/go/db.go
@@ -10,10 +10,10 @@ import (
 )
 
 type DBTX interface {
-	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
 	PrepareContext(context.Context, string) (*sql.Stmt, error)
-	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
-	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/params_placeholder_in_left_expr/mysql/go/db.go
+++ b/internal/endtoend/testdata/params_placeholder_in_left_expr/mysql/go/db.go
@@ -10,10 +10,10 @@ import (
 )
 
 type DBTX interface {
-	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
 	PrepareContext(context.Context, string) (*sql.Stmt, error)
-	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
-	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/params_placeholder_in_left_expr/postgresql/go/db.go
+++ b/internal/endtoend/testdata/params_placeholder_in_left_expr/postgresql/go/db.go
@@ -10,10 +10,10 @@ import (
 )
 
 type DBTX interface {
-	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
 	PrepareContext(context.Context, string) (*sql.Stmt, error)
-	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
-	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/params_two/mysql/go/db.go
+++ b/internal/endtoend/testdata/params_two/mysql/go/db.go
@@ -10,10 +10,10 @@ import (
 )
 
 type DBTX interface {
-	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
 	PrepareContext(context.Context, string) (*sql.Stmt, error)
-	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
-	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/params_two/postgresql/pgx/v4/go/db.go
+++ b/internal/endtoend/testdata/params_two/postgresql/pgx/v4/go/db.go
@@ -12,9 +12,9 @@ import (
 )
 
 type DBTX interface {
-	Exec(context.Context, string, ...interface{}) (pgconn.CommandTag, error)
-	Query(context.Context, string, ...interface{}) (pgx.Rows, error)
-	QueryRow(context.Context, string, ...interface{}) pgx.Row
+	Exec(context.Context, string, ...any) (pgconn.CommandTag, error)
+	Query(context.Context, string, ...any) (pgx.Rows, error)
+	QueryRow(context.Context, string, ...any) pgx.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/params_two/postgresql/pgx/v5/go/db.go
+++ b/internal/endtoend/testdata/params_two/postgresql/pgx/v5/go/db.go
@@ -12,9 +12,9 @@ import (
 )
 
 type DBTX interface {
-	Exec(context.Context, string, ...interface{}) (pgconn.CommandTag, error)
-	Query(context.Context, string, ...interface{}) (pgx.Rows, error)
-	QueryRow(context.Context, string, ...interface{}) pgx.Row
+	Exec(context.Context, string, ...any) (pgconn.CommandTag, error)
+	Query(context.Context, string, ...any) (pgx.Rows, error)
+	QueryRow(context.Context, string, ...any) pgx.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/params_two/postgresql/stdlib/go/db.go
+++ b/internal/endtoend/testdata/params_two/postgresql/stdlib/go/db.go
@@ -10,10 +10,10 @@ import (
 )
 
 type DBTX interface {
-	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
 	PrepareContext(context.Context, string) (*sql.Stmt, error)
-	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
-	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/pattern_in_expr/mysql/go/db.go
+++ b/internal/endtoend/testdata/pattern_in_expr/mysql/go/db.go
@@ -10,10 +10,10 @@ import (
 )
 
 type DBTX interface {
-	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
 	PrepareContext(context.Context, string) (*sql.Stmt, error)
-	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
-	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/pattern_matching/mysql/go/db.go
+++ b/internal/endtoend/testdata/pattern_matching/mysql/go/db.go
@@ -10,10 +10,10 @@ import (
 )
 
 type DBTX interface {
-	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
 	PrepareContext(context.Context, string) (*sql.Stmt, error)
-	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
-	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/pattern_matching/postgresql/go/db.go
+++ b/internal/endtoend/testdata/pattern_matching/postgresql/go/db.go
@@ -10,10 +10,10 @@ import (
 )
 
 type DBTX interface {
-	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
 	PrepareContext(context.Context, string) (*sql.Stmt, error)
-	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
-	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/pg_advisory_xact_lock/postgresql/pgx/v4/go/db.go
+++ b/internal/endtoend/testdata/pg_advisory_xact_lock/postgresql/pgx/v4/go/db.go
@@ -12,9 +12,9 @@ import (
 )
 
 type DBTX interface {
-	Exec(context.Context, string, ...interface{}) (pgconn.CommandTag, error)
-	Query(context.Context, string, ...interface{}) (pgx.Rows, error)
-	QueryRow(context.Context, string, ...interface{}) pgx.Row
+	Exec(context.Context, string, ...any) (pgconn.CommandTag, error)
+	Query(context.Context, string, ...any) (pgx.Rows, error)
+	QueryRow(context.Context, string, ...any) pgx.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/pg_advisory_xact_lock/postgresql/pgx/v4/go/query.sql.go
+++ b/internal/endtoend/testdata/pg_advisory_xact_lock/postgresql/pgx/v4/go/query.sql.go
@@ -23,9 +23,9 @@ const advisoryLockOne = `-- name: AdvisoryLockOne :one
 SELECT pg_advisory_lock($1)
 `
 
-func (q *Queries) AdvisoryLockOne(ctx context.Context, pgAdvisoryLock int64) (interface{}, error) {
+func (q *Queries) AdvisoryLockOne(ctx context.Context, pgAdvisoryLock int64) (any, error) {
 	row := q.db.QueryRow(ctx, advisoryLockOne, pgAdvisoryLock)
-	var pg_advisory_lock interface{}
+	var pg_advisory_lock any
 	err := row.Scan(&pg_advisory_lock)
 	return pg_advisory_lock, err
 }

--- a/internal/endtoend/testdata/pg_advisory_xact_lock/postgresql/pgx/v5/go/db.go
+++ b/internal/endtoend/testdata/pg_advisory_xact_lock/postgresql/pgx/v5/go/db.go
@@ -12,9 +12,9 @@ import (
 )
 
 type DBTX interface {
-	Exec(context.Context, string, ...interface{}) (pgconn.CommandTag, error)
-	Query(context.Context, string, ...interface{}) (pgx.Rows, error)
-	QueryRow(context.Context, string, ...interface{}) pgx.Row
+	Exec(context.Context, string, ...any) (pgconn.CommandTag, error)
+	Query(context.Context, string, ...any) (pgx.Rows, error)
+	QueryRow(context.Context, string, ...any) pgx.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/pg_advisory_xact_lock/postgresql/pgx/v5/go/query.sql.go
+++ b/internal/endtoend/testdata/pg_advisory_xact_lock/postgresql/pgx/v5/go/query.sql.go
@@ -23,9 +23,9 @@ const advisoryLockOne = `-- name: AdvisoryLockOne :one
 SELECT pg_advisory_lock($1)
 `
 
-func (q *Queries) AdvisoryLockOne(ctx context.Context, pgAdvisoryLock int64) (interface{}, error) {
+func (q *Queries) AdvisoryLockOne(ctx context.Context, pgAdvisoryLock int64) (any, error) {
 	row := q.db.QueryRow(ctx, advisoryLockOne, pgAdvisoryLock)
-	var pg_advisory_lock interface{}
+	var pg_advisory_lock any
 	err := row.Scan(&pg_advisory_lock)
 	return pg_advisory_lock, err
 }

--- a/internal/endtoend/testdata/pg_advisory_xact_lock/postgresql/stdlib/go/db.go
+++ b/internal/endtoend/testdata/pg_advisory_xact_lock/postgresql/stdlib/go/db.go
@@ -10,10 +10,10 @@ import (
 )
 
 type DBTX interface {
-	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
 	PrepareContext(context.Context, string) (*sql.Stmt, error)
-	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
-	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/pg_advisory_xact_lock/postgresql/stdlib/go/query.sql.go
+++ b/internal/endtoend/testdata/pg_advisory_xact_lock/postgresql/stdlib/go/query.sql.go
@@ -22,9 +22,9 @@ const advisoryLockOne = `-- name: AdvisoryLockOne :one
 SELECT pg_advisory_lock($1)
 `
 
-func (q *Queries) AdvisoryLockOne(ctx context.Context, pgAdvisoryLock int64) (interface{}, error) {
+func (q *Queries) AdvisoryLockOne(ctx context.Context, pgAdvisoryLock int64) (any, error) {
 	row := q.db.QueryRowContext(ctx, advisoryLockOne, pgAdvisoryLock)
-	var pg_advisory_lock interface{}
+	var pg_advisory_lock any
 	err := row.Scan(&pg_advisory_lock)
 	return pg_advisory_lock, err
 }

--- a/internal/endtoend/testdata/pg_dump/db/db.go
+++ b/internal/endtoend/testdata/pg_dump/db/db.go
@@ -10,10 +10,10 @@ import (
 )
 
 type DBTX interface {
-	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
 	PrepareContext(context.Context, string) (*sql.Stmt, error)
-	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
-	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/pg_ext_ltree/postgresql/pgx/v4/go/db.go
+++ b/internal/endtoend/testdata/pg_ext_ltree/postgresql/pgx/v4/go/db.go
@@ -12,9 +12,9 @@ import (
 )
 
 type DBTX interface {
-	Exec(context.Context, string, ...interface{}) (pgconn.CommandTag, error)
-	Query(context.Context, string, ...interface{}) (pgx.Rows, error)
-	QueryRow(context.Context, string, ...interface{}) pgx.Row
+	Exec(context.Context, string, ...any) (pgconn.CommandTag, error)
+	Query(context.Context, string, ...any) (pgx.Rows, error)
+	QueryRow(context.Context, string, ...any) pgx.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/pg_ext_ltree/postgresql/pgx/v5/go/db.go
+++ b/internal/endtoend/testdata/pg_ext_ltree/postgresql/pgx/v5/go/db.go
@@ -12,9 +12,9 @@ import (
 )
 
 type DBTX interface {
-	Exec(context.Context, string, ...interface{}) (pgconn.CommandTag, error)
-	Query(context.Context, string, ...interface{}) (pgx.Rows, error)
-	QueryRow(context.Context, string, ...interface{}) pgx.Row
+	Exec(context.Context, string, ...any) (pgconn.CommandTag, error)
+	Query(context.Context, string, ...any) (pgx.Rows, error)
+	QueryRow(context.Context, string, ...any) pgx.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/pg_ext_ltree/postgresql/stdlib/go/db.go
+++ b/internal/endtoend/testdata/pg_ext_ltree/postgresql/stdlib/go/db.go
@@ -10,10 +10,10 @@ import (
 )
 
 type DBTX interface {
-	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
 	PrepareContext(context.Context, string) (*sql.Stmt, error)
-	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
-	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/pg_extensions/postgresql/pgx/v4/go/db.go
+++ b/internal/endtoend/testdata/pg_extensions/postgresql/pgx/v4/go/db.go
@@ -12,9 +12,9 @@ import (
 )
 
 type DBTX interface {
-	Exec(context.Context, string, ...interface{}) (pgconn.CommandTag, error)
-	Query(context.Context, string, ...interface{}) (pgx.Rows, error)
-	QueryRow(context.Context, string, ...interface{}) pgx.Row
+	Exec(context.Context, string, ...any) (pgconn.CommandTag, error)
+	Query(context.Context, string, ...any) (pgx.Rows, error)
+	QueryRow(context.Context, string, ...any) pgx.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/pg_extensions/postgresql/pgx/v5/go/db.go
+++ b/internal/endtoend/testdata/pg_extensions/postgresql/pgx/v5/go/db.go
@@ -12,9 +12,9 @@ import (
 )
 
 type DBTX interface {
-	Exec(context.Context, string, ...interface{}) (pgconn.CommandTag, error)
-	Query(context.Context, string, ...interface{}) (pgx.Rows, error)
-	QueryRow(context.Context, string, ...interface{}) pgx.Row
+	Exec(context.Context, string, ...any) (pgconn.CommandTag, error)
+	Query(context.Context, string, ...any) (pgx.Rows, error)
+	QueryRow(context.Context, string, ...any) pgx.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/pg_extensions/postgresql/stdlib/go/db.go
+++ b/internal/endtoend/testdata/pg_extensions/postgresql/stdlib/go/db.go
@@ -10,10 +10,10 @@ import (
 )
 
 type DBTX interface {
-	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
 	PrepareContext(context.Context, string) (*sql.Stmt, error)
-	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
-	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/pg_generate_series/postgresql/pgx/v4/go/db.go
+++ b/internal/endtoend/testdata/pg_generate_series/postgresql/pgx/v4/go/db.go
@@ -12,9 +12,9 @@ import (
 )
 
 type DBTX interface {
-	Exec(context.Context, string, ...interface{}) (pgconn.CommandTag, error)
-	Query(context.Context, string, ...interface{}) (pgx.Rows, error)
-	QueryRow(context.Context, string, ...interface{}) pgx.Row
+	Exec(context.Context, string, ...any) (pgconn.CommandTag, error)
+	Query(context.Context, string, ...any) (pgx.Rows, error)
+	QueryRow(context.Context, string, ...any) pgx.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/pg_generate_series/postgresql/pgx/v5/go/db.go
+++ b/internal/endtoend/testdata/pg_generate_series/postgresql/pgx/v5/go/db.go
@@ -12,9 +12,9 @@ import (
 )
 
 type DBTX interface {
-	Exec(context.Context, string, ...interface{}) (pgconn.CommandTag, error)
-	Query(context.Context, string, ...interface{}) (pgx.Rows, error)
-	QueryRow(context.Context, string, ...interface{}) pgx.Row
+	Exec(context.Context, string, ...any) (pgconn.CommandTag, error)
+	Query(context.Context, string, ...any) (pgx.Rows, error)
+	QueryRow(context.Context, string, ...any) pgx.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/pg_generate_series/postgresql/stdlib/go/db.go
+++ b/internal/endtoend/testdata/pg_generate_series/postgresql/stdlib/go/db.go
@@ -10,10 +10,10 @@ import (
 )
 
 type DBTX interface {
-	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
 	PrepareContext(context.Context, string) (*sql.Stmt, error)
-	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
-	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/pg_timezone_names/go_pgx/v4/db.go
+++ b/internal/endtoend/testdata/pg_timezone_names/go_pgx/v4/db.go
@@ -12,9 +12,9 @@ import (
 )
 
 type DBTX interface {
-	Exec(context.Context, string, ...interface{}) (pgconn.CommandTag, error)
-	Query(context.Context, string, ...interface{}) (pgx.Rows, error)
-	QueryRow(context.Context, string, ...interface{}) pgx.Row
+	Exec(context.Context, string, ...any) (pgconn.CommandTag, error)
+	Query(context.Context, string, ...any) (pgx.Rows, error)
+	QueryRow(context.Context, string, ...any) pgx.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/pg_timezone_names/go_pgx/v5/db.go
+++ b/internal/endtoend/testdata/pg_timezone_names/go_pgx/v5/db.go
@@ -12,9 +12,9 @@ import (
 )
 
 type DBTX interface {
-	Exec(context.Context, string, ...interface{}) (pgconn.CommandTag, error)
-	Query(context.Context, string, ...interface{}) (pgx.Rows, error)
-	QueryRow(context.Context, string, ...interface{}) pgx.Row
+	Exec(context.Context, string, ...any) (pgconn.CommandTag, error)
+	Query(context.Context, string, ...any) (pgx.Rows, error)
+	QueryRow(context.Context, string, ...any) pgx.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/pg_timezone_names/go_stdlib/db.go
+++ b/internal/endtoend/testdata/pg_timezone_names/go_stdlib/db.go
@@ -10,10 +10,10 @@ import (
 )
 
 type DBTX interface {
-	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
 	PrepareContext(context.Context, string) (*sql.Stmt, error)
-	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
-	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/pg_user_table/postgresql/pgx/v4/go/db.go
+++ b/internal/endtoend/testdata/pg_user_table/postgresql/pgx/v4/go/db.go
@@ -12,9 +12,9 @@ import (
 )
 
 type DBTX interface {
-	Exec(context.Context, string, ...interface{}) (pgconn.CommandTag, error)
-	Query(context.Context, string, ...interface{}) (pgx.Rows, error)
-	QueryRow(context.Context, string, ...interface{}) pgx.Row
+	Exec(context.Context, string, ...any) (pgconn.CommandTag, error)
+	Query(context.Context, string, ...any) (pgx.Rows, error)
+	QueryRow(context.Context, string, ...any) pgx.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/pg_user_table/postgresql/pgx/v5/go/db.go
+++ b/internal/endtoend/testdata/pg_user_table/postgresql/pgx/v5/go/db.go
@@ -12,9 +12,9 @@ import (
 )
 
 type DBTX interface {
-	Exec(context.Context, string, ...interface{}) (pgconn.CommandTag, error)
-	Query(context.Context, string, ...interface{}) (pgx.Rows, error)
-	QueryRow(context.Context, string, ...interface{}) pgx.Row
+	Exec(context.Context, string, ...any) (pgconn.CommandTag, error)
+	Query(context.Context, string, ...any) (pgx.Rows, error)
+	QueryRow(context.Context, string, ...any) pgx.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/pg_user_table/postgresql/stdlib/go/db.go
+++ b/internal/endtoend/testdata/pg_user_table/postgresql/stdlib/go/db.go
@@ -10,10 +10,10 @@ import (
 )
 
 type DBTX interface {
-	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
 	PrepareContext(context.Context, string) (*sql.Stmt, error)
-	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
-	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/pg_vector/postgresql/pgx/go/db.go
+++ b/internal/endtoend/testdata/pg_vector/postgresql/pgx/go/db.go
@@ -12,9 +12,9 @@ import (
 )
 
 type DBTX interface {
-	Exec(context.Context, string, ...interface{}) (pgconn.CommandTag, error)
-	Query(context.Context, string, ...interface{}) (pgx.Rows, error)
-	QueryRow(context.Context, string, ...interface{}) pgx.Row
+	Exec(context.Context, string, ...any) (pgconn.CommandTag, error)
+	Query(context.Context, string, ...any) (pgx.Rows, error)
+	QueryRow(context.Context, string, ...any) pgx.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/pointer_type_import/postgresql/pgx/v4/go/db.go
+++ b/internal/endtoend/testdata/pointer_type_import/postgresql/pgx/v4/go/db.go
@@ -12,9 +12,9 @@ import (
 )
 
 type DBTX interface {
-	Exec(context.Context, string, ...interface{}) (pgconn.CommandTag, error)
-	Query(context.Context, string, ...interface{}) (pgx.Rows, error)
-	QueryRow(context.Context, string, ...interface{}) pgx.Row
+	Exec(context.Context, string, ...any) (pgconn.CommandTag, error)
+	Query(context.Context, string, ...any) (pgx.Rows, error)
+	QueryRow(context.Context, string, ...any) pgx.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/pointer_type_import/postgresql/pgx/v5/go/db.go
+++ b/internal/endtoend/testdata/pointer_type_import/postgresql/pgx/v5/go/db.go
@@ -12,9 +12,9 @@ import (
 )
 
 type DBTX interface {
-	Exec(context.Context, string, ...interface{}) (pgconn.CommandTag, error)
-	Query(context.Context, string, ...interface{}) (pgx.Rows, error)
-	QueryRow(context.Context, string, ...interface{}) pgx.Row
+	Exec(context.Context, string, ...any) (pgconn.CommandTag, error)
+	Query(context.Context, string, ...any) (pgx.Rows, error)
+	QueryRow(context.Context, string, ...any) pgx.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/prepared_queries/mysql/go/db.go
+++ b/internal/endtoend/testdata/prepared_queries/mysql/go/db.go
@@ -11,10 +11,10 @@ import (
 )
 
 type DBTX interface {
-	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
 	PrepareContext(context.Context, string) (*sql.Stmt, error)
-	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
-	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
 }
 
 func New(db DBTX) *Queries {
@@ -72,7 +72,7 @@ func (q *Queries) Close() error {
 	return err
 }
 
-func (q *Queries) exec(ctx context.Context, stmt *sql.Stmt, query string, args ...interface{}) (sql.Result, error) {
+func (q *Queries) exec(ctx context.Context, stmt *sql.Stmt, query string, args ...any) (sql.Result, error) {
 	switch {
 	case stmt != nil && q.tx != nil:
 		return q.tx.StmtContext(ctx, stmt).ExecContext(ctx, args...)
@@ -83,7 +83,7 @@ func (q *Queries) exec(ctx context.Context, stmt *sql.Stmt, query string, args .
 	}
 }
 
-func (q *Queries) query(ctx context.Context, stmt *sql.Stmt, query string, args ...interface{}) (*sql.Rows, error) {
+func (q *Queries) query(ctx context.Context, stmt *sql.Stmt, query string, args ...any) (*sql.Rows, error) {
 	switch {
 	case stmt != nil && q.tx != nil:
 		return q.tx.StmtContext(ctx, stmt).QueryContext(ctx, args...)
@@ -94,7 +94,7 @@ func (q *Queries) query(ctx context.Context, stmt *sql.Stmt, query string, args 
 	}
 }
 
-func (q *Queries) queryRow(ctx context.Context, stmt *sql.Stmt, query string, args ...interface{}) *sql.Row {
+func (q *Queries) queryRow(ctx context.Context, stmt *sql.Stmt, query string, args ...any) *sql.Row {
 	switch {
 	case stmt != nil && q.tx != nil:
 		return q.tx.StmtContext(ctx, stmt).QueryRowContext(ctx, args...)

--- a/internal/endtoend/testdata/prepared_queries/postgresql/stdlib/go/db.go
+++ b/internal/endtoend/testdata/prepared_queries/postgresql/stdlib/go/db.go
@@ -11,10 +11,10 @@ import (
 )
 
 type DBTX interface {
-	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
 	PrepareContext(context.Context, string) (*sql.Stmt, error)
-	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
-	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
 }
 
 func New(db DBTX) *Queries {
@@ -72,7 +72,7 @@ func (q *Queries) Close() error {
 	return err
 }
 
-func (q *Queries) exec(ctx context.Context, stmt *sql.Stmt, query string, args ...interface{}) (sql.Result, error) {
+func (q *Queries) exec(ctx context.Context, stmt *sql.Stmt, query string, args ...any) (sql.Result, error) {
 	switch {
 	case stmt != nil && q.tx != nil:
 		return q.tx.StmtContext(ctx, stmt).ExecContext(ctx, args...)
@@ -83,7 +83,7 @@ func (q *Queries) exec(ctx context.Context, stmt *sql.Stmt, query string, args .
 	}
 }
 
-func (q *Queries) query(ctx context.Context, stmt *sql.Stmt, query string, args ...interface{}) (*sql.Rows, error) {
+func (q *Queries) query(ctx context.Context, stmt *sql.Stmt, query string, args ...any) (*sql.Rows, error) {
 	switch {
 	case stmt != nil && q.tx != nil:
 		return q.tx.StmtContext(ctx, stmt).QueryContext(ctx, args...)
@@ -94,7 +94,7 @@ func (q *Queries) query(ctx context.Context, stmt *sql.Stmt, query string, args 
 	}
 }
 
-func (q *Queries) queryRow(ctx context.Context, stmt *sql.Stmt, query string, args ...interface{}) *sql.Row {
+func (q *Queries) queryRow(ctx context.Context, stmt *sql.Stmt, query string, args ...any) *sql.Row {
 	switch {
 	case stmt != nil && q.tx != nil:
 		return q.tx.StmtContext(ctx, stmt).QueryRowContext(ctx, args...)

--- a/internal/endtoend/testdata/primary_key_later/postgresql/pgx/v4/go/db.go
+++ b/internal/endtoend/testdata/primary_key_later/postgresql/pgx/v4/go/db.go
@@ -12,9 +12,9 @@ import (
 )
 
 type DBTX interface {
-	Exec(context.Context, string, ...interface{}) (pgconn.CommandTag, error)
-	Query(context.Context, string, ...interface{}) (pgx.Rows, error)
-	QueryRow(context.Context, string, ...interface{}) pgx.Row
+	Exec(context.Context, string, ...any) (pgconn.CommandTag, error)
+	Query(context.Context, string, ...any) (pgx.Rows, error)
+	QueryRow(context.Context, string, ...any) pgx.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/primary_key_later/postgresql/pgx/v5/go/db.go
+++ b/internal/endtoend/testdata/primary_key_later/postgresql/pgx/v5/go/db.go
@@ -12,9 +12,9 @@ import (
 )
 
 type DBTX interface {
-	Exec(context.Context, string, ...interface{}) (pgconn.CommandTag, error)
-	Query(context.Context, string, ...interface{}) (pgx.Rows, error)
-	QueryRow(context.Context, string, ...interface{}) pgx.Row
+	Exec(context.Context, string, ...any) (pgconn.CommandTag, error)
+	Query(context.Context, string, ...any) (pgx.Rows, error)
+	QueryRow(context.Context, string, ...any) pgx.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/primary_key_later/postgresql/stdlib/go/db.go
+++ b/internal/endtoend/testdata/primary_key_later/postgresql/stdlib/go/db.go
@@ -10,10 +10,10 @@ import (
 )
 
 type DBTX interface {
-	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
 	PrepareContext(context.Context, string) (*sql.Stmt, error)
-	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
-	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/query_parameter_limit_param_only/postgresql/go/db.go
+++ b/internal/endtoend/testdata/query_parameter_limit_param_only/postgresql/go/db.go
@@ -10,10 +10,10 @@ import (
 )
 
 type DBTX interface {
-	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
 	PrepareContext(context.Context, string) (*sql.Stmt, error)
-	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
-	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/query_parameter_limit_to_two/postgresql/go/db.go
+++ b/internal/endtoend/testdata/query_parameter_limit_to_two/postgresql/go/db.go
@@ -10,10 +10,10 @@ import (
 )
 
 type DBTX interface {
-	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
 	PrepareContext(context.Context, string) (*sql.Stmt, error)
-	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
-	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/query_parameter_limit_to_two/postgresql/go/query.sql.go
+++ b/internal/endtoend/testdata/query_parameter_limit_to_two/postgresql/go/query.sql.go
@@ -97,7 +97,7 @@ WHERE id IN ($2) AND name = $1
 
 func (q *Queries) DeleteAuthors(ctx context.Context, name string, ids []int64) error {
 	query := deleteAuthors
-	var queryParams []interface{}
+	var queryParams []any
 	queryParams = append(queryParams, name)
 	if len(ids) > 0 {
 		for _, v := range ids {

--- a/internal/endtoend/testdata/query_parameter_limit_to_zero/postgresql/go/db.go
+++ b/internal/endtoend/testdata/query_parameter_limit_to_zero/postgresql/go/db.go
@@ -10,10 +10,10 @@ import (
 )
 
 type DBTX interface {
-	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
 	PrepareContext(context.Context, string) (*sql.Stmt, error)
-	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
-	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/quoted_colname/sqlite/go/db.go
+++ b/internal/endtoend/testdata/quoted_colname/sqlite/go/db.go
@@ -10,10 +10,10 @@ import (
 )
 
 type DBTX interface {
-	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
 	PrepareContext(context.Context, string) (*sql.Stmt, error)
-	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
-	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/quoted_names_complex/sqlite/go/db.go
+++ b/internal/endtoend/testdata/quoted_names_complex/sqlite/go/db.go
@@ -10,10 +10,10 @@ import (
 )
 
 type DBTX interface {
-	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
 	PrepareContext(context.Context, string) (*sql.Stmt, error)
-	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
-	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/quoted_tablename/sqlite/go/db.go
+++ b/internal/endtoend/testdata/quoted_tablename/sqlite/go/db.go
@@ -10,10 +10,10 @@ import (
 )
 
 type DBTX interface {
-	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
 	PrepareContext(context.Context, string) (*sql.Stmt, error)
-	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
-	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/ranges/pgx/v5/go/db.go
+++ b/internal/endtoend/testdata/ranges/pgx/v5/go/db.go
@@ -12,9 +12,9 @@ import (
 )
 
 type DBTX interface {
-	Exec(context.Context, string, ...interface{}) (pgconn.CommandTag, error)
-	Query(context.Context, string, ...interface{}) (pgx.Rows, error)
-	QueryRow(context.Context, string, ...interface{}) pgx.Row
+	Exec(context.Context, string, ...any) (pgconn.CommandTag, error)
+	Query(context.Context, string, ...any) (pgx.Rows, error)
+	QueryRow(context.Context, string, ...any) pgx.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/refreshmatview/postgresql/pgx/v4/go/db.go
+++ b/internal/endtoend/testdata/refreshmatview/postgresql/pgx/v4/go/db.go
@@ -12,9 +12,9 @@ import (
 )
 
 type DBTX interface {
-	Exec(context.Context, string, ...interface{}) (pgconn.CommandTag, error)
-	Query(context.Context, string, ...interface{}) (pgx.Rows, error)
-	QueryRow(context.Context, string, ...interface{}) pgx.Row
+	Exec(context.Context, string, ...any) (pgconn.CommandTag, error)
+	Query(context.Context, string, ...any) (pgx.Rows, error)
+	QueryRow(context.Context, string, ...any) pgx.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/refreshmatview/postgresql/pgx/v5/go/db.go
+++ b/internal/endtoend/testdata/refreshmatview/postgresql/pgx/v5/go/db.go
@@ -12,9 +12,9 @@ import (
 )
 
 type DBTX interface {
-	Exec(context.Context, string, ...interface{}) (pgconn.CommandTag, error)
-	Query(context.Context, string, ...interface{}) (pgx.Rows, error)
-	QueryRow(context.Context, string, ...interface{}) pgx.Row
+	Exec(context.Context, string, ...any) (pgconn.CommandTag, error)
+	Query(context.Context, string, ...any) (pgx.Rows, error)
+	QueryRow(context.Context, string, ...any) pgx.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/rename/v1/pgx/v4/go/db.go
+++ b/internal/endtoend/testdata/rename/v1/pgx/v4/go/db.go
@@ -12,9 +12,9 @@ import (
 )
 
 type DBTX interface {
-	Exec(context.Context, string, ...interface{}) (pgconn.CommandTag, error)
-	Query(context.Context, string, ...interface{}) (pgx.Rows, error)
-	QueryRow(context.Context, string, ...interface{}) pgx.Row
+	Exec(context.Context, string, ...any) (pgconn.CommandTag, error)
+	Query(context.Context, string, ...any) (pgx.Rows, error)
+	QueryRow(context.Context, string, ...any) pgx.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/rename/v1/pgx/v4/go/models.go
+++ b/internal/endtoend/testdata/rename/v1/pgx/v4/go/models.go
@@ -17,7 +17,7 @@ const (
 	IpProtocolIcmp IPProtocol = "icmp"
 )
 
-func (e *IPProtocol) Scan(src interface{}) error {
+func (e *IPProtocol) Scan(src any) error {
 	switch s := src.(type) {
 	case []byte:
 		*e = IPProtocol(s)
@@ -35,7 +35,7 @@ type NullIPProtocol struct {
 }
 
 // Scan implements the Scanner interface.
-func (ns *NullIPProtocol) Scan(value interface{}) error {
+func (ns *NullIPProtocol) Scan(value any) error {
 	if value == nil {
 		ns.IPProtocol, ns.Valid = "", false
 		return nil

--- a/internal/endtoend/testdata/rename/v1/pgx/v5/go/db.go
+++ b/internal/endtoend/testdata/rename/v1/pgx/v5/go/db.go
@@ -12,9 +12,9 @@ import (
 )
 
 type DBTX interface {
-	Exec(context.Context, string, ...interface{}) (pgconn.CommandTag, error)
-	Query(context.Context, string, ...interface{}) (pgx.Rows, error)
-	QueryRow(context.Context, string, ...interface{}) pgx.Row
+	Exec(context.Context, string, ...any) (pgconn.CommandTag, error)
+	Query(context.Context, string, ...any) (pgx.Rows, error)
+	QueryRow(context.Context, string, ...any) pgx.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/rename/v1/pgx/v5/go/models.go
+++ b/internal/endtoend/testdata/rename/v1/pgx/v5/go/models.go
@@ -17,7 +17,7 @@ const (
 	IpProtocolIcmp IPProtocol = "icmp"
 )
 
-func (e *IPProtocol) Scan(src interface{}) error {
+func (e *IPProtocol) Scan(src any) error {
 	switch s := src.(type) {
 	case []byte:
 		*e = IPProtocol(s)
@@ -35,7 +35,7 @@ type NullIPProtocol struct {
 }
 
 // Scan implements the Scanner interface.
-func (ns *NullIPProtocol) Scan(value interface{}) error {
+func (ns *NullIPProtocol) Scan(value any) error {
 	if value == nil {
 		ns.IPProtocol, ns.Valid = "", false
 		return nil

--- a/internal/endtoend/testdata/rename/v1/stdlib/go/db.go
+++ b/internal/endtoend/testdata/rename/v1/stdlib/go/db.go
@@ -10,10 +10,10 @@ import (
 )
 
 type DBTX interface {
-	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
 	PrepareContext(context.Context, string) (*sql.Stmt, error)
-	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
-	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/rename/v1/stdlib/go/models.go
+++ b/internal/endtoend/testdata/rename/v1/stdlib/go/models.go
@@ -17,7 +17,7 @@ const (
 	IpProtocolIcmp IPProtocol = "icmp"
 )
 
-func (e *IPProtocol) Scan(src interface{}) error {
+func (e *IPProtocol) Scan(src any) error {
 	switch s := src.(type) {
 	case []byte:
 		*e = IPProtocol(s)
@@ -35,7 +35,7 @@ type NullIPProtocol struct {
 }
 
 // Scan implements the Scanner interface.
-func (ns *NullIPProtocol) Scan(value interface{}) error {
+func (ns *NullIPProtocol) Scan(value any) error {
 	if value == nil {
 		ns.IPProtocol, ns.Valid = "", false
 		return nil

--- a/internal/endtoend/testdata/rename/v2/pgx/v4/go/db.go
+++ b/internal/endtoend/testdata/rename/v2/pgx/v4/go/db.go
@@ -12,9 +12,9 @@ import (
 )
 
 type DBTX interface {
-	Exec(context.Context, string, ...interface{}) (pgconn.CommandTag, error)
-	Query(context.Context, string, ...interface{}) (pgx.Rows, error)
-	QueryRow(context.Context, string, ...interface{}) pgx.Row
+	Exec(context.Context, string, ...any) (pgconn.CommandTag, error)
+	Query(context.Context, string, ...any) (pgx.Rows, error)
+	QueryRow(context.Context, string, ...any) pgx.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/rename/v2/pgx/v4/go/models.go
+++ b/internal/endtoend/testdata/rename/v2/pgx/v4/go/models.go
@@ -17,7 +17,7 @@ const (
 	IpProtocolIcmp IPProtocol = "icmp"
 )
 
-func (e *IPProtocol) Scan(src interface{}) error {
+func (e *IPProtocol) Scan(src any) error {
 	switch s := src.(type) {
 	case []byte:
 		*e = IPProtocol(s)
@@ -35,7 +35,7 @@ type NullIPProtocol struct {
 }
 
 // Scan implements the Scanner interface.
-func (ns *NullIPProtocol) Scan(value interface{}) error {
+func (ns *NullIPProtocol) Scan(value any) error {
 	if value == nil {
 		ns.IPProtocol, ns.Valid = "", false
 		return nil

--- a/internal/endtoend/testdata/rename/v2/pgx/v5/go/db.go
+++ b/internal/endtoend/testdata/rename/v2/pgx/v5/go/db.go
@@ -12,9 +12,9 @@ import (
 )
 
 type DBTX interface {
-	Exec(context.Context, string, ...interface{}) (pgconn.CommandTag, error)
-	Query(context.Context, string, ...interface{}) (pgx.Rows, error)
-	QueryRow(context.Context, string, ...interface{}) pgx.Row
+	Exec(context.Context, string, ...any) (pgconn.CommandTag, error)
+	Query(context.Context, string, ...any) (pgx.Rows, error)
+	QueryRow(context.Context, string, ...any) pgx.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/rename/v2/pgx/v5/go/models.go
+++ b/internal/endtoend/testdata/rename/v2/pgx/v5/go/models.go
@@ -17,7 +17,7 @@ const (
 	IpProtocolIcmp IPProtocol = "icmp"
 )
 
-func (e *IPProtocol) Scan(src interface{}) error {
+func (e *IPProtocol) Scan(src any) error {
 	switch s := src.(type) {
 	case []byte:
 		*e = IPProtocol(s)
@@ -35,7 +35,7 @@ type NullIPProtocol struct {
 }
 
 // Scan implements the Scanner interface.
-func (ns *NullIPProtocol) Scan(value interface{}) error {
+func (ns *NullIPProtocol) Scan(value any) error {
 	if value == nil {
 		ns.IPProtocol, ns.Valid = "", false
 		return nil

--- a/internal/endtoend/testdata/rename/v2/stdlib/go/db.go
+++ b/internal/endtoend/testdata/rename/v2/stdlib/go/db.go
@@ -10,10 +10,10 @@ import (
 )
 
 type DBTX interface {
-	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
 	PrepareContext(context.Context, string) (*sql.Stmt, error)
-	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
-	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/rename/v2/stdlib/go/models.go
+++ b/internal/endtoend/testdata/rename/v2/stdlib/go/models.go
@@ -17,7 +17,7 @@ const (
 	IpProtocolIcmp IPProtocol = "icmp"
 )
 
-func (e *IPProtocol) Scan(src interface{}) error {
+func (e *IPProtocol) Scan(src any) error {
 	switch s := src.(type) {
 	case []byte:
 		*e = IPProtocol(s)
@@ -35,7 +35,7 @@ type NullIPProtocol struct {
 }
 
 // Scan implements the Scanner interface.
-func (ns *NullIPProtocol) Scan(value interface{}) error {
+func (ns *NullIPProtocol) Scan(value any) error {
 	if value == nil {
 		ns.IPProtocol, ns.Valid = "", false
 		return nil

--- a/internal/endtoend/testdata/returning/postgresql/pgx/v4/go/db.go
+++ b/internal/endtoend/testdata/returning/postgresql/pgx/v4/go/db.go
@@ -12,9 +12,9 @@ import (
 )
 
 type DBTX interface {
-	Exec(context.Context, string, ...interface{}) (pgconn.CommandTag, error)
-	Query(context.Context, string, ...interface{}) (pgx.Rows, error)
-	QueryRow(context.Context, string, ...interface{}) pgx.Row
+	Exec(context.Context, string, ...any) (pgconn.CommandTag, error)
+	Query(context.Context, string, ...any) (pgx.Rows, error)
+	QueryRow(context.Context, string, ...any) pgx.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/returning/postgresql/pgx/v5/go/db.go
+++ b/internal/endtoend/testdata/returning/postgresql/pgx/v5/go/db.go
@@ -12,9 +12,9 @@ import (
 )
 
 type DBTX interface {
-	Exec(context.Context, string, ...interface{}) (pgconn.CommandTag, error)
-	Query(context.Context, string, ...interface{}) (pgx.Rows, error)
-	QueryRow(context.Context, string, ...interface{}) pgx.Row
+	Exec(context.Context, string, ...any) (pgconn.CommandTag, error)
+	Query(context.Context, string, ...any) (pgx.Rows, error)
+	QueryRow(context.Context, string, ...any) pgx.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/returning/postgresql/stdlib/go/db.go
+++ b/internal/endtoend/testdata/returning/postgresql/stdlib/go/db.go
@@ -10,10 +10,10 @@ import (
 )
 
 type DBTX interface {
-	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
 	PrepareContext(context.Context, string) (*sql.Stmt, error)
-	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
-	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/returning/sqlite/go/db.go
+++ b/internal/endtoend/testdata/returning/sqlite/go/db.go
@@ -10,10 +10,10 @@ import (
 )
 
 type DBTX interface {
-	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
 	PrepareContext(context.Context, string) (*sql.Stmt, error)
-	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
-	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/returning_old_new/postgresql/pgx/v5/go/db.go
+++ b/internal/endtoend/testdata/returning_old_new/postgresql/pgx/v5/go/db.go
@@ -12,9 +12,9 @@ import (
 )
 
 type DBTX interface {
-	Exec(context.Context, string, ...interface{}) (pgconn.CommandTag, error)
-	Query(context.Context, string, ...interface{}) (pgx.Rows, error)
-	QueryRow(context.Context, string, ...interface{}) pgx.Row
+	Exec(context.Context, string, ...any) (pgconn.CommandTag, error)
+	Query(context.Context, string, ...any) (pgx.Rows, error)
+	QueryRow(context.Context, string, ...any) pgx.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/returning_old_new/postgresql/stdlib/go/db.go
+++ b/internal/endtoend/testdata/returning_old_new/postgresql/stdlib/go/db.go
@@ -10,10 +10,10 @@ import (
 )
 
 type DBTX interface {
-	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
 	PrepareContext(context.Context, string) (*sql.Stmt, error)
-	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
-	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/schema_scoped_create/mysql/go/db.go
+++ b/internal/endtoend/testdata/schema_scoped_create/mysql/go/db.go
@@ -10,10 +10,10 @@ import (
 )
 
 type DBTX interface {
-	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
 	PrepareContext(context.Context, string) (*sql.Stmt, error)
-	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
-	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/schema_scoped_create/postgresql/pgx/v4/go/db.go
+++ b/internal/endtoend/testdata/schema_scoped_create/postgresql/pgx/v4/go/db.go
@@ -12,9 +12,9 @@ import (
 )
 
 type DBTX interface {
-	Exec(context.Context, string, ...interface{}) (pgconn.CommandTag, error)
-	Query(context.Context, string, ...interface{}) (pgx.Rows, error)
-	QueryRow(context.Context, string, ...interface{}) pgx.Row
+	Exec(context.Context, string, ...any) (pgconn.CommandTag, error)
+	Query(context.Context, string, ...any) (pgx.Rows, error)
+	QueryRow(context.Context, string, ...any) pgx.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/schema_scoped_create/postgresql/pgx/v5/go/db.go
+++ b/internal/endtoend/testdata/schema_scoped_create/postgresql/pgx/v5/go/db.go
@@ -12,9 +12,9 @@ import (
 )
 
 type DBTX interface {
-	Exec(context.Context, string, ...interface{}) (pgconn.CommandTag, error)
-	Query(context.Context, string, ...interface{}) (pgx.Rows, error)
-	QueryRow(context.Context, string, ...interface{}) pgx.Row
+	Exec(context.Context, string, ...any) (pgconn.CommandTag, error)
+	Query(context.Context, string, ...any) (pgx.Rows, error)
+	QueryRow(context.Context, string, ...any) pgx.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/schema_scoped_create/postgresql/stdlib/go/db.go
+++ b/internal/endtoend/testdata/schema_scoped_create/postgresql/stdlib/go/db.go
@@ -10,10 +10,10 @@ import (
 )
 
 type DBTX interface {
-	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
 	PrepareContext(context.Context, string) (*sql.Stmt, error)
-	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
-	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/schema_scoped_delete/mysql/go/db.go
+++ b/internal/endtoend/testdata/schema_scoped_delete/mysql/go/db.go
@@ -10,10 +10,10 @@ import (
 )
 
 type DBTX interface {
-	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
 	PrepareContext(context.Context, string) (*sql.Stmt, error)
-	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
-	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/schema_scoped_delete/postgresql/pgx/v4/go/db.go
+++ b/internal/endtoend/testdata/schema_scoped_delete/postgresql/pgx/v4/go/db.go
@@ -12,9 +12,9 @@ import (
 )
 
 type DBTX interface {
-	Exec(context.Context, string, ...interface{}) (pgconn.CommandTag, error)
-	Query(context.Context, string, ...interface{}) (pgx.Rows, error)
-	QueryRow(context.Context, string, ...interface{}) pgx.Row
+	Exec(context.Context, string, ...any) (pgconn.CommandTag, error)
+	Query(context.Context, string, ...any) (pgx.Rows, error)
+	QueryRow(context.Context, string, ...any) pgx.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/schema_scoped_delete/postgresql/pgx/v5/go/db.go
+++ b/internal/endtoend/testdata/schema_scoped_delete/postgresql/pgx/v5/go/db.go
@@ -12,9 +12,9 @@ import (
 )
 
 type DBTX interface {
-	Exec(context.Context, string, ...interface{}) (pgconn.CommandTag, error)
-	Query(context.Context, string, ...interface{}) (pgx.Rows, error)
-	QueryRow(context.Context, string, ...interface{}) pgx.Row
+	Exec(context.Context, string, ...any) (pgconn.CommandTag, error)
+	Query(context.Context, string, ...any) (pgx.Rows, error)
+	QueryRow(context.Context, string, ...any) pgx.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/schema_scoped_delete/postgresql/stdlib/go/db.go
+++ b/internal/endtoend/testdata/schema_scoped_delete/postgresql/stdlib/go/db.go
@@ -10,10 +10,10 @@ import (
 )
 
 type DBTX interface {
-	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
 	PrepareContext(context.Context, string) (*sql.Stmt, error)
-	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
-	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/schema_scoped_enum/pgx/v4/go/db.go
+++ b/internal/endtoend/testdata/schema_scoped_enum/pgx/v4/go/db.go
@@ -12,9 +12,9 @@ import (
 )
 
 type DBTX interface {
-	Exec(context.Context, string, ...interface{}) (pgconn.CommandTag, error)
-	Query(context.Context, string, ...interface{}) (pgx.Rows, error)
-	QueryRow(context.Context, string, ...interface{}) pgx.Row
+	Exec(context.Context, string, ...any) (pgconn.CommandTag, error)
+	Query(context.Context, string, ...any) (pgx.Rows, error)
+	QueryRow(context.Context, string, ...any) pgx.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/schema_scoped_enum/pgx/v4/go/models.go
+++ b/internal/endtoend/testdata/schema_scoped_enum/pgx/v4/go/models.go
@@ -16,7 +16,7 @@ const (
 	FooTypeUserRoleUser  FooTypeUserRole = "user"
 )
 
-func (e *FooTypeUserRole) Scan(src interface{}) error {
+func (e *FooTypeUserRole) Scan(src any) error {
 	switch s := src.(type) {
 	case []byte:
 		*e = FooTypeUserRole(s)
@@ -34,7 +34,7 @@ type NullFooTypeUserRole struct {
 }
 
 // Scan implements the Scanner interface.
-func (ns *NullFooTypeUserRole) Scan(value interface{}) error {
+func (ns *NullFooTypeUserRole) Scan(value any) error {
 	if value == nil {
 		ns.FooTypeUserRole, ns.Valid = "", false
 		return nil

--- a/internal/endtoend/testdata/schema_scoped_enum/pgx/v5/go/db.go
+++ b/internal/endtoend/testdata/schema_scoped_enum/pgx/v5/go/db.go
@@ -12,9 +12,9 @@ import (
 )
 
 type DBTX interface {
-	Exec(context.Context, string, ...interface{}) (pgconn.CommandTag, error)
-	Query(context.Context, string, ...interface{}) (pgx.Rows, error)
-	QueryRow(context.Context, string, ...interface{}) pgx.Row
+	Exec(context.Context, string, ...any) (pgconn.CommandTag, error)
+	Query(context.Context, string, ...any) (pgx.Rows, error)
+	QueryRow(context.Context, string, ...any) pgx.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/schema_scoped_enum/pgx/v5/go/models.go
+++ b/internal/endtoend/testdata/schema_scoped_enum/pgx/v5/go/models.go
@@ -16,7 +16,7 @@ const (
 	FooTypeUserRoleUser  FooTypeUserRole = "user"
 )
 
-func (e *FooTypeUserRole) Scan(src interface{}) error {
+func (e *FooTypeUserRole) Scan(src any) error {
 	switch s := src.(type) {
 	case []byte:
 		*e = FooTypeUserRole(s)
@@ -34,7 +34,7 @@ type NullFooTypeUserRole struct {
 }
 
 // Scan implements the Scanner interface.
-func (ns *NullFooTypeUserRole) Scan(value interface{}) error {
+func (ns *NullFooTypeUserRole) Scan(value any) error {
 	if value == nil {
 		ns.FooTypeUserRole, ns.Valid = "", false
 		return nil

--- a/internal/endtoend/testdata/schema_scoped_enum/stdlib/go/db.go
+++ b/internal/endtoend/testdata/schema_scoped_enum/stdlib/go/db.go
@@ -10,10 +10,10 @@ import (
 )
 
 type DBTX interface {
-	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
 	PrepareContext(context.Context, string) (*sql.Stmt, error)
-	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
-	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/schema_scoped_enum/stdlib/go/models.go
+++ b/internal/endtoend/testdata/schema_scoped_enum/stdlib/go/models.go
@@ -16,7 +16,7 @@ const (
 	FooTypeUserRoleUser  FooTypeUserRole = "user"
 )
 
-func (e *FooTypeUserRole) Scan(src interface{}) error {
+func (e *FooTypeUserRole) Scan(src any) error {
 	switch s := src.(type) {
 	case []byte:
 		*e = FooTypeUserRole(s)
@@ -34,7 +34,7 @@ type NullFooTypeUserRole struct {
 }
 
 // Scan implements the Scanner interface.
-func (ns *NullFooTypeUserRole) Scan(value interface{}) error {
+func (ns *NullFooTypeUserRole) Scan(value any) error {
 	if value == nil {
 		ns.FooTypeUserRole, ns.Valid = "", false
 		return nil

--- a/internal/endtoend/testdata/schema_scoped_filter/mysql/go/db.go
+++ b/internal/endtoend/testdata/schema_scoped_filter/mysql/go/db.go
@@ -10,10 +10,10 @@ import (
 )
 
 type DBTX interface {
-	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
 	PrepareContext(context.Context, string) (*sql.Stmt, error)
-	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
-	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/schema_scoped_filter/postgresql/pgx/v4/go/db.go
+++ b/internal/endtoend/testdata/schema_scoped_filter/postgresql/pgx/v4/go/db.go
@@ -12,9 +12,9 @@ import (
 )
 
 type DBTX interface {
-	Exec(context.Context, string, ...interface{}) (pgconn.CommandTag, error)
-	Query(context.Context, string, ...interface{}) (pgx.Rows, error)
-	QueryRow(context.Context, string, ...interface{}) pgx.Row
+	Exec(context.Context, string, ...any) (pgconn.CommandTag, error)
+	Query(context.Context, string, ...any) (pgx.Rows, error)
+	QueryRow(context.Context, string, ...any) pgx.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/schema_scoped_filter/postgresql/pgx/v5/go/db.go
+++ b/internal/endtoend/testdata/schema_scoped_filter/postgresql/pgx/v5/go/db.go
@@ -12,9 +12,9 @@ import (
 )
 
 type DBTX interface {
-	Exec(context.Context, string, ...interface{}) (pgconn.CommandTag, error)
-	Query(context.Context, string, ...interface{}) (pgx.Rows, error)
-	QueryRow(context.Context, string, ...interface{}) pgx.Row
+	Exec(context.Context, string, ...any) (pgconn.CommandTag, error)
+	Query(context.Context, string, ...any) (pgx.Rows, error)
+	QueryRow(context.Context, string, ...any) pgx.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/schema_scoped_filter/postgresql/stdlib/go/db.go
+++ b/internal/endtoend/testdata/schema_scoped_filter/postgresql/stdlib/go/db.go
@@ -10,10 +10,10 @@ import (
 )
 
 type DBTX interface {
-	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
 	PrepareContext(context.Context, string) (*sql.Stmt, error)
-	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
-	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/schema_scoped_list/mysql/go/db.go
+++ b/internal/endtoend/testdata/schema_scoped_list/mysql/go/db.go
@@ -10,10 +10,10 @@ import (
 )
 
 type DBTX interface {
-	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
 	PrepareContext(context.Context, string) (*sql.Stmt, error)
-	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
-	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/schema_scoped_list/postgresql/pgx/v4/go/db.go
+++ b/internal/endtoend/testdata/schema_scoped_list/postgresql/pgx/v4/go/db.go
@@ -12,9 +12,9 @@ import (
 )
 
 type DBTX interface {
-	Exec(context.Context, string, ...interface{}) (pgconn.CommandTag, error)
-	Query(context.Context, string, ...interface{}) (pgx.Rows, error)
-	QueryRow(context.Context, string, ...interface{}) pgx.Row
+	Exec(context.Context, string, ...any) (pgconn.CommandTag, error)
+	Query(context.Context, string, ...any) (pgx.Rows, error)
+	QueryRow(context.Context, string, ...any) pgx.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/schema_scoped_list/postgresql/pgx/v5/go/db.go
+++ b/internal/endtoend/testdata/schema_scoped_list/postgresql/pgx/v5/go/db.go
@@ -12,9 +12,9 @@ import (
 )
 
 type DBTX interface {
-	Exec(context.Context, string, ...interface{}) (pgconn.CommandTag, error)
-	Query(context.Context, string, ...interface{}) (pgx.Rows, error)
-	QueryRow(context.Context, string, ...interface{}) pgx.Row
+	Exec(context.Context, string, ...any) (pgconn.CommandTag, error)
+	Query(context.Context, string, ...any) (pgx.Rows, error)
+	QueryRow(context.Context, string, ...any) pgx.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/schema_scoped_list/postgresql/stdlib/go/db.go
+++ b/internal/endtoend/testdata/schema_scoped_list/postgresql/stdlib/go/db.go
@@ -10,10 +10,10 @@ import (
 )
 
 type DBTX interface {
-	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
 	PrepareContext(context.Context, string) (*sql.Stmt, error)
-	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
-	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/schema_scoped_update/mysql/go/db.go
+++ b/internal/endtoend/testdata/schema_scoped_update/mysql/go/db.go
@@ -10,10 +10,10 @@ import (
 )
 
 type DBTX interface {
-	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
 	PrepareContext(context.Context, string) (*sql.Stmt, error)
-	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
-	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/schema_scoped_update/postgresql/pgx/v4/go/db.go
+++ b/internal/endtoend/testdata/schema_scoped_update/postgresql/pgx/v4/go/db.go
@@ -12,9 +12,9 @@ import (
 )
 
 type DBTX interface {
-	Exec(context.Context, string, ...interface{}) (pgconn.CommandTag, error)
-	Query(context.Context, string, ...interface{}) (pgx.Rows, error)
-	QueryRow(context.Context, string, ...interface{}) pgx.Row
+	Exec(context.Context, string, ...any) (pgconn.CommandTag, error)
+	Query(context.Context, string, ...any) (pgx.Rows, error)
+	QueryRow(context.Context, string, ...any) pgx.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/schema_scoped_update/postgresql/pgx/v5/go/db.go
+++ b/internal/endtoend/testdata/schema_scoped_update/postgresql/pgx/v5/go/db.go
@@ -12,9 +12,9 @@ import (
 )
 
 type DBTX interface {
-	Exec(context.Context, string, ...interface{}) (pgconn.CommandTag, error)
-	Query(context.Context, string, ...interface{}) (pgx.Rows, error)
-	QueryRow(context.Context, string, ...interface{}) pgx.Row
+	Exec(context.Context, string, ...any) (pgconn.CommandTag, error)
+	Query(context.Context, string, ...any) (pgx.Rows, error)
+	QueryRow(context.Context, string, ...any) pgx.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/schema_scoped_update/postgresql/stdlib/go/db.go
+++ b/internal/endtoend/testdata/schema_scoped_update/postgresql/stdlib/go/db.go
@@ -10,10 +10,10 @@ import (
 )
 
 type DBTX interface {
-	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
 	PrepareContext(context.Context, string) (*sql.Stmt, error)
-	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
-	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/schema_table_column_ref/postgresql/pgx/go/db.go
+++ b/internal/endtoend/testdata/schema_table_column_ref/postgresql/pgx/go/db.go
@@ -12,9 +12,9 @@ import (
 )
 
 type DBTX interface {
-	Exec(context.Context, string, ...interface{}) (pgconn.CommandTag, error)
-	Query(context.Context, string, ...interface{}) (pgx.Rows, error)
-	QueryRow(context.Context, string, ...interface{}) pgx.Row
+	Exec(context.Context, string, ...any) (pgconn.CommandTag, error)
+	Query(context.Context, string, ...any) (pgx.Rows, error)
+	QueryRow(context.Context, string, ...any) pgx.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/select_column_cast/mysql/go/db.go
+++ b/internal/endtoend/testdata/select_column_cast/mysql/go/db.go
@@ -10,10 +10,10 @@ import (
 )
 
 type DBTX interface {
-	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
 	PrepareContext(context.Context, string) (*sql.Stmt, error)
-	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
-	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/select_column_cast/postgresql/pgx/v4/go/db.go
+++ b/internal/endtoend/testdata/select_column_cast/postgresql/pgx/v4/go/db.go
@@ -12,9 +12,9 @@ import (
 )
 
 type DBTX interface {
-	Exec(context.Context, string, ...interface{}) (pgconn.CommandTag, error)
-	Query(context.Context, string, ...interface{}) (pgx.Rows, error)
-	QueryRow(context.Context, string, ...interface{}) pgx.Row
+	Exec(context.Context, string, ...any) (pgconn.CommandTag, error)
+	Query(context.Context, string, ...any) (pgx.Rows, error)
+	QueryRow(context.Context, string, ...any) pgx.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/select_column_cast/postgresql/pgx/v5/go/db.go
+++ b/internal/endtoend/testdata/select_column_cast/postgresql/pgx/v5/go/db.go
@@ -12,9 +12,9 @@ import (
 )
 
 type DBTX interface {
-	Exec(context.Context, string, ...interface{}) (pgconn.CommandTag, error)
-	Query(context.Context, string, ...interface{}) (pgx.Rows, error)
-	QueryRow(context.Context, string, ...interface{}) pgx.Row
+	Exec(context.Context, string, ...any) (pgconn.CommandTag, error)
+	Query(context.Context, string, ...any) (pgx.Rows, error)
+	QueryRow(context.Context, string, ...any) pgx.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/select_column_cast/postgresql/stdlib/go/db.go
+++ b/internal/endtoend/testdata/select_column_cast/postgresql/stdlib/go/db.go
@@ -10,10 +10,10 @@ import (
 )
 
 type DBTX interface {
-	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
 	PrepareContext(context.Context, string) (*sql.Stmt, error)
-	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
-	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/select_column_cast/sqlite/go/db.go
+++ b/internal/endtoend/testdata/select_column_cast/sqlite/go/db.go
@@ -10,10 +10,10 @@ import (
 )
 
 type DBTX interface {
-	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
 	PrepareContext(context.Context, string) (*sql.Stmt, error)
-	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
-	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/select_cte/sqlite/go/db.go
+++ b/internal/endtoend/testdata/select_cte/sqlite/go/db.go
@@ -10,10 +10,10 @@ import (
 )
 
 type DBTX interface {
-	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
 	PrepareContext(context.Context, string) (*sql.Stmt, error)
-	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
-	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/select_distinct/pgx/v4/go/db.go
+++ b/internal/endtoend/testdata/select_distinct/pgx/v4/go/db.go
@@ -12,9 +12,9 @@ import (
 )
 
 type DBTX interface {
-	Exec(context.Context, string, ...interface{}) (pgconn.CommandTag, error)
-	Query(context.Context, string, ...interface{}) (pgx.Rows, error)
-	QueryRow(context.Context, string, ...interface{}) pgx.Row
+	Exec(context.Context, string, ...any) (pgconn.CommandTag, error)
+	Query(context.Context, string, ...any) (pgx.Rows, error)
+	QueryRow(context.Context, string, ...any) pgx.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/select_distinct/pgx/v5/go/db.go
+++ b/internal/endtoend/testdata/select_distinct/pgx/v5/go/db.go
@@ -12,9 +12,9 @@ import (
 )
 
 type DBTX interface {
-	Exec(context.Context, string, ...interface{}) (pgconn.CommandTag, error)
-	Query(context.Context, string, ...interface{}) (pgx.Rows, error)
-	QueryRow(context.Context, string, ...interface{}) pgx.Row
+	Exec(context.Context, string, ...any) (pgconn.CommandTag, error)
+	Query(context.Context, string, ...any) (pgx.Rows, error)
+	QueryRow(context.Context, string, ...any) pgx.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/select_distinct/stdlib/go/db.go
+++ b/internal/endtoend/testdata/select_distinct/stdlib/go/db.go
@@ -10,10 +10,10 @@ import (
 )
 
 type DBTX interface {
-	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
 	PrepareContext(context.Context, string) (*sql.Stmt, error)
-	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
-	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/select_empty_column_list/postgresql/pgx/v4/go/db.go
+++ b/internal/endtoend/testdata/select_empty_column_list/postgresql/pgx/v4/go/db.go
@@ -12,9 +12,9 @@ import (
 )
 
 type DBTX interface {
-	Exec(context.Context, string, ...interface{}) (pgconn.CommandTag, error)
-	Query(context.Context, string, ...interface{}) (pgx.Rows, error)
-	QueryRow(context.Context, string, ...interface{}) pgx.Row
+	Exec(context.Context, string, ...any) (pgconn.CommandTag, error)
+	Query(context.Context, string, ...any) (pgx.Rows, error)
+	QueryRow(context.Context, string, ...any) pgx.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/select_empty_column_list/postgresql/pgx/v5/go/db.go
+++ b/internal/endtoend/testdata/select_empty_column_list/postgresql/pgx/v5/go/db.go
@@ -12,9 +12,9 @@ import (
 )
 
 type DBTX interface {
-	Exec(context.Context, string, ...interface{}) (pgconn.CommandTag, error)
-	Query(context.Context, string, ...interface{}) (pgx.Rows, error)
-	QueryRow(context.Context, string, ...interface{}) pgx.Row
+	Exec(context.Context, string, ...any) (pgconn.CommandTag, error)
+	Query(context.Context, string, ...any) (pgx.Rows, error)
+	QueryRow(context.Context, string, ...any) pgx.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/select_empty_column_list/postgresql/stdlib/go/db.go
+++ b/internal/endtoend/testdata/select_empty_column_list/postgresql/stdlib/go/db.go
@@ -10,10 +10,10 @@ import (
 )
 
 type DBTX interface {
-	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
 	PrepareContext(context.Context, string) (*sql.Stmt, error)
-	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
-	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/select_exists/pgx/v4/go/db.go
+++ b/internal/endtoend/testdata/select_exists/pgx/v4/go/db.go
@@ -12,9 +12,9 @@ import (
 )
 
 type DBTX interface {
-	Exec(context.Context, string, ...interface{}) (pgconn.CommandTag, error)
-	Query(context.Context, string, ...interface{}) (pgx.Rows, error)
-	QueryRow(context.Context, string, ...interface{}) pgx.Row
+	Exec(context.Context, string, ...any) (pgconn.CommandTag, error)
+	Query(context.Context, string, ...any) (pgx.Rows, error)
+	QueryRow(context.Context, string, ...any) pgx.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/select_exists/pgx/v5/go/db.go
+++ b/internal/endtoend/testdata/select_exists/pgx/v5/go/db.go
@@ -12,9 +12,9 @@ import (
 )
 
 type DBTX interface {
-	Exec(context.Context, string, ...interface{}) (pgconn.CommandTag, error)
-	Query(context.Context, string, ...interface{}) (pgx.Rows, error)
-	QueryRow(context.Context, string, ...interface{}) pgx.Row
+	Exec(context.Context, string, ...any) (pgconn.CommandTag, error)
+	Query(context.Context, string, ...any) (pgx.Rows, error)
+	QueryRow(context.Context, string, ...any) pgx.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/select_exists/sqlite/go/db.go
+++ b/internal/endtoend/testdata/select_exists/sqlite/go/db.go
@@ -10,10 +10,10 @@ import (
 )
 
 type DBTX interface {
-	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
 	PrepareContext(context.Context, string) (*sql.Stmt, error)
-	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
-	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/select_exists/stdlib/go/db.go
+++ b/internal/endtoend/testdata/select_exists/stdlib/go/db.go
@@ -10,10 +10,10 @@ import (
 )
 
 type DBTX interface {
-	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
 	PrepareContext(context.Context, string) (*sql.Stmt, error)
-	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
-	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/select_in_and/sqlite/go/db.go
+++ b/internal/endtoend/testdata/select_in_and/sqlite/go/db.go
@@ -10,10 +10,10 @@ import (
 )
 
 type DBTX interface {
-	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
 	PrepareContext(context.Context, string) (*sql.Stmt, error)
-	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
-	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/select_limit/mysql/go/db.go
+++ b/internal/endtoend/testdata/select_limit/mysql/go/db.go
@@ -10,10 +10,10 @@ import (
 )
 
 type DBTX interface {
-	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
 	PrepareContext(context.Context, string) (*sql.Stmt, error)
-	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
-	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/select_limit/postgresql/pgx/v4/go/db.go
+++ b/internal/endtoend/testdata/select_limit/postgresql/pgx/v4/go/db.go
@@ -12,9 +12,9 @@ import (
 )
 
 type DBTX interface {
-	Exec(context.Context, string, ...interface{}) (pgconn.CommandTag, error)
-	Query(context.Context, string, ...interface{}) (pgx.Rows, error)
-	QueryRow(context.Context, string, ...interface{}) pgx.Row
+	Exec(context.Context, string, ...any) (pgconn.CommandTag, error)
+	Query(context.Context, string, ...any) (pgx.Rows, error)
+	QueryRow(context.Context, string, ...any) pgx.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/select_limit/postgresql/pgx/v5/go/db.go
+++ b/internal/endtoend/testdata/select_limit/postgresql/pgx/v5/go/db.go
@@ -12,9 +12,9 @@ import (
 )
 
 type DBTX interface {
-	Exec(context.Context, string, ...interface{}) (pgconn.CommandTag, error)
-	Query(context.Context, string, ...interface{}) (pgx.Rows, error)
-	QueryRow(context.Context, string, ...interface{}) pgx.Row
+	Exec(context.Context, string, ...any) (pgconn.CommandTag, error)
+	Query(context.Context, string, ...any) (pgx.Rows, error)
+	QueryRow(context.Context, string, ...any) pgx.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/select_limit/postgresql/stdlib/go/db.go
+++ b/internal/endtoend/testdata/select_limit/postgresql/stdlib/go/db.go
@@ -10,10 +10,10 @@ import (
 )
 
 type DBTX interface {
-	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
 	PrepareContext(context.Context, string) (*sql.Stmt, error)
-	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
-	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/select_limit/sqlite/go/db.go
+++ b/internal/endtoend/testdata/select_limit/sqlite/go/db.go
@@ -10,10 +10,10 @@ import (
 )
 
 type DBTX interface {
-	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
 	PrepareContext(context.Context, string) (*sql.Stmt, error)
-	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
-	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/select_nested_count/mysql/go/db.go
+++ b/internal/endtoend/testdata/select_nested_count/mysql/go/db.go
@@ -10,10 +10,10 @@ import (
 )
 
 type DBTX interface {
-	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
 	PrepareContext(context.Context, string) (*sql.Stmt, error)
-	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
-	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/select_nested_count/postgresql/go/db.go
+++ b/internal/endtoend/testdata/select_nested_count/postgresql/go/db.go
@@ -10,10 +10,10 @@ import (
 )
 
 type DBTX interface {
-	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
 	PrepareContext(context.Context, string) (*sql.Stmt, error)
-	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
-	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/select_nested_count/sqlite/go/db.go
+++ b/internal/endtoend/testdata/select_nested_count/sqlite/go/db.go
@@ -10,10 +10,10 @@ import (
 )
 
 type DBTX interface {
-	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
 	PrepareContext(context.Context, string) (*sql.Stmt, error)
-	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
-	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/select_not_exists/pgx/v4/go/db.go
+++ b/internal/endtoend/testdata/select_not_exists/pgx/v4/go/db.go
@@ -12,9 +12,9 @@ import (
 )
 
 type DBTX interface {
-	Exec(context.Context, string, ...interface{}) (pgconn.CommandTag, error)
-	Query(context.Context, string, ...interface{}) (pgx.Rows, error)
-	QueryRow(context.Context, string, ...interface{}) pgx.Row
+	Exec(context.Context, string, ...any) (pgconn.CommandTag, error)
+	Query(context.Context, string, ...any) (pgx.Rows, error)
+	QueryRow(context.Context, string, ...any) pgx.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/select_not_exists/pgx/v5/go/db.go
+++ b/internal/endtoend/testdata/select_not_exists/pgx/v5/go/db.go
@@ -12,9 +12,9 @@ import (
 )
 
 type DBTX interface {
-	Exec(context.Context, string, ...interface{}) (pgconn.CommandTag, error)
-	Query(context.Context, string, ...interface{}) (pgx.Rows, error)
-	QueryRow(context.Context, string, ...interface{}) pgx.Row
+	Exec(context.Context, string, ...any) (pgconn.CommandTag, error)
+	Query(context.Context, string, ...any) (pgx.Rows, error)
+	QueryRow(context.Context, string, ...any) pgx.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/select_not_exists/sqlite/go/db.go
+++ b/internal/endtoend/testdata/select_not_exists/sqlite/go/db.go
@@ -10,10 +10,10 @@ import (
 )
 
 type DBTX interface {
-	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
 	PrepareContext(context.Context, string) (*sql.Stmt, error)
-	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
-	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/select_not_exists/stdlib/go/db.go
+++ b/internal/endtoend/testdata/select_not_exists/stdlib/go/db.go
@@ -10,10 +10,10 @@ import (
 )
 
 type DBTX interface {
-	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
 	PrepareContext(context.Context, string) (*sql.Stmt, error)
-	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
-	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/select_sequence/postgresql/pgx/go/db.go
+++ b/internal/endtoend/testdata/select_sequence/postgresql/pgx/go/db.go
@@ -12,9 +12,9 @@ import (
 )
 
 type DBTX interface {
-	Exec(context.Context, string, ...interface{}) (pgconn.CommandTag, error)
-	Query(context.Context, string, ...interface{}) (pgx.Rows, error)
-	QueryRow(context.Context, string, ...interface{}) pgx.Row
+	Exec(context.Context, string, ...any) (pgconn.CommandTag, error)
+	Query(context.Context, string, ...any) (pgx.Rows, error)
+	QueryRow(context.Context, string, ...any) pgx.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/select_star/mysql/go/db.go
+++ b/internal/endtoend/testdata/select_star/mysql/go/db.go
@@ -10,10 +10,10 @@ import (
 )
 
 type DBTX interface {
-	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
 	PrepareContext(context.Context, string) (*sql.Stmt, error)
-	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
-	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/select_star/postgresql/pgx/v4/go/db.go
+++ b/internal/endtoend/testdata/select_star/postgresql/pgx/v4/go/db.go
@@ -12,9 +12,9 @@ import (
 )
 
 type DBTX interface {
-	Exec(context.Context, string, ...interface{}) (pgconn.CommandTag, error)
-	Query(context.Context, string, ...interface{}) (pgx.Rows, error)
-	QueryRow(context.Context, string, ...interface{}) pgx.Row
+	Exec(context.Context, string, ...any) (pgconn.CommandTag, error)
+	Query(context.Context, string, ...any) (pgx.Rows, error)
+	QueryRow(context.Context, string, ...any) pgx.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/select_star/postgresql/pgx/v5/go/db.go
+++ b/internal/endtoend/testdata/select_star/postgresql/pgx/v5/go/db.go
@@ -12,9 +12,9 @@ import (
 )
 
 type DBTX interface {
-	Exec(context.Context, string, ...interface{}) (pgconn.CommandTag, error)
-	Query(context.Context, string, ...interface{}) (pgx.Rows, error)
-	QueryRow(context.Context, string, ...interface{}) pgx.Row
+	Exec(context.Context, string, ...any) (pgconn.CommandTag, error)
+	Query(context.Context, string, ...any) (pgx.Rows, error)
+	QueryRow(context.Context, string, ...any) pgx.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/select_star/postgresql/stdlib/go/db.go
+++ b/internal/endtoend/testdata/select_star/postgresql/stdlib/go/db.go
@@ -10,10 +10,10 @@ import (
 )
 
 type DBTX interface {
-	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
 	PrepareContext(context.Context, string) (*sql.Stmt, error)
-	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
-	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/select_star/sqlite/go/db.go
+++ b/internal/endtoend/testdata/select_star/sqlite/go/db.go
@@ -10,10 +10,10 @@ import (
 )
 
 type DBTX interface {
-	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
 	PrepareContext(context.Context, string) (*sql.Stmt, error)
-	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
-	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/select_star_quoted/mysql/go/db.go
+++ b/internal/endtoend/testdata/select_star_quoted/mysql/go/db.go
@@ -10,10 +10,10 @@ import (
 )
 
 type DBTX interface {
-	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
 	PrepareContext(context.Context, string) (*sql.Stmt, error)
-	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
-	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/select_star_quoted/postgresql/pgx/v4/go/db.go
+++ b/internal/endtoend/testdata/select_star_quoted/postgresql/pgx/v4/go/db.go
@@ -12,9 +12,9 @@ import (
 )
 
 type DBTX interface {
-	Exec(context.Context, string, ...interface{}) (pgconn.CommandTag, error)
-	Query(context.Context, string, ...interface{}) (pgx.Rows, error)
-	QueryRow(context.Context, string, ...interface{}) pgx.Row
+	Exec(context.Context, string, ...any) (pgconn.CommandTag, error)
+	Query(context.Context, string, ...any) (pgx.Rows, error)
+	QueryRow(context.Context, string, ...any) pgx.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/select_star_quoted/postgresql/pgx/v5/go/db.go
+++ b/internal/endtoend/testdata/select_star_quoted/postgresql/pgx/v5/go/db.go
@@ -12,9 +12,9 @@ import (
 )
 
 type DBTX interface {
-	Exec(context.Context, string, ...interface{}) (pgconn.CommandTag, error)
-	Query(context.Context, string, ...interface{}) (pgx.Rows, error)
-	QueryRow(context.Context, string, ...interface{}) pgx.Row
+	Exec(context.Context, string, ...any) (pgconn.CommandTag, error)
+	Query(context.Context, string, ...any) (pgx.Rows, error)
+	QueryRow(context.Context, string, ...any) pgx.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/select_star_quoted/postgresql/stdlib/go/db.go
+++ b/internal/endtoend/testdata/select_star_quoted/postgresql/stdlib/go/db.go
@@ -10,10 +10,10 @@ import (
 )
 
 type DBTX interface {
-	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
 	PrepareContext(context.Context, string) (*sql.Stmt, error)
-	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
-	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/select_subquery/postgresql/stdlib/go/db.go
+++ b/internal/endtoend/testdata/select_subquery/postgresql/stdlib/go/db.go
@@ -10,10 +10,10 @@ import (
 )
 
 type DBTX interface {
-	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
 	PrepareContext(context.Context, string) (*sql.Stmt, error)
-	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
-	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/select_subquery_alias/postgresql/pgx/go/db.go
+++ b/internal/endtoend/testdata/select_subquery_alias/postgresql/pgx/go/db.go
@@ -12,9 +12,9 @@ import (
 )
 
 type DBTX interface {
-	Exec(context.Context, string, ...interface{}) (pgconn.CommandTag, error)
-	Query(context.Context, string, ...interface{}) (pgx.Rows, error)
-	QueryRow(context.Context, string, ...interface{}) pgx.Row
+	Exec(context.Context, string, ...any) (pgconn.CommandTag, error)
+	Query(context.Context, string, ...any) (pgx.Rows, error)
+	QueryRow(context.Context, string, ...any) pgx.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/select_subquery_no_alias/mysql/go/db.go
+++ b/internal/endtoend/testdata/select_subquery_no_alias/mysql/go/db.go
@@ -10,10 +10,10 @@ import (
 )
 
 type DBTX interface {
-	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
 	PrepareContext(context.Context, string) (*sql.Stmt, error)
-	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
-	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/select_subquery_no_alias/postgres/stdlib/go/db.go
+++ b/internal/endtoend/testdata/select_subquery_no_alias/postgres/stdlib/go/db.go
@@ -10,10 +10,10 @@ import (
 )
 
 type DBTX interface {
-	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
 	PrepareContext(context.Context, string) (*sql.Stmt, error)
-	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
-	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/select_subquery_no_alias/sqlite/go/db.go
+++ b/internal/endtoend/testdata/select_subquery_no_alias/sqlite/go/db.go
@@ -10,10 +10,10 @@ import (
 )
 
 type DBTX interface {
-	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
 	PrepareContext(context.Context, string) (*sql.Stmt, error)
-	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
-	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/select_system/pgx/go/db.go
+++ b/internal/endtoend/testdata/select_system/pgx/go/db.go
@@ -12,9 +12,9 @@ import (
 )
 
 type DBTX interface {
-	Exec(context.Context, string, ...interface{}) (pgconn.CommandTag, error)
-	Query(context.Context, string, ...interface{}) (pgx.Rows, error)
-	QueryRow(context.Context, string, ...interface{}) pgx.Row
+	Exec(context.Context, string, ...any) (pgconn.CommandTag, error)
+	Query(context.Context, string, ...any) (pgx.Rows, error)
+	QueryRow(context.Context, string, ...any) pgx.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/select_text_array/pgx/v4/go/db.go
+++ b/internal/endtoend/testdata/select_text_array/pgx/v4/go/db.go
@@ -12,9 +12,9 @@ import (
 )
 
 type DBTX interface {
-	Exec(context.Context, string, ...interface{}) (pgconn.CommandTag, error)
-	Query(context.Context, string, ...interface{}) (pgx.Rows, error)
-	QueryRow(context.Context, string, ...interface{}) pgx.Row
+	Exec(context.Context, string, ...any) (pgconn.CommandTag, error)
+	Query(context.Context, string, ...any) (pgx.Rows, error)
+	QueryRow(context.Context, string, ...any) pgx.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/select_text_array/pgx/v5/go/db.go
+++ b/internal/endtoend/testdata/select_text_array/pgx/v5/go/db.go
@@ -12,9 +12,9 @@ import (
 )
 
 type DBTX interface {
-	Exec(context.Context, string, ...interface{}) (pgconn.CommandTag, error)
-	Query(context.Context, string, ...interface{}) (pgx.Rows, error)
-	QueryRow(context.Context, string, ...interface{}) pgx.Row
+	Exec(context.Context, string, ...any) (pgconn.CommandTag, error)
+	Query(context.Context, string, ...any) (pgx.Rows, error)
+	QueryRow(context.Context, string, ...any) pgx.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/select_text_array/stdlib/go/db.go
+++ b/internal/endtoend/testdata/select_text_array/stdlib/go/db.go
@@ -10,10 +10,10 @@ import (
 )
 
 type DBTX interface {
-	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
 	PrepareContext(context.Context, string) (*sql.Stmt, error)
-	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
-	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/select_union/mysql/go/db.go
+++ b/internal/endtoend/testdata/select_union/mysql/go/db.go
@@ -10,10 +10,10 @@ import (
 )
 
 type DBTX interface {
-	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
 	PrepareContext(context.Context, string) (*sql.Stmt, error)
-	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
-	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/select_union/postgres/pgx/v4/go/db.go
+++ b/internal/endtoend/testdata/select_union/postgres/pgx/v4/go/db.go
@@ -12,9 +12,9 @@ import (
 )
 
 type DBTX interface {
-	Exec(context.Context, string, ...interface{}) (pgconn.CommandTag, error)
-	Query(context.Context, string, ...interface{}) (pgx.Rows, error)
-	QueryRow(context.Context, string, ...interface{}) pgx.Row
+	Exec(context.Context, string, ...any) (pgconn.CommandTag, error)
+	Query(context.Context, string, ...any) (pgx.Rows, error)
+	QueryRow(context.Context, string, ...any) pgx.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/select_union/postgres/pgx/v5/go/db.go
+++ b/internal/endtoend/testdata/select_union/postgres/pgx/v5/go/db.go
@@ -12,9 +12,9 @@ import (
 )
 
 type DBTX interface {
-	Exec(context.Context, string, ...interface{}) (pgconn.CommandTag, error)
-	Query(context.Context, string, ...interface{}) (pgx.Rows, error)
-	QueryRow(context.Context, string, ...interface{}) pgx.Row
+	Exec(context.Context, string, ...any) (pgconn.CommandTag, error)
+	Query(context.Context, string, ...any) (pgx.Rows, error)
+	QueryRow(context.Context, string, ...any) pgx.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/select_union/postgres/stdlib/go/db.go
+++ b/internal/endtoend/testdata/select_union/postgres/stdlib/go/db.go
@@ -10,10 +10,10 @@ import (
 )
 
 type DBTX interface {
-	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
 	PrepareContext(context.Context, string) (*sql.Stmt, error)
-	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
-	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/select_union/sqlite/go/db.go
+++ b/internal/endtoend/testdata/select_union/sqlite/go/db.go
@@ -10,10 +10,10 @@ import (
 )
 
 type DBTX interface {
-	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
 	PrepareContext(context.Context, string) (*sql.Stmt, error)
-	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
-	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/select_union_subquery/mysql/go/db.go
+++ b/internal/endtoend/testdata/select_union_subquery/mysql/go/db.go
@@ -10,10 +10,10 @@ import (
 )
 
 type DBTX interface {
-	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
 	PrepareContext(context.Context, string) (*sql.Stmt, error)
-	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
-	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/select_union_subquery/postgresql/go/db.go
+++ b/internal/endtoend/testdata/select_union_subquery/postgresql/go/db.go
@@ -12,9 +12,9 @@ import (
 )
 
 type DBTX interface {
-	Exec(context.Context, string, ...interface{}) (pgconn.CommandTag, error)
-	Query(context.Context, string, ...interface{}) (pgx.Rows, error)
-	QueryRow(context.Context, string, ...interface{}) pgx.Row
+	Exec(context.Context, string, ...any) (pgconn.CommandTag, error)
+	Query(context.Context, string, ...any) (pgx.Rows, error)
+	QueryRow(context.Context, string, ...any) pgx.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/selectstatic/mysql/go/db.go
+++ b/internal/endtoend/testdata/selectstatic/mysql/go/db.go
@@ -10,10 +10,10 @@ import (
 )
 
 type DBTX interface {
-	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
 	PrepareContext(context.Context, string) (*sql.Stmt, error)
-	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
-	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/show_warnings/mysql/go/db.go
+++ b/internal/endtoend/testdata/show_warnings/mysql/go/db.go
@@ -10,10 +10,10 @@ import (
 )
 
 type DBTX interface {
-	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
 	PrepareContext(context.Context, string) (*sql.Stmt, error)
-	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
-	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/single_param_conflict/mysql/go/db.go
+++ b/internal/endtoend/testdata/single_param_conflict/mysql/go/db.go
@@ -10,10 +10,10 @@ import (
 )
 
 type DBTX interface {
-	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
 	PrepareContext(context.Context, string) (*sql.Stmt, error)
-	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
-	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/single_param_conflict/postgresql/pgx/v4/go/db.go
+++ b/internal/endtoend/testdata/single_param_conflict/postgresql/pgx/v4/go/db.go
@@ -12,9 +12,9 @@ import (
 )
 
 type DBTX interface {
-	Exec(context.Context, string, ...interface{}) (pgconn.CommandTag, error)
-	Query(context.Context, string, ...interface{}) (pgx.Rows, error)
-	QueryRow(context.Context, string, ...interface{}) pgx.Row
+	Exec(context.Context, string, ...any) (pgconn.CommandTag, error)
+	Query(context.Context, string, ...any) (pgx.Rows, error)
+	QueryRow(context.Context, string, ...any) pgx.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/single_param_conflict/postgresql/pgx/v5/go/db.go
+++ b/internal/endtoend/testdata/single_param_conflict/postgresql/pgx/v5/go/db.go
@@ -12,9 +12,9 @@ import (
 )
 
 type DBTX interface {
-	Exec(context.Context, string, ...interface{}) (pgconn.CommandTag, error)
-	Query(context.Context, string, ...interface{}) (pgx.Rows, error)
-	QueryRow(context.Context, string, ...interface{}) pgx.Row
+	Exec(context.Context, string, ...any) (pgconn.CommandTag, error)
+	Query(context.Context, string, ...any) (pgx.Rows, error)
+	QueryRow(context.Context, string, ...any) pgx.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/single_param_conflict/postgresql/stdlib/go/db.go
+++ b/internal/endtoend/testdata/single_param_conflict/postgresql/stdlib/go/db.go
@@ -10,10 +10,10 @@ import (
 )
 
 type DBTX interface {
-	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
 	PrepareContext(context.Context, string) (*sql.Stmt, error)
-	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
-	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/single_param_conflict/sqlite/go/db.go
+++ b/internal/endtoend/testdata/single_param_conflict/sqlite/go/db.go
@@ -10,10 +10,10 @@ import (
 )
 
 type DBTX interface {
-	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
 	PrepareContext(context.Context, string) (*sql.Stmt, error)
-	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
-	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/sql_syntax_calling_funcs/postgresql/pgx/v4/go/db.go
+++ b/internal/endtoend/testdata/sql_syntax_calling_funcs/postgresql/pgx/v4/go/db.go
@@ -12,9 +12,9 @@ import (
 )
 
 type DBTX interface {
-	Exec(context.Context, string, ...interface{}) (pgconn.CommandTag, error)
-	Query(context.Context, string, ...interface{}) (pgx.Rows, error)
-	QueryRow(context.Context, string, ...interface{}) pgx.Row
+	Exec(context.Context, string, ...any) (pgconn.CommandTag, error)
+	Query(context.Context, string, ...any) (pgx.Rows, error)
+	QueryRow(context.Context, string, ...any) pgx.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/sql_syntax_calling_funcs/postgresql/pgx/v5/go/db.go
+++ b/internal/endtoend/testdata/sql_syntax_calling_funcs/postgresql/pgx/v5/go/db.go
@@ -12,9 +12,9 @@ import (
 )
 
 type DBTX interface {
-	Exec(context.Context, string, ...interface{}) (pgconn.CommandTag, error)
-	Query(context.Context, string, ...interface{}) (pgx.Rows, error)
-	QueryRow(context.Context, string, ...interface{}) pgx.Row
+	Exec(context.Context, string, ...any) (pgconn.CommandTag, error)
+	Query(context.Context, string, ...any) (pgx.Rows, error)
+	QueryRow(context.Context, string, ...any) pgx.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/sql_syntax_calling_funcs/postgresql/stdlib/go/db.go
+++ b/internal/endtoend/testdata/sql_syntax_calling_funcs/postgresql/stdlib/go/db.go
@@ -10,10 +10,10 @@ import (
 )
 
 type DBTX interface {
-	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
 	PrepareContext(context.Context, string) (*sql.Stmt, error)
-	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
-	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/sqlc_arg/mysql/go/db.go
+++ b/internal/endtoend/testdata/sqlc_arg/mysql/go/db.go
@@ -10,10 +10,10 @@ import (
 )
 
 type DBTX interface {
-	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
 	PrepareContext(context.Context, string) (*sql.Stmt, error)
-	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
-	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/sqlc_arg/postgresql/pgx/v4/go/db.go
+++ b/internal/endtoend/testdata/sqlc_arg/postgresql/pgx/v4/go/db.go
@@ -12,9 +12,9 @@ import (
 )
 
 type DBTX interface {
-	Exec(context.Context, string, ...interface{}) (pgconn.CommandTag, error)
-	Query(context.Context, string, ...interface{}) (pgx.Rows, error)
-	QueryRow(context.Context, string, ...interface{}) pgx.Row
+	Exec(context.Context, string, ...any) (pgconn.CommandTag, error)
+	Query(context.Context, string, ...any) (pgx.Rows, error)
+	QueryRow(context.Context, string, ...any) pgx.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/sqlc_arg/postgresql/pgx/v5/go/db.go
+++ b/internal/endtoend/testdata/sqlc_arg/postgresql/pgx/v5/go/db.go
@@ -12,9 +12,9 @@ import (
 )
 
 type DBTX interface {
-	Exec(context.Context, string, ...interface{}) (pgconn.CommandTag, error)
-	Query(context.Context, string, ...interface{}) (pgx.Rows, error)
-	QueryRow(context.Context, string, ...interface{}) pgx.Row
+	Exec(context.Context, string, ...any) (pgconn.CommandTag, error)
+	Query(context.Context, string, ...any) (pgx.Rows, error)
+	QueryRow(context.Context, string, ...any) pgx.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/sqlc_arg/postgresql/stdlib/go/db.go
+++ b/internal/endtoend/testdata/sqlc_arg/postgresql/stdlib/go/db.go
@@ -10,10 +10,10 @@ import (
 )
 
 type DBTX interface {
-	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
 	PrepareContext(context.Context, string) (*sql.Stmt, error)
-	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
-	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/sqlc_arg/sqlite/go/db.go
+++ b/internal/endtoend/testdata/sqlc_arg/sqlite/go/db.go
@@ -10,10 +10,10 @@ import (
 )
 
 type DBTX interface {
-	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
 	PrepareContext(context.Context, string) (*sql.Stmt, error)
-	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
-	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/sqlc_embed/mysql/go/db.go
+++ b/internal/endtoend/testdata/sqlc_embed/mysql/go/db.go
@@ -10,10 +10,10 @@ import (
 )
 
 type DBTX interface {
-	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
 	PrepareContext(context.Context, string) (*sql.Stmt, error)
-	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
-	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/sqlc_embed/postgresql/pgx/go/db.go
+++ b/internal/endtoend/testdata/sqlc_embed/postgresql/pgx/go/db.go
@@ -12,9 +12,9 @@ import (
 )
 
 type DBTX interface {
-	Exec(context.Context, string, ...interface{}) (pgconn.CommandTag, error)
-	Query(context.Context, string, ...interface{}) (pgx.Rows, error)
-	QueryRow(context.Context, string, ...interface{}) pgx.Row
+	Exec(context.Context, string, ...any) (pgconn.CommandTag, error)
+	Query(context.Context, string, ...any) (pgx.Rows, error)
+	QueryRow(context.Context, string, ...any) pgx.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/sqlc_embed/postgresql/stdlib/go/db.go
+++ b/internal/endtoend/testdata/sqlc_embed/postgresql/stdlib/go/db.go
@@ -10,10 +10,10 @@ import (
 )
 
 type DBTX interface {
-	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
 	PrepareContext(context.Context, string) (*sql.Stmt, error)
-	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
-	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/sqlc_embed/sqlite/go/db.go
+++ b/internal/endtoend/testdata/sqlc_embed/sqlite/go/db.go
@@ -10,10 +10,10 @@ import (
 )
 
 type DBTX interface {
-	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
 	PrepareContext(context.Context, string) (*sql.Stmt, error)
-	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
-	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/sqlc_narg/mysql/go/db.go
+++ b/internal/endtoend/testdata/sqlc_narg/mysql/go/db.go
@@ -10,10 +10,10 @@ import (
 )
 
 type DBTX interface {
-	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
 	PrepareContext(context.Context, string) (*sql.Stmt, error)
-	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
-	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/sqlc_narg/postgresql/pgx/v4/go/db.go
+++ b/internal/endtoend/testdata/sqlc_narg/postgresql/pgx/v4/go/db.go
@@ -12,9 +12,9 @@ import (
 )
 
 type DBTX interface {
-	Exec(context.Context, string, ...interface{}) (pgconn.CommandTag, error)
-	Query(context.Context, string, ...interface{}) (pgx.Rows, error)
-	QueryRow(context.Context, string, ...interface{}) pgx.Row
+	Exec(context.Context, string, ...any) (pgconn.CommandTag, error)
+	Query(context.Context, string, ...any) (pgx.Rows, error)
+	QueryRow(context.Context, string, ...any) pgx.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/sqlc_narg/postgresql/pgx/v5/go/db.go
+++ b/internal/endtoend/testdata/sqlc_narg/postgresql/pgx/v5/go/db.go
@@ -12,9 +12,9 @@ import (
 )
 
 type DBTX interface {
-	Exec(context.Context, string, ...interface{}) (pgconn.CommandTag, error)
-	Query(context.Context, string, ...interface{}) (pgx.Rows, error)
-	QueryRow(context.Context, string, ...interface{}) pgx.Row
+	Exec(context.Context, string, ...any) (pgconn.CommandTag, error)
+	Query(context.Context, string, ...any) (pgx.Rows, error)
+	QueryRow(context.Context, string, ...any) pgx.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/sqlc_narg/postgresql/stdlib/go/db.go
+++ b/internal/endtoend/testdata/sqlc_narg/postgresql/stdlib/go/db.go
@@ -10,10 +10,10 @@ import (
 )
 
 type DBTX interface {
-	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
 	PrepareContext(context.Context, string) (*sql.Stmt, error)
-	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
-	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/sqlc_narg/postgresql/stdlib/go_strict/db.go
+++ b/internal/endtoend/testdata/sqlc_narg/postgresql/stdlib/go_strict/db.go
@@ -10,10 +10,10 @@ import (
 )
 
 type DBTX interface {
-	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
 	PrepareContext(context.Context, string) (*sql.Stmt, error)
-	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
-	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/sqlc_narg/sqlite/go/db.go
+++ b/internal/endtoend/testdata/sqlc_narg/sqlite/go/db.go
@@ -10,10 +10,10 @@ import (
 )
 
 type DBTX interface {
-	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
 	PrepareContext(context.Context, string) (*sql.Stmt, error)
-	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
-	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/sqlc_slice/mysql/go/db.go
+++ b/internal/endtoend/testdata/sqlc_slice/mysql/go/db.go
@@ -10,10 +10,10 @@ import (
 )
 
 type DBTX interface {
-	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
 	PrepareContext(context.Context, string) (*sql.Stmt, error)
-	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
-	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/sqlc_slice/mysql/go/query.sql.go
+++ b/internal/endtoend/testdata/sqlc_slice/mysql/go/query.sql.go
@@ -20,7 +20,7 @@ WHERE id IN (/*SLICE:favourites*/?)
 
 func (q *Queries) FuncNullable(ctx context.Context, favourites []int32) ([]sql.NullString, error) {
 	query := funcNullable
-	var queryParams []interface{}
+	var queryParams []any
 	if len(favourites) > 0 {
 		for _, v := range favourites {
 			queryParams = append(queryParams, v)
@@ -58,7 +58,7 @@ WHERE id NOT IN (/*SLICE:favourites*/?)
 
 func (q *Queries) FuncNullableNot(ctx context.Context, favourites []int32) ([]sql.NullString, error) {
 	query := funcNullableNot
-	var queryParams []interface{}
+	var queryParams []any
 	if len(favourites) > 0 {
 		for _, v := range favourites {
 			queryParams = append(queryParams, v)
@@ -102,7 +102,7 @@ type FuncParamIdentParams struct {
 
 func (q *Queries) FuncParamIdent(ctx context.Context, arg FuncParamIdentParams) ([]string, error) {
 	query := funcParamIdent
-	var queryParams []interface{}
+	var queryParams []any
 	queryParams = append(queryParams, arg.Slug)
 	if len(arg.Favourites) > 0 {
 		for _, v := range arg.Favourites {
@@ -141,7 +141,7 @@ WHERE id IN (/*SLICE:favourites*/?)
 
 func (q *Queries) FuncParamSoloArg(ctx context.Context, favourites []int32) ([]string, error) {
 	query := funcParamSoloArg
-	var queryParams []interface{}
+	var queryParams []any
 	if len(favourites) > 0 {
 		for _, v := range favourites {
 			queryParams = append(queryParams, v)
@@ -185,7 +185,7 @@ type FuncParamStringParams struct {
 
 func (q *Queries) FuncParamString(ctx context.Context, arg FuncParamStringParams) ([]string, error) {
 	query := funcParamString
-	var queryParams []interface{}
+	var queryParams []any
 	queryParams = append(queryParams, arg.Slug)
 	if len(arg.Favourites) > 0 {
 		for _, v := range arg.Favourites {
@@ -229,7 +229,7 @@ type SliceExecParams struct {
 
 func (q *Queries) SliceExec(ctx context.Context, arg SliceExecParams) error {
 	query := sliceExec
-	var queryParams []interface{}
+	var queryParams []any
 	queryParams = append(queryParams, arg.Slug)
 	if len(arg.Favourites) > 0 {
 		for _, v := range arg.Favourites {
@@ -250,7 +250,7 @@ WHERE mystr IN (/*SLICE:mystr*/?)
 
 func (q *Queries) TypedMyStr(ctx context.Context, mystr []mysql.ID) ([]sql.NullString, error) {
 	query := typedMyStr
-	var queryParams []interface{}
+	var queryParams []any
 	if len(mystr) > 0 {
 		for _, v := range mystr {
 			queryParams = append(queryParams, v)

--- a/internal/endtoend/testdata/sqlc_slice/postgresql/pgx/go/db.go
+++ b/internal/endtoend/testdata/sqlc_slice/postgresql/pgx/go/db.go
@@ -12,9 +12,9 @@ import (
 )
 
 type DBTX interface {
-	Exec(context.Context, string, ...interface{}) (pgconn.CommandTag, error)
-	Query(context.Context, string, ...interface{}) (pgx.Rows, error)
-	QueryRow(context.Context, string, ...interface{}) pgx.Row
+	Exec(context.Context, string, ...any) (pgconn.CommandTag, error)
+	Query(context.Context, string, ...any) (pgx.Rows, error)
+	QueryRow(context.Context, string, ...any) pgx.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/sqlc_slice/postgresql/stdlib/go/db.go
+++ b/internal/endtoend/testdata/sqlc_slice/postgresql/stdlib/go/db.go
@@ -10,10 +10,10 @@ import (
 )
 
 type DBTX interface {
-	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
 	PrepareContext(context.Context, string) (*sql.Stmt, error)
-	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
-	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/sqlc_slice/postgresql/stdlib/go/query.sql.go
+++ b/internal/endtoend/testdata/sqlc_slice/postgresql/stdlib/go/query.sql.go
@@ -23,7 +23,7 @@ type FuncParamIdentParams struct {
 
 func (q *Queries) FuncParamIdent(ctx context.Context, arg FuncParamIdentParams) ([]string, error) {
 	query := funcParamIdent
-	var queryParams []interface{}
+	var queryParams []any
 	queryParams = append(queryParams, arg.Slug)
 	if len(arg.Favourites) > 0 {
 		for _, v := range arg.Favourites {
@@ -68,7 +68,7 @@ type FuncParamStringParams struct {
 
 func (q *Queries) FuncParamString(ctx context.Context, arg FuncParamStringParams) ([]string, error) {
 	query := funcParamString
-	var queryParams []interface{}
+	var queryParams []any
 	queryParams = append(queryParams, arg.Slug)
 	if len(arg.Favourites) > 0 {
 		for _, v := range arg.Favourites {

--- a/internal/endtoend/testdata/sqlc_slice/sqlite/go/db.go
+++ b/internal/endtoend/testdata/sqlc_slice/sqlite/go/db.go
@@ -10,10 +10,10 @@ import (
 )
 
 type DBTX interface {
-	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
 	PrepareContext(context.Context, string) (*sql.Stmt, error)
-	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
-	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/sqlc_slice/sqlite/go/query.sql.go
+++ b/internal/endtoend/testdata/sqlc_slice/sqlite/go/query.sql.go
@@ -18,7 +18,7 @@ WHERE id IN (/*SLICE:favourites*/?)
 
 func (q *Queries) FuncNullable(ctx context.Context, favourites []int64) ([]sql.NullString, error) {
 	query := funcNullable
-	var queryParams []interface{}
+	var queryParams []any
 	if len(favourites) > 0 {
 		for _, v := range favourites {
 			queryParams = append(queryParams, v)
@@ -56,7 +56,7 @@ WHERE id NOT IN (/*SLICE:favourites*/?)
 
 func (q *Queries) FuncNullableNot(ctx context.Context, favourites []int64) ([]sql.NullString, error) {
 	query := funcNullableNot
-	var queryParams []interface{}
+	var queryParams []any
 	if len(favourites) > 0 {
 		for _, v := range favourites {
 			queryParams = append(queryParams, v)
@@ -100,7 +100,7 @@ type FuncParamIdentParams struct {
 
 func (q *Queries) FuncParamIdent(ctx context.Context, arg FuncParamIdentParams) ([]string, error) {
 	query := funcParamIdent
-	var queryParams []interface{}
+	var queryParams []any
 	queryParams = append(queryParams, arg.Slug)
 	if len(arg.Favourites) > 0 {
 		for _, v := range arg.Favourites {
@@ -139,7 +139,7 @@ WHERE id IN (/*SLICE:favourites*/?)
 
 func (q *Queries) FuncParamSoloArg(ctx context.Context, favourites []int64) ([]string, error) {
 	query := funcParamSoloArg
-	var queryParams []interface{}
+	var queryParams []any
 	if len(favourites) > 0 {
 		for _, v := range favourites {
 			queryParams = append(queryParams, v)
@@ -183,7 +183,7 @@ type FuncParamStringParams struct {
 
 func (q *Queries) FuncParamString(ctx context.Context, arg FuncParamStringParams) ([]string, error) {
 	query := funcParamString
-	var queryParams []interface{}
+	var queryParams []any
 	queryParams = append(queryParams, arg.Slug)
 	if len(arg.Favourites) > 0 {
 		for _, v := range arg.Favourites {
@@ -227,7 +227,7 @@ type SliceExecParams struct {
 
 func (q *Queries) SliceExec(ctx context.Context, arg SliceExecParams) error {
 	query := sliceExec
-	var queryParams []interface{}
+	var queryParams []any
 	queryParams = append(queryParams, arg.Slug)
 	if len(arg.Favourites) > 0 {
 		for _, v := range arg.Favourites {

--- a/internal/endtoend/testdata/sqlc_slice_prepared/sqlite/go/db.go
+++ b/internal/endtoend/testdata/sqlc_slice_prepared/sqlite/go/db.go
@@ -11,10 +11,10 @@ import (
 )
 
 type DBTX interface {
-	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
 	PrepareContext(context.Context, string) (*sql.Stmt, error)
-	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
-	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
 }
 
 func New(db DBTX) *Queries {
@@ -40,7 +40,7 @@ func (q *Queries) Close() error {
 	return err
 }
 
-func (q *Queries) exec(ctx context.Context, stmt *sql.Stmt, query string, args ...interface{}) (sql.Result, error) {
+func (q *Queries) exec(ctx context.Context, stmt *sql.Stmt, query string, args ...any) (sql.Result, error) {
 	switch {
 	case stmt != nil && q.tx != nil:
 		return q.tx.StmtContext(ctx, stmt).ExecContext(ctx, args...)
@@ -51,7 +51,7 @@ func (q *Queries) exec(ctx context.Context, stmt *sql.Stmt, query string, args .
 	}
 }
 
-func (q *Queries) query(ctx context.Context, stmt *sql.Stmt, query string, args ...interface{}) (*sql.Rows, error) {
+func (q *Queries) query(ctx context.Context, stmt *sql.Stmt, query string, args ...any) (*sql.Rows, error) {
 	switch {
 	case stmt != nil && q.tx != nil:
 		return q.tx.StmtContext(ctx, stmt).QueryContext(ctx, args...)
@@ -62,7 +62,7 @@ func (q *Queries) query(ctx context.Context, stmt *sql.Stmt, query string, args 
 	}
 }
 
-func (q *Queries) queryRow(ctx context.Context, stmt *sql.Stmt, query string, args ...interface{}) *sql.Row {
+func (q *Queries) queryRow(ctx context.Context, stmt *sql.Stmt, query string, args ...any) *sql.Row {
 	switch {
 	case stmt != nil && q.tx != nil:
 		return q.tx.StmtContext(ctx, stmt).QueryRowContext(ctx, args...)

--- a/internal/endtoend/testdata/sqlc_slice_prepared/sqlite/go/query.sql.go
+++ b/internal/endtoend/testdata/sqlc_slice_prepared/sqlite/go/query.sql.go
@@ -23,7 +23,7 @@ type FuncParamIdentParams struct {
 
 func (q *Queries) FuncParamIdent(ctx context.Context, arg FuncParamIdentParams) ([]string, error) {
 	query := funcParamIdent
-	var queryParams []interface{}
+	var queryParams []any
 	queryParams = append(queryParams, arg.Slug)
 	if len(arg.Favourites) > 0 {
 		for _, v := range arg.Favourites {

--- a/internal/endtoend/testdata/sqlite_skip_todo/db/db.go
+++ b/internal/endtoend/testdata/sqlite_skip_todo/db/db.go
@@ -10,10 +10,10 @@ import (
 )
 
 type DBTX interface {
-	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
 	PrepareContext(context.Context, string) (*sql.Stmt, error)
-	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
-	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/sqlite_table_options/sqlite/go/db.go
+++ b/internal/endtoend/testdata/sqlite_table_options/sqlite/go/db.go
@@ -10,10 +10,10 @@ import (
 )
 
 type DBTX interface {
-	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
 	PrepareContext(context.Context, string) (*sql.Stmt, error)
-	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
-	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/star_expansion/mysql/go/db.go
+++ b/internal/endtoend/testdata/star_expansion/mysql/go/db.go
@@ -10,10 +10,10 @@ import (
 )
 
 type DBTX interface {
-	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
 	PrepareContext(context.Context, string) (*sql.Stmt, error)
-	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
-	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/star_expansion/postgresql/pgx/v4/go/db.go
+++ b/internal/endtoend/testdata/star_expansion/postgresql/pgx/v4/go/db.go
@@ -12,9 +12,9 @@ import (
 )
 
 type DBTX interface {
-	Exec(context.Context, string, ...interface{}) (pgconn.CommandTag, error)
-	Query(context.Context, string, ...interface{}) (pgx.Rows, error)
-	QueryRow(context.Context, string, ...interface{}) pgx.Row
+	Exec(context.Context, string, ...any) (pgconn.CommandTag, error)
+	Query(context.Context, string, ...any) (pgx.Rows, error)
+	QueryRow(context.Context, string, ...any) pgx.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/star_expansion/postgresql/pgx/v5/go/db.go
+++ b/internal/endtoend/testdata/star_expansion/postgresql/pgx/v5/go/db.go
@@ -12,9 +12,9 @@ import (
 )
 
 type DBTX interface {
-	Exec(context.Context, string, ...interface{}) (pgconn.CommandTag, error)
-	Query(context.Context, string, ...interface{}) (pgx.Rows, error)
-	QueryRow(context.Context, string, ...interface{}) pgx.Row
+	Exec(context.Context, string, ...any) (pgconn.CommandTag, error)
+	Query(context.Context, string, ...any) (pgx.Rows, error)
+	QueryRow(context.Context, string, ...any) pgx.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/star_expansion/postgresql/stdlib/go/db.go
+++ b/internal/endtoend/testdata/star_expansion/postgresql/stdlib/go/db.go
@@ -10,10 +10,10 @@ import (
 )
 
 type DBTX interface {
-	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
 	PrepareContext(context.Context, string) (*sql.Stmt, error)
-	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
-	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/star_expansion/sqlite/go/db.go
+++ b/internal/endtoend/testdata/star_expansion/sqlite/go/db.go
@@ -10,10 +10,10 @@ import (
 )
 
 type DBTX interface {
-	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
 	PrepareContext(context.Context, string) (*sql.Stmt, error)
-	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
-	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/star_expansion_cte/pgx/v4/go/db.go
+++ b/internal/endtoend/testdata/star_expansion_cte/pgx/v4/go/db.go
@@ -12,9 +12,9 @@ import (
 )
 
 type DBTX interface {
-	Exec(context.Context, string, ...interface{}) (pgconn.CommandTag, error)
-	Query(context.Context, string, ...interface{}) (pgx.Rows, error)
-	QueryRow(context.Context, string, ...interface{}) pgx.Row
+	Exec(context.Context, string, ...any) (pgconn.CommandTag, error)
+	Query(context.Context, string, ...any) (pgx.Rows, error)
+	QueryRow(context.Context, string, ...any) pgx.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/star_expansion_cte/pgx/v5/go/db.go
+++ b/internal/endtoend/testdata/star_expansion_cte/pgx/v5/go/db.go
@@ -12,9 +12,9 @@ import (
 )
 
 type DBTX interface {
-	Exec(context.Context, string, ...interface{}) (pgconn.CommandTag, error)
-	Query(context.Context, string, ...interface{}) (pgx.Rows, error)
-	QueryRow(context.Context, string, ...interface{}) pgx.Row
+	Exec(context.Context, string, ...any) (pgconn.CommandTag, error)
+	Query(context.Context, string, ...any) (pgx.Rows, error)
+	QueryRow(context.Context, string, ...any) pgx.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/star_expansion_cte/stdlib/go/db.go
+++ b/internal/endtoend/testdata/star_expansion_cte/stdlib/go/db.go
@@ -10,10 +10,10 @@ import (
 )
 
 type DBTX interface {
-	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
 	PrepareContext(context.Context, string) (*sql.Stmt, error)
-	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
-	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/star_expansion_failed/postgresql/pgx/go/db.go
+++ b/internal/endtoend/testdata/star_expansion_failed/postgresql/pgx/go/db.go
@@ -12,9 +12,9 @@ import (
 )
 
 type DBTX interface {
-	Exec(context.Context, string, ...interface{}) (pgconn.CommandTag, error)
-	Query(context.Context, string, ...interface{}) (pgx.Rows, error)
-	QueryRow(context.Context, string, ...interface{}) pgx.Row
+	Exec(context.Context, string, ...any) (pgconn.CommandTag, error)
+	Query(context.Context, string, ...any) (pgx.Rows, error)
+	QueryRow(context.Context, string, ...any) pgx.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/star_expansion_from_cte/pgx/v4/go/db.go
+++ b/internal/endtoend/testdata/star_expansion_from_cte/pgx/v4/go/db.go
@@ -12,9 +12,9 @@ import (
 )
 
 type DBTX interface {
-	Exec(context.Context, string, ...interface{}) (pgconn.CommandTag, error)
-	Query(context.Context, string, ...interface{}) (pgx.Rows, error)
-	QueryRow(context.Context, string, ...interface{}) pgx.Row
+	Exec(context.Context, string, ...any) (pgconn.CommandTag, error)
+	Query(context.Context, string, ...any) (pgx.Rows, error)
+	QueryRow(context.Context, string, ...any) pgx.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/star_expansion_from_cte/pgx/v5/go/db.go
+++ b/internal/endtoend/testdata/star_expansion_from_cte/pgx/v5/go/db.go
@@ -12,9 +12,9 @@ import (
 )
 
 type DBTX interface {
-	Exec(context.Context, string, ...interface{}) (pgconn.CommandTag, error)
-	Query(context.Context, string, ...interface{}) (pgx.Rows, error)
-	QueryRow(context.Context, string, ...interface{}) pgx.Row
+	Exec(context.Context, string, ...any) (pgconn.CommandTag, error)
+	Query(context.Context, string, ...any) (pgx.Rows, error)
+	QueryRow(context.Context, string, ...any) pgx.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/star_expansion_from_cte/stdlib/go/db.go
+++ b/internal/endtoend/testdata/star_expansion_from_cte/stdlib/go/db.go
@@ -10,10 +10,10 @@ import (
 )
 
 type DBTX interface {
-	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
 	PrepareContext(context.Context, string) (*sql.Stmt, error)
-	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
-	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/star_expansion_join/mysql/go/db.go
+++ b/internal/endtoend/testdata/star_expansion_join/mysql/go/db.go
@@ -10,10 +10,10 @@ import (
 )
 
 type DBTX interface {
-	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
 	PrepareContext(context.Context, string) (*sql.Stmt, error)
-	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
-	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/star_expansion_join/postgresql/pgx/v4/go/db.go
+++ b/internal/endtoend/testdata/star_expansion_join/postgresql/pgx/v4/go/db.go
@@ -12,9 +12,9 @@ import (
 )
 
 type DBTX interface {
-	Exec(context.Context, string, ...interface{}) (pgconn.CommandTag, error)
-	Query(context.Context, string, ...interface{}) (pgx.Rows, error)
-	QueryRow(context.Context, string, ...interface{}) pgx.Row
+	Exec(context.Context, string, ...any) (pgconn.CommandTag, error)
+	Query(context.Context, string, ...any) (pgx.Rows, error)
+	QueryRow(context.Context, string, ...any) pgx.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/star_expansion_join/postgresql/pgx/v5/go/db.go
+++ b/internal/endtoend/testdata/star_expansion_join/postgresql/pgx/v5/go/db.go
@@ -12,9 +12,9 @@ import (
 )
 
 type DBTX interface {
-	Exec(context.Context, string, ...interface{}) (pgconn.CommandTag, error)
-	Query(context.Context, string, ...interface{}) (pgx.Rows, error)
-	QueryRow(context.Context, string, ...interface{}) pgx.Row
+	Exec(context.Context, string, ...any) (pgconn.CommandTag, error)
+	Query(context.Context, string, ...any) (pgx.Rows, error)
+	QueryRow(context.Context, string, ...any) pgx.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/star_expansion_join/postgresql/stdlib/go/db.go
+++ b/internal/endtoend/testdata/star_expansion_join/postgresql/stdlib/go/db.go
@@ -10,10 +10,10 @@ import (
 )
 
 type DBTX interface {
-	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
 	PrepareContext(context.Context, string) (*sql.Stmt, error)
-	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
-	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/star_expansion_reserved/mysql/go/db.go
+++ b/internal/endtoend/testdata/star_expansion_reserved/mysql/go/db.go
@@ -10,10 +10,10 @@ import (
 )
 
 type DBTX interface {
-	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
 	PrepareContext(context.Context, string) (*sql.Stmt, error)
-	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
-	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/star_expansion_reserved/postgresql/pgx/v4/go/db.go
+++ b/internal/endtoend/testdata/star_expansion_reserved/postgresql/pgx/v4/go/db.go
@@ -12,9 +12,9 @@ import (
 )
 
 type DBTX interface {
-	Exec(context.Context, string, ...interface{}) (pgconn.CommandTag, error)
-	Query(context.Context, string, ...interface{}) (pgx.Rows, error)
-	QueryRow(context.Context, string, ...interface{}) pgx.Row
+	Exec(context.Context, string, ...any) (pgconn.CommandTag, error)
+	Query(context.Context, string, ...any) (pgx.Rows, error)
+	QueryRow(context.Context, string, ...any) pgx.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/star_expansion_reserved/postgresql/pgx/v5/go/db.go
+++ b/internal/endtoend/testdata/star_expansion_reserved/postgresql/pgx/v5/go/db.go
@@ -12,9 +12,9 @@ import (
 )
 
 type DBTX interface {
-	Exec(context.Context, string, ...interface{}) (pgconn.CommandTag, error)
-	Query(context.Context, string, ...interface{}) (pgx.Rows, error)
-	QueryRow(context.Context, string, ...interface{}) pgx.Row
+	Exec(context.Context, string, ...any) (pgconn.CommandTag, error)
+	Query(context.Context, string, ...any) (pgx.Rows, error)
+	QueryRow(context.Context, string, ...any) pgx.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/star_expansion_reserved/postgresql/stdlib/go/db.go
+++ b/internal/endtoend/testdata/star_expansion_reserved/postgresql/stdlib/go/db.go
@@ -10,10 +10,10 @@ import (
 )
 
 type DBTX interface {
-	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
 	PrepareContext(context.Context, string) (*sql.Stmt, error)
-	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
-	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/star_expansion_series/postgresql/pgx/go/db.go
+++ b/internal/endtoend/testdata/star_expansion_series/postgresql/pgx/go/db.go
@@ -12,9 +12,9 @@ import (
 )
 
 type DBTX interface {
-	Exec(context.Context, string, ...interface{}) (pgconn.CommandTag, error)
-	Query(context.Context, string, ...interface{}) (pgx.Rows, error)
-	QueryRow(context.Context, string, ...interface{}) pgx.Row
+	Exec(context.Context, string, ...any) (pgconn.CommandTag, error)
+	Query(context.Context, string, ...any) (pgx.Rows, error)
+	QueryRow(context.Context, string, ...any) pgx.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/star_expansion_subquery/mysql/go/db.go
+++ b/internal/endtoend/testdata/star_expansion_subquery/mysql/go/db.go
@@ -10,10 +10,10 @@ import (
 )
 
 type DBTX interface {
-	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
 	PrepareContext(context.Context, string) (*sql.Stmt, error)
-	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
-	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/star_expansion_subquery/postgresql/pgx/v4/go/db.go
+++ b/internal/endtoend/testdata/star_expansion_subquery/postgresql/pgx/v4/go/db.go
@@ -12,9 +12,9 @@ import (
 )
 
 type DBTX interface {
-	Exec(context.Context, string, ...interface{}) (pgconn.CommandTag, error)
-	Query(context.Context, string, ...interface{}) (pgx.Rows, error)
-	QueryRow(context.Context, string, ...interface{}) pgx.Row
+	Exec(context.Context, string, ...any) (pgconn.CommandTag, error)
+	Query(context.Context, string, ...any) (pgx.Rows, error)
+	QueryRow(context.Context, string, ...any) pgx.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/star_expansion_subquery/postgresql/pgx/v5/go/db.go
+++ b/internal/endtoend/testdata/star_expansion_subquery/postgresql/pgx/v5/go/db.go
@@ -12,9 +12,9 @@ import (
 )
 
 type DBTX interface {
-	Exec(context.Context, string, ...interface{}) (pgconn.CommandTag, error)
-	Query(context.Context, string, ...interface{}) (pgx.Rows, error)
-	QueryRow(context.Context, string, ...interface{}) pgx.Row
+	Exec(context.Context, string, ...any) (pgconn.CommandTag, error)
+	Query(context.Context, string, ...any) (pgx.Rows, error)
+	QueryRow(context.Context, string, ...any) pgx.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/star_expansion_subquery/postgresql/stdlib/go/db.go
+++ b/internal/endtoend/testdata/star_expansion_subquery/postgresql/stdlib/go/db.go
@@ -10,10 +10,10 @@ import (
 )
 
 type DBTX interface {
-	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
 	PrepareContext(context.Context, string) (*sql.Stmt, error)
-	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
-	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/subquery_calculated_column/mysql/go/db.go
+++ b/internal/endtoend/testdata/subquery_calculated_column/mysql/go/db.go
@@ -10,10 +10,10 @@ import (
 )
 
 type DBTX interface {
-	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
 	PrepareContext(context.Context, string) (*sql.Stmt, error)
-	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
-	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/subquery_calculated_column/postgresql/pgx/v4/go/db.go
+++ b/internal/endtoend/testdata/subquery_calculated_column/postgresql/pgx/v4/go/db.go
@@ -12,9 +12,9 @@ import (
 )
 
 type DBTX interface {
-	Exec(context.Context, string, ...interface{}) (pgconn.CommandTag, error)
-	Query(context.Context, string, ...interface{}) (pgx.Rows, error)
-	QueryRow(context.Context, string, ...interface{}) pgx.Row
+	Exec(context.Context, string, ...any) (pgconn.CommandTag, error)
+	Query(context.Context, string, ...any) (pgx.Rows, error)
+	QueryRow(context.Context, string, ...any) pgx.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/subquery_calculated_column/postgresql/pgx/v5/go/db.go
+++ b/internal/endtoend/testdata/subquery_calculated_column/postgresql/pgx/v5/go/db.go
@@ -12,9 +12,9 @@ import (
 )
 
 type DBTX interface {
-	Exec(context.Context, string, ...interface{}) (pgconn.CommandTag, error)
-	Query(context.Context, string, ...interface{}) (pgx.Rows, error)
-	QueryRow(context.Context, string, ...interface{}) pgx.Row
+	Exec(context.Context, string, ...any) (pgconn.CommandTag, error)
+	Query(context.Context, string, ...any) (pgx.Rows, error)
+	QueryRow(context.Context, string, ...any) pgx.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/subquery_calculated_column/postgresql/stdlib/go/db.go
+++ b/internal/endtoend/testdata/subquery_calculated_column/postgresql/stdlib/go/db.go
@@ -10,10 +10,10 @@ import (
 )
 
 type DBTX interface {
-	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
 	PrepareContext(context.Context, string) (*sql.Stmt, error)
-	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
-	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/subquery_calculated_column/sqlite/go/db.go
+++ b/internal/endtoend/testdata/subquery_calculated_column/sqlite/go/db.go
@@ -10,10 +10,10 @@ import (
 )
 
 type DBTX interface {
-	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
 	PrepareContext(context.Context, string) (*sql.Stmt, error)
-	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
-	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/sum_type/postgresql/pgx/go/db.go
+++ b/internal/endtoend/testdata/sum_type/postgresql/pgx/go/db.go
@@ -12,9 +12,9 @@ import (
 )
 
 type DBTX interface {
-	Exec(context.Context, string, ...interface{}) (pgconn.CommandTag, error)
-	Query(context.Context, string, ...interface{}) (pgx.Rows, error)
-	QueryRow(context.Context, string, ...interface{}) pgx.Row
+	Exec(context.Context, string, ...any) (pgconn.CommandTag, error)
+	Query(context.Context, string, ...any) (pgx.Rows, error)
+	QueryRow(context.Context, string, ...any) pgx.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/table_function/postgresql/pgx/v4/go/db.go
+++ b/internal/endtoend/testdata/table_function/postgresql/pgx/v4/go/db.go
@@ -12,9 +12,9 @@ import (
 )
 
 type DBTX interface {
-	Exec(context.Context, string, ...interface{}) (pgconn.CommandTag, error)
-	Query(context.Context, string, ...interface{}) (pgx.Rows, error)
-	QueryRow(context.Context, string, ...interface{}) pgx.Row
+	Exec(context.Context, string, ...any) (pgconn.CommandTag, error)
+	Query(context.Context, string, ...any) (pgx.Rows, error)
+	QueryRow(context.Context, string, ...any) pgx.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/table_function/postgresql/pgx/v5/go/db.go
+++ b/internal/endtoend/testdata/table_function/postgresql/pgx/v5/go/db.go
@@ -12,9 +12,9 @@ import (
 )
 
 type DBTX interface {
-	Exec(context.Context, string, ...interface{}) (pgconn.CommandTag, error)
-	Query(context.Context, string, ...interface{}) (pgx.Rows, error)
-	QueryRow(context.Context, string, ...interface{}) pgx.Row
+	Exec(context.Context, string, ...any) (pgconn.CommandTag, error)
+	Query(context.Context, string, ...any) (pgx.Rows, error)
+	QueryRow(context.Context, string, ...any) pgx.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/table_function/postgresql/stdlib/go/db.go
+++ b/internal/endtoend/testdata/table_function/postgresql/stdlib/go/db.go
@@ -10,10 +10,10 @@ import (
 )
 
 type DBTX interface {
-	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
 	PrepareContext(context.Context, string) (*sql.Stmt, error)
-	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
-	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/table_function/sqlite/go/db.go
+++ b/internal/endtoend/testdata/table_function/sqlite/go/db.go
@@ -10,10 +10,10 @@ import (
 )
 
 type DBTX interface {
-	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
 	PrepareContext(context.Context, string) (*sql.Stmt, error)
-	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
-	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/table_function/sqlite/go/query.sql.go
+++ b/internal/endtoend/testdata/table_function/sqlite/go/query.sql.go
@@ -31,8 +31,8 @@ type GetTransactionParams struct {
 }
 
 type GetTransactionRow struct {
-	JsonExtract    interface{}
-	JsonGroupArray interface{}
+	JsonExtract    any
+	JsonGroupArray any
 }
 
 func (q *Queries) GetTransaction(ctx context.Context, arg GetTransactionParams) ([]GetTransactionRow, error) {

--- a/internal/endtoend/testdata/table_name_case_sensitivity/sqlite/go/db.go
+++ b/internal/endtoend/testdata/table_name_case_sensitivity/sqlite/go/db.go
@@ -10,10 +10,10 @@ import (
 )
 
 type DBTX interface {
-	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
 	PrepareContext(context.Context, string) (*sql.Stmt, error)
-	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
-	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/truncate/mysql/go/db.go
+++ b/internal/endtoend/testdata/truncate/mysql/go/db.go
@@ -10,10 +10,10 @@ import (
 )
 
 type DBTX interface {
-	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
 	PrepareContext(context.Context, string) (*sql.Stmt, error)
-	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
-	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/truncate/postgresql/pgx/v4/go/db.go
+++ b/internal/endtoend/testdata/truncate/postgresql/pgx/v4/go/db.go
@@ -12,9 +12,9 @@ import (
 )
 
 type DBTX interface {
-	Exec(context.Context, string, ...interface{}) (pgconn.CommandTag, error)
-	Query(context.Context, string, ...interface{}) (pgx.Rows, error)
-	QueryRow(context.Context, string, ...interface{}) pgx.Row
+	Exec(context.Context, string, ...any) (pgconn.CommandTag, error)
+	Query(context.Context, string, ...any) (pgx.Rows, error)
+	QueryRow(context.Context, string, ...any) pgx.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/truncate/postgresql/pgx/v5/go/db.go
+++ b/internal/endtoend/testdata/truncate/postgresql/pgx/v5/go/db.go
@@ -12,9 +12,9 @@ import (
 )
 
 type DBTX interface {
-	Exec(context.Context, string, ...interface{}) (pgconn.CommandTag, error)
-	Query(context.Context, string, ...interface{}) (pgx.Rows, error)
-	QueryRow(context.Context, string, ...interface{}) pgx.Row
+	Exec(context.Context, string, ...any) (pgconn.CommandTag, error)
+	Query(context.Context, string, ...any) (pgx.Rows, error)
+	QueryRow(context.Context, string, ...any) pgx.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/truncate/postgresql/stdlib/go/db.go
+++ b/internal/endtoend/testdata/truncate/postgresql/stdlib/go/db.go
@@ -10,10 +10,10 @@ import (
 )
 
 type DBTX interface {
-	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
 	PrepareContext(context.Context, string) (*sql.Stmt, error)
-	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
-	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/types_uuid/postgresql/stdlib/go/db.go
+++ b/internal/endtoend/testdata/types_uuid/postgresql/stdlib/go/db.go
@@ -10,10 +10,10 @@ import (
 )
 
 type DBTX interface {
-	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
 	PrepareContext(context.Context, string) (*sql.Stmt, error)
-	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
-	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/unknown_func/pgx/v4/go/db.go
+++ b/internal/endtoend/testdata/unknown_func/pgx/v4/go/db.go
@@ -12,9 +12,9 @@ import (
 )
 
 type DBTX interface {
-	Exec(context.Context, string, ...interface{}) (pgconn.CommandTag, error)
-	Query(context.Context, string, ...interface{}) (pgx.Rows, error)
-	QueryRow(context.Context, string, ...interface{}) pgx.Row
+	Exec(context.Context, string, ...any) (pgconn.CommandTag, error)
+	Query(context.Context, string, ...any) (pgx.Rows, error)
+	QueryRow(context.Context, string, ...any) pgx.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/unknown_func/pgx/v4/go/query.sql.go
+++ b/internal/endtoend/testdata/unknown_func/pgx/v4/go/query.sql.go
@@ -13,7 +13,7 @@ const listFoos = `-- name: ListFoos :one
 SELECT id FROM foo WHERE id = frobnicate($1)
 `
 
-func (q *Queries) ListFoos(ctx context.Context, frobnicate interface{}) (string, error) {
+func (q *Queries) ListFoos(ctx context.Context, frobnicate any) (string, error) {
 	row := q.db.QueryRow(ctx, listFoos, frobnicate)
 	var id string
 	err := row.Scan(&id)

--- a/internal/endtoend/testdata/unknown_func/pgx/v5/go/db.go
+++ b/internal/endtoend/testdata/unknown_func/pgx/v5/go/db.go
@@ -12,9 +12,9 @@ import (
 )
 
 type DBTX interface {
-	Exec(context.Context, string, ...interface{}) (pgconn.CommandTag, error)
-	Query(context.Context, string, ...interface{}) (pgx.Rows, error)
-	QueryRow(context.Context, string, ...interface{}) pgx.Row
+	Exec(context.Context, string, ...any) (pgconn.CommandTag, error)
+	Query(context.Context, string, ...any) (pgx.Rows, error)
+	QueryRow(context.Context, string, ...any) pgx.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/unknown_func/pgx/v5/go/query.sql.go
+++ b/internal/endtoend/testdata/unknown_func/pgx/v5/go/query.sql.go
@@ -13,7 +13,7 @@ const listFoos = `-- name: ListFoos :one
 SELECT id FROM foo WHERE id = frobnicate($1)
 `
 
-func (q *Queries) ListFoos(ctx context.Context, frobnicate interface{}) (string, error) {
+func (q *Queries) ListFoos(ctx context.Context, frobnicate any) (string, error) {
 	row := q.db.QueryRow(ctx, listFoos, frobnicate)
 	var id string
 	err := row.Scan(&id)

--- a/internal/endtoend/testdata/unknown_func/stdlib/go/db.go
+++ b/internal/endtoend/testdata/unknown_func/stdlib/go/db.go
@@ -10,10 +10,10 @@ import (
 )
 
 type DBTX interface {
-	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
 	PrepareContext(context.Context, string) (*sql.Stmt, error)
-	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
-	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/unknown_func/stdlib/go/query.sql.go
+++ b/internal/endtoend/testdata/unknown_func/stdlib/go/query.sql.go
@@ -13,7 +13,7 @@ const listFoos = `-- name: ListFoos :one
 SELECT id FROM foo WHERE id = frobnicate($1)
 `
 
-func (q *Queries) ListFoos(ctx context.Context, frobnicate interface{}) (string, error) {
+func (q *Queries) ListFoos(ctx context.Context, frobnicate any) (string, error) {
 	row := q.db.QueryRowContext(ctx, listFoos, frobnicate)
 	var id string
 	err := row.Scan(&id)

--- a/internal/endtoend/testdata/unnest/postgresql/pgx/v4/go/db.go
+++ b/internal/endtoend/testdata/unnest/postgresql/pgx/v4/go/db.go
@@ -12,9 +12,9 @@ import (
 )
 
 type DBTX interface {
-	Exec(context.Context, string, ...interface{}) (pgconn.CommandTag, error)
-	Query(context.Context, string, ...interface{}) (pgx.Rows, error)
-	QueryRow(context.Context, string, ...interface{}) pgx.Row
+	Exec(context.Context, string, ...any) (pgconn.CommandTag, error)
+	Query(context.Context, string, ...any) (pgx.Rows, error)
+	QueryRow(context.Context, string, ...any) pgx.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/unnest/postgresql/pgx/v5/go/db.go
+++ b/internal/endtoend/testdata/unnest/postgresql/pgx/v5/go/db.go
@@ -12,9 +12,9 @@ import (
 )
 
 type DBTX interface {
-	Exec(context.Context, string, ...interface{}) (pgconn.CommandTag, error)
-	Query(context.Context, string, ...interface{}) (pgx.Rows, error)
-	QueryRow(context.Context, string, ...interface{}) pgx.Row
+	Exec(context.Context, string, ...any) (pgconn.CommandTag, error)
+	Query(context.Context, string, ...any) (pgx.Rows, error)
+	QueryRow(context.Context, string, ...any) pgx.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/unnest/postgresql/stdlib/go/db.go
+++ b/internal/endtoend/testdata/unnest/postgresql/stdlib/go/db.go
@@ -10,10 +10,10 @@ import (
 )
 
 type DBTX interface {
-	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
 	PrepareContext(context.Context, string) (*sql.Stmt, error)
-	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
-	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/unnest_star/postgresql/pgx/go/db.go
+++ b/internal/endtoend/testdata/unnest_star/postgresql/pgx/go/db.go
@@ -12,9 +12,9 @@ import (
 )
 
 type DBTX interface {
-	Exec(context.Context, string, ...interface{}) (pgconn.CommandTag, error)
-	Query(context.Context, string, ...interface{}) (pgx.Rows, error)
-	QueryRow(context.Context, string, ...interface{}) pgx.Row
+	Exec(context.Context, string, ...any) (pgconn.CommandTag, error)
+	Query(context.Context, string, ...any) (pgx.Rows, error)
+	QueryRow(context.Context, string, ...any) pgx.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/unnest_with_ordinality/postgresql/pgx/v4/go/db.go
+++ b/internal/endtoend/testdata/unnest_with_ordinality/postgresql/pgx/v4/go/db.go
@@ -12,9 +12,9 @@ import (
 )
 
 type DBTX interface {
-	Exec(context.Context, string, ...interface{}) (pgconn.CommandTag, error)
-	Query(context.Context, string, ...interface{}) (pgx.Rows, error)
-	QueryRow(context.Context, string, ...interface{}) pgx.Row
+	Exec(context.Context, string, ...any) (pgconn.CommandTag, error)
+	Query(context.Context, string, ...any) (pgx.Rows, error)
+	QueryRow(context.Context, string, ...any) pgx.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/unnest_with_ordinality/postgresql/pgx/v5/go/db.go
+++ b/internal/endtoend/testdata/unnest_with_ordinality/postgresql/pgx/v5/go/db.go
@@ -12,9 +12,9 @@ import (
 )
 
 type DBTX interface {
-	Exec(context.Context, string, ...interface{}) (pgconn.CommandTag, error)
-	Query(context.Context, string, ...interface{}) (pgx.Rows, error)
-	QueryRow(context.Context, string, ...interface{}) pgx.Row
+	Exec(context.Context, string, ...any) (pgconn.CommandTag, error)
+	Query(context.Context, string, ...any) (pgx.Rows, error)
+	QueryRow(context.Context, string, ...any) pgx.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/unnest_with_ordinality/postgresql/stdlib/go/db.go
+++ b/internal/endtoend/testdata/unnest_with_ordinality/postgresql/stdlib/go/db.go
@@ -10,10 +10,10 @@ import (
 )
 
 type DBTX interface {
-	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
 	PrepareContext(context.Context, string) (*sql.Stmt, error)
-	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
-	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/unsigned_params/mysql/go/db.go
+++ b/internal/endtoend/testdata/unsigned_params/mysql/go/db.go
@@ -10,10 +10,10 @@ import (
 )
 
 type DBTX interface {
-	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
 	PrepareContext(context.Context, string) (*sql.Stmt, error)
-	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
-	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/untyped_columns/sqlite/stdlib/db/db.go
+++ b/internal/endtoend/testdata/untyped_columns/sqlite/stdlib/db/db.go
@@ -10,10 +10,10 @@ import (
 )
 
 type DBTX interface {
-	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
 	PrepareContext(context.Context, string) (*sql.Stmt, error)
-	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
-	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/untyped_columns/sqlite/stdlib/db/models.go
+++ b/internal/endtoend/testdata/untyped_columns/sqlite/stdlib/db/models.go
@@ -5,7 +5,7 @@
 package db
 
 type Repro struct {
-	ID   interface{}
-	Name interface{}
-	Seq  interface{}
+	ID   any
+	Name any
+	Seq  any
 }

--- a/internal/endtoend/testdata/untyped_columns/sqlite/stdlib/db/query.sql.go
+++ b/internal/endtoend/testdata/untyped_columns/sqlite/stdlib/db/query.sql.go
@@ -13,7 +13,7 @@ const getRepro = `-- name: GetRepro :one
 select id, name, seq from repro where id = ? limit 1
 `
 
-func (q *Queries) GetRepro(ctx context.Context, id interface{}) (Repro, error) {
+func (q *Queries) GetRepro(ctx context.Context, id any) (Repro, error) {
 	row := q.db.QueryRowContext(ctx, getRepro, id)
 	var i Repro
 	err := row.Scan(&i.ID, &i.Name, &i.Seq)

--- a/internal/endtoend/testdata/update_array_index/postgresql/pgx/go/db.go
+++ b/internal/endtoend/testdata/update_array_index/postgresql/pgx/go/db.go
@@ -12,9 +12,9 @@ import (
 )
 
 type DBTX interface {
-	Exec(context.Context, string, ...interface{}) (pgconn.CommandTag, error)
-	Query(context.Context, string, ...interface{}) (pgx.Rows, error)
-	QueryRow(context.Context, string, ...interface{}) pgx.Row
+	Exec(context.Context, string, ...any) (pgconn.CommandTag, error)
+	Query(context.Context, string, ...any) (pgx.Rows, error)
+	QueryRow(context.Context, string, ...any) pgx.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/update_cte/pgx/v4/go/db.go
+++ b/internal/endtoend/testdata/update_cte/pgx/v4/go/db.go
@@ -12,9 +12,9 @@ import (
 )
 
 type DBTX interface {
-	Exec(context.Context, string, ...interface{}) (pgconn.CommandTag, error)
-	Query(context.Context, string, ...interface{}) (pgx.Rows, error)
-	QueryRow(context.Context, string, ...interface{}) pgx.Row
+	Exec(context.Context, string, ...any) (pgconn.CommandTag, error)
+	Query(context.Context, string, ...any) (pgx.Rows, error)
+	QueryRow(context.Context, string, ...any) pgx.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/update_cte/pgx/v5/go/db.go
+++ b/internal/endtoend/testdata/update_cte/pgx/v5/go/db.go
@@ -12,9 +12,9 @@ import (
 )
 
 type DBTX interface {
-	Exec(context.Context, string, ...interface{}) (pgconn.CommandTag, error)
-	Query(context.Context, string, ...interface{}) (pgx.Rows, error)
-	QueryRow(context.Context, string, ...interface{}) pgx.Row
+	Exec(context.Context, string, ...any) (pgconn.CommandTag, error)
+	Query(context.Context, string, ...any) (pgx.Rows, error)
+	QueryRow(context.Context, string, ...any) pgx.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/update_cte/stdlib/go/db.go
+++ b/internal/endtoend/testdata/update_cte/stdlib/go/db.go
@@ -10,10 +10,10 @@ import (
 )
 
 type DBTX interface {
-	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
 	PrepareContext(context.Context, string) (*sql.Stmt, error)
-	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
-	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/update_inner_join/db/db.go
+++ b/internal/endtoend/testdata/update_inner_join/db/db.go
@@ -10,10 +10,10 @@ import (
 )
 
 type DBTX interface {
-	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
 	PrepareContext(context.Context, string) (*sql.Stmt, error)
-	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
-	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/update_join/mysql/db/db.go
+++ b/internal/endtoend/testdata/update_join/mysql/db/db.go
@@ -10,10 +10,10 @@ import (
 )
 
 type DBTX interface {
-	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
 	PrepareContext(context.Context, string) (*sql.Stmt, error)
-	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
-	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/update_join/postgresql/db/db.go
+++ b/internal/endtoend/testdata/update_join/postgresql/db/db.go
@@ -10,10 +10,10 @@ import (
 )
 
 type DBTX interface {
-	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
 	PrepareContext(context.Context, string) (*sql.Stmt, error)
-	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
-	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/update_set/myql/go/db.go
+++ b/internal/endtoend/testdata/update_set/myql/go/db.go
@@ -10,10 +10,10 @@ import (
 )
 
 type DBTX interface {
-	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
 	PrepareContext(context.Context, string) (*sql.Stmt, error)
-	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
-	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/update_set/postgresql/pgx/v4/go/db.go
+++ b/internal/endtoend/testdata/update_set/postgresql/pgx/v4/go/db.go
@@ -12,9 +12,9 @@ import (
 )
 
 type DBTX interface {
-	Exec(context.Context, string, ...interface{}) (pgconn.CommandTag, error)
-	Query(context.Context, string, ...interface{}) (pgx.Rows, error)
-	QueryRow(context.Context, string, ...interface{}) pgx.Row
+	Exec(context.Context, string, ...any) (pgconn.CommandTag, error)
+	Query(context.Context, string, ...any) (pgx.Rows, error)
+	QueryRow(context.Context, string, ...any) pgx.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/update_set/postgresql/pgx/v5/go/db.go
+++ b/internal/endtoend/testdata/update_set/postgresql/pgx/v5/go/db.go
@@ -12,9 +12,9 @@ import (
 )
 
 type DBTX interface {
-	Exec(context.Context, string, ...interface{}) (pgconn.CommandTag, error)
-	Query(context.Context, string, ...interface{}) (pgx.Rows, error)
-	QueryRow(context.Context, string, ...interface{}) pgx.Row
+	Exec(context.Context, string, ...any) (pgconn.CommandTag, error)
+	Query(context.Context, string, ...any) (pgx.Rows, error)
+	QueryRow(context.Context, string, ...any) pgx.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/update_set/postgresql/stdlib/go/db.go
+++ b/internal/endtoend/testdata/update_set/postgresql/stdlib/go/db.go
@@ -10,10 +10,10 @@ import (
 )
 
 type DBTX interface {
-	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
 	PrepareContext(context.Context, string) (*sql.Stmt, error)
-	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
-	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/update_set/sqlite/go/db.go
+++ b/internal/endtoend/testdata/update_set/sqlite/go/db.go
@@ -10,10 +10,10 @@ import (
 )
 
 type DBTX interface {
-	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
 	PrepareContext(context.Context, string) (*sql.Stmt, error)
-	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
-	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/update_set_multiple/mysql/go/db.go
+++ b/internal/endtoend/testdata/update_set_multiple/mysql/go/db.go
@@ -10,10 +10,10 @@ import (
 )
 
 type DBTX interface {
-	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
 	PrepareContext(context.Context, string) (*sql.Stmt, error)
-	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
-	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/update_set_multiple/postgresql/pgx/v4/go/db.go
+++ b/internal/endtoend/testdata/update_set_multiple/postgresql/pgx/v4/go/db.go
@@ -12,9 +12,9 @@ import (
 )
 
 type DBTX interface {
-	Exec(context.Context, string, ...interface{}) (pgconn.CommandTag, error)
-	Query(context.Context, string, ...interface{}) (pgx.Rows, error)
-	QueryRow(context.Context, string, ...interface{}) pgx.Row
+	Exec(context.Context, string, ...any) (pgconn.CommandTag, error)
+	Query(context.Context, string, ...any) (pgx.Rows, error)
+	QueryRow(context.Context, string, ...any) pgx.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/update_set_multiple/postgresql/pgx/v5/go/db.go
+++ b/internal/endtoend/testdata/update_set_multiple/postgresql/pgx/v5/go/db.go
@@ -12,9 +12,9 @@ import (
 )
 
 type DBTX interface {
-	Exec(context.Context, string, ...interface{}) (pgconn.CommandTag, error)
-	Query(context.Context, string, ...interface{}) (pgx.Rows, error)
-	QueryRow(context.Context, string, ...interface{}) pgx.Row
+	Exec(context.Context, string, ...any) (pgconn.CommandTag, error)
+	Query(context.Context, string, ...any) (pgx.Rows, error)
+	QueryRow(context.Context, string, ...any) pgx.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/update_set_multiple/postgresql/stdlib/go/db.go
+++ b/internal/endtoend/testdata/update_set_multiple/postgresql/stdlib/go/db.go
@@ -10,10 +10,10 @@ import (
 )
 
 type DBTX interface {
-	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
 	PrepareContext(context.Context, string) (*sql.Stmt, error)
-	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
-	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/update_set_multiple/sqlite/go/db.go
+++ b/internal/endtoend/testdata/update_set_multiple/sqlite/go/db.go
@@ -10,10 +10,10 @@ import (
 )
 
 type DBTX interface {
-	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
 	PrepareContext(context.Context, string) (*sql.Stmt, error)
-	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
-	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/update_two_table/mysql/go/db.go
+++ b/internal/endtoend/testdata/update_two_table/mysql/go/db.go
@@ -10,10 +10,10 @@ import (
 )
 
 type DBTX interface {
-	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
 	PrepareContext(context.Context, string) (*sql.Stmt, error)
-	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
-	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/upsert/sqlite/go/db.go
+++ b/internal/endtoend/testdata/upsert/sqlite/go/db.go
@@ -10,10 +10,10 @@ import (
 )
 
 type DBTX interface {
-	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
 	PrepareContext(context.Context, string) (*sql.Stmt, error)
-	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
-	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/valid_group_by_reference/mysql/go/db.go
+++ b/internal/endtoend/testdata/valid_group_by_reference/mysql/go/db.go
@@ -10,10 +10,10 @@ import (
 )
 
 type DBTX interface {
-	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
 	PrepareContext(context.Context, string) (*sql.Stmt, error)
-	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
-	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/valid_group_by_reference/mysql/go/query.sql.go
+++ b/internal/endtoend/testdata/valid_group_by_reference/mysql/go/query.sql.go
@@ -83,9 +83,9 @@ ORDER BY bucket DESC
 `
 
 type ListMetricsRow struct {
-	Bucket   interface{}
+	Bucket   any
 	CityName sql.NullString
-	Avg      interface{}
+	Avg      any
 }
 
 func (q *Queries) ListMetrics(ctx context.Context) ([]ListMetricsRow, error) {

--- a/internal/endtoend/testdata/valid_group_by_reference/pganalyzer/go/db.go
+++ b/internal/endtoend/testdata/valid_group_by_reference/pganalyzer/go/db.go
@@ -10,10 +10,10 @@ import (
 )
 
 type DBTX interface {
-	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
 	PrepareContext(context.Context, string) (*sql.Stmt, error)
-	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
-	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/valid_group_by_reference/postgresql/go/db.go
+++ b/internal/endtoend/testdata/valid_group_by_reference/postgresql/go/db.go
@@ -10,10 +10,10 @@ import (
 )
 
 type DBTX interface {
-	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
 	PrepareContext(context.Context, string) (*sql.Stmt, error)
-	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
-	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/vet_explain/mysql/db/db.go
+++ b/internal/endtoend/testdata/vet_explain/mysql/db/db.go
@@ -10,10 +10,10 @@ import (
 )
 
 type DBTX interface {
-	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
 	PrepareContext(context.Context, string) (*sql.Stmt, error)
-	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
-	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/vet_explain/mysql/db/models.go
+++ b/internal/endtoend/testdata/vet_explain/mysql/db/models.go
@@ -19,7 +19,7 @@ const (
 	DebugCenumThree DebugCenum = "three"
 )
 
-func (e *DebugCenum) Scan(src interface{}) error {
+func (e *DebugCenum) Scan(src any) error {
 	switch s := src.(type) {
 	case []byte:
 		*e = DebugCenum(s)
@@ -37,7 +37,7 @@ type NullDebugCenum struct {
 }
 
 // Scan implements the Scanner interface.
-func (ns *NullDebugCenum) Scan(value interface{}) error {
+func (ns *NullDebugCenum) Scan(value any) error {
 	if value == nil {
 		ns.DebugCenum, ns.Valid = "", false
 		return nil
@@ -62,7 +62,7 @@ const (
 	DebugCsetThree DebugCset = "three"
 )
 
-func (e *DebugCset) Scan(src interface{}) error {
+func (e *DebugCset) Scan(src any) error {
 	switch s := src.(type) {
 	case []byte:
 		*e = DebugCset(s)
@@ -80,7 +80,7 @@ type NullDebugCset struct {
 }
 
 // Scan implements the Scanner interface.
-func (ns *NullDebugCset) Scan(value interface{}) error {
+func (ns *NullDebugCset) Scan(value any) error {
 	if value == nil {
 		ns.DebugCset, ns.Valid = "", false
 		return nil
@@ -113,7 +113,7 @@ type Debug struct {
 	Ctinyint         int8
 	Cbool            bool
 	Cmediumint       int32
-	Cbit             interface{}
+	Cbit             any
 	Cdate            time.Time
 	Cdatetime        time.Time
 	Ctimestamp       time.Time

--- a/internal/endtoend/testdata/vet_explain/mysql/db/query.sql.go
+++ b/internal/endtoend/testdata/vet_explain/mysql/db/query.sql.go
@@ -28,7 +28,7 @@ SELECT id FROM debug
 WHERE Cbit = ? LIMIT 1
 `
 
-func (q *Queries) SelectByCbit(ctx context.Context, cbit interface{}) (int64, error) {
+func (q *Queries) SelectByCbit(ctx context.Context, cbit any) (int64, error) {
 	row := q.db.QueryRowContext(ctx, selectByCbit, cbit)
 	var id int64
 	err := row.Scan(&id)

--- a/internal/endtoend/testdata/virtual_table/sqlite/go/db.go
+++ b/internal/endtoend/testdata/virtual_table/sqlite/go/db.go
@@ -10,10 +10,10 @@ import (
 )
 
 type DBTX interface {
-	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
 	PrepareContext(context.Context, string) (*sql.Stmt, error)
-	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
-	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/where_collate/sqlite/go/db.go
+++ b/internal/endtoend/testdata/where_collate/sqlite/go/db.go
@@ -10,10 +10,10 @@ import (
 )
 
 type DBTX interface {
-	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
 	PrepareContext(context.Context, string) (*sql.Stmt, error)
-	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
-	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/wrap_errors/mysql/db/db.go
+++ b/internal/endtoend/testdata/wrap_errors/mysql/db/db.go
@@ -10,10 +10,10 @@ import (
 )
 
 type DBTX interface {
-	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
 	PrepareContext(context.Context, string) (*sql.Stmt, error)
-	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
-	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/wrap_errors/postgresql/pgx/db/db.go
+++ b/internal/endtoend/testdata/wrap_errors/postgresql/pgx/db/db.go
@@ -12,9 +12,9 @@ import (
 )
 
 type DBTX interface {
-	Exec(context.Context, string, ...interface{}) (pgconn.CommandTag, error)
-	Query(context.Context, string, ...interface{}) (pgx.Rows, error)
-	QueryRow(context.Context, string, ...interface{}) pgx.Row
+	Exec(context.Context, string, ...any) (pgconn.CommandTag, error)
+	Query(context.Context, string, ...any) (pgx.Rows, error)
+	QueryRow(context.Context, string, ...any) pgx.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/wrap_errors/postgresql/stdlib/db/db.go
+++ b/internal/endtoend/testdata/wrap_errors/postgresql/stdlib/db/db.go
@@ -10,10 +10,10 @@ import (
 )
 
 type DBTX interface {
-	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
 	PrepareContext(context.Context, string) (*sql.Stmt, error)
-	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
-	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/wrap_errors/sqlite/db/db.go
+++ b/internal/endtoend/testdata/wrap_errors/sqlite/db/db.go
@@ -10,10 +10,10 @@ import (
 )
 
 type DBTX interface {
-	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
 	PrepareContext(context.Context, string) (*sql.Stmt, error)
-	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
-	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
 }
 
 func New(db DBTX) *Queries {

--- a/internal/endtoend/testdata/yaml_overrides/go/db.go
+++ b/internal/endtoend/testdata/yaml_overrides/go/db.go
@@ -10,10 +10,10 @@ import (
 )
 
 type DBTX interface {
-	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
 	PrepareContext(context.Context, string) (*sql.Stmt, error)
-	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
-	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
 }
 
 func New(db DBTX) *Queries {


### PR DESCRIPTION
Fixes #4470

Generated Go code now uses the predeclared `any` alias everywhere the generator previously wrote `interface{}`, so `go fix` has nothing left to change in sqlc's output.

## Generator changes

- All four Go type mappers (`postgresql_type.go`, `mysql_type.go`, `sqlite_type.go`, `go_type.go`) return `"any"` for unknown/fallback types, and the stdlib/pgx templates (`DBTX` interfaces, `exec`/`query`/`queryRow` helpers, `queryParams`, batch/copyfrom value slices, enum `Scan` methods) spell the type `any`.
- The unknown-type backfill in `result.go` matches the new `"any"` spelling.
- `any` is added to the reserved identifier list, and query constant names are now escaped. This fixes a bug the switch would otherwise introduce: a query named `Any` generated `const any = ...`, which shadows the predeclared `any` type package-wide and no longer compiles once the surrounding code uses `any`. It now generates `const any_` (the same `_`-suffix treatment other reserved identifiers get, which also covers previously-broken constants like `const select`).

## Regenerated output

- All affected `internal/endtoend/testdata` golden directories (889 cases), with managed-db-only cases regenerated against a live PostgreSQL through the same config mutation `TestReplay` applies.
- All `examples/`.
- The six fixture files generation never overwrites (`diff_output`, `diff_no_output`, and expected-failure cases), plus the generated-code samples in `docs/howto/`.

## Verification

- `go fix` itself skips files with a `// Code generated ... DO NOT EDIT.` header, so as proof both trees were copied with the markers stripped and run through `go fix -diff` on Go 1.26: zero diagnostics across all of `internal/endtoend/testdata` and `examples`, for every registered fixer (not just the `any` modernizer).
- Every golden-file change was verified to be purely the `interface{}` → `any` rewrite (no unrelated churn); the `any` case's `const any_` rename is the one intentional exception.
- `cd internal/endtoend/testdata && go build ./...` passes, and the full suite `go test --tags=examples -timeout 20m ./...` passes against live PostgreSQL and MySQL, including `TestReplay` in both the base and managed-db contexts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Pq9Cgx285AU4NZpCYgtkYS

---
_Generated by [Claude Code](https://claude.ai/code/session_01Pq9Cgx285AU4NZpCYgtkYS)_