### PR TITLE
docs: note that analyze, parse and fmt are in beta

### DIFF
--- a/docs/howto/analyze.md
+++ b/docs/howto/analyze.md
@@ -1,5 +1,10 @@
 # `analyze` - Analyzing query result types
 
+> [!NOTE]
+> `analyze` is in beta. Its flags and JSON output may change in a
+> future release, and the types it reports can differ from the ones
+> `generate` produces.
+
 `sqlc analyze` analyzes a query against a schema and prints the inferred result
 columns and parameters as a single JSON document.
 

--- a/docs/howto/fmt.md
+++ b/docs/howto/fmt.md
@@ -1,5 +1,10 @@
 # `fmt` - Formatting queries
 
+> [!NOTE]
+> `fmt` is in beta. It rewrites your query files in place, so commit
+> or back them up first. The formatting it produces may change in a
+> future release.
+
 `sqlc fmt` rewrites the query files referenced by your configuration file in a
 canonical format. Each query is parsed with the engine's parser and printed
 back from the syntax tree, so formatting never depends on how the query was

--- a/docs/howto/parse.md
+++ b/docs/howto/parse.md
@@ -1,5 +1,9 @@
 # `parse` - Parsing SQL into an AST
 
+> [!NOTE]
+> `parse` is in beta. Its flags and the shape of the JSON AST it
+> prints may change in a future release.
+
 `sqlc parse` parses SQL from a file or standard input and prints the abstract
 syntax tree (AST) as a single JSON document. It does not require a configuration
 file or a database connection.


### PR DESCRIPTION
Adds a beta notice to the top of the three command pages so readers know these commands aren't stable yet.

Each notice sits directly under the page title and uses the `> [!NOTE]` GitHub alert style already used elsewhere in the docs (`docs/howto/push.md`, `docs/howto/overrides.md`) — `internal/docs/lint.go` requires GitHub alerts rather than MyST directives.

- `docs/howto/analyze.md` — flags and JSON output may change, and the types it reports can differ from what `generate` produces
- `docs/howto/parse.md` — flags and the shape of the printed JSON AST may change
- `docs/howto/fmt.md` — the formatting it produces may change, plus a reminder that it rewrites query files in place

Docs only; no code changes. `go test ./internal/docs/...` passes.

---
_Generated by [Claude Code](https://claude.ai/code/session_01DnqiFw1XAw6b14bSf1GQZb)_