### PR TITLE
Remove Riza sponsor image from README and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,10 +35,6 @@ Development is possible thanks to our sponsors. If you would like to support sql
 please consider [sponsoring on GitHub](https://github.com/sponsors/kyleconroy).
 
 <p align="center">
-  <a href="https://riza.io?utm_source=sqlc+readme"><img width=400 src="https://sqlc.dev/sponsors/riza-readme.png" alt="Riza.io"></a>
-</p>
-
-<p align="center">
   <a href="https://coder.com?utm_source=sqlc+readme"><img width=200 src="https://sqlc.dev/sponsors/coder-readme.png" alt="Coder.com" /></a>
   <a href="https://mint.fun?utm_source=sqlc+readme"><img width=200 src="https://sqlc.dev/sponsors/mint-readme.png" alt="Mint.fun" /></a>
   <a href="https://mux.com?utm_source=sqlc+readme"><img width=200 src="https://sqlc.dev/sponsors/mux-readme.png" alt="Mux.com" /></a>

--- a/docs/_static/customize.css
+++ b/docs/_static/customize.css
@@ -15,8 +15,3 @@
   color: #F0F0F4;
   text-decoration: underline;
 }
-
-#sponsorship > img {
-  width: 100%;
-  max-width: 200px;
-}

--- a/docs/_templates/layout.html
+++ b/docs/_templates/layout.html
@@ -4,13 +4,3 @@
 <script defer data-domain="docs.sqlc.dev" data-api="https://proxy.sqlc.dev/api/event" src="https://proxy.sqlc.dev/js/script.js"></script>
 {{ super() }}
 {% endblock %}
-
-{% block menu %}
-{{ super() }}
-<p class="caption" role="heading"><span class="caption-text">Sponsored By</span></p>
-<div>
-<a id="sponsorship" href="https://riza.io?utm_source=sqlc+docs">
-<img src="https://sqlc.dev/sponsors/riza-readme.png" alt="Riza logo" />
-</a>
-</div>
-{% endblock %}


### PR DESCRIPTION
Removes the Riza sponsorship banner image from the project documentation and the README.

- `README.md` — drops the centered Riza banner from the Sponsors section. The Coder / Mint / Mux row and the individual sponsor links are unchanged.
- `docs/_templates/layout.html` — removes the `{% block menu %}` override, which existed only to add the "Sponsored By" sidebar heading and the Riza logo. The Plausible analytics `extrahead` block is unchanged.
- `docs/_static/customize.css` — removes the now-unused `#sponsorship > img` rule, since nothing carries that id anymore.

The `Riza, Inc.` copyright holder and author fields in `docs/conf.py` are left alone — those are legal attribution rather than the sponsorship image.

Docs-only change; no code or generated output is affected.

---
_Generated by [Claude Code](https://claude.ai/code/session_01M9TV1fKN88r2bifi78mMXy)_