### PR TITLE
docs(transactions): note the lost-update risk in read-modify-write

### DIFF
--- a/docs/howto/transactions.md
+++ b/docs/howto/transactions.md
@@ -99,3 +99,29 @@ func bumpCounter(ctx context.Context, db *pgx.Conn, queries *tutorial.Queries, i
 	return tx.Commit(ctx)
 }
 ```
+
+## Concurrent read-modify-write
+
+The `bumpCounter` example reads a row and then writes a value derived from it.
+Under the default isolation level (`READ COMMITTED`), two transactions running
+`bumpCounter` concurrently can both read the same `counter`, both write
+`counter + 1`, and one update is lost.
+
+When a write depends on a value read earlier in the same transaction, lock the
+row on read with `SELECT ... FOR UPDATE` (supported by PostgreSQL and
+MySQL/InnoDB):
+
+```sql
+-- name: GetRecordForUpdate :one
+SELECT * FROM records
+WHERE id = $1
+FOR UPDATE;
+```
+
+Call `GetRecordForUpdate` in place of `GetRecord`; the second transaction then
+blocks until the first commits, and reads the updated value.
+
+Alternatively, run the transaction at `SERIALIZABLE` isolation and retry on
+serialization failures. sqlc does not manage isolation levels or retries — set
+the isolation level when you begin the transaction and handle the retry loop in
+your application code.


### PR DESCRIPTION
## What

The **Using transactions** how-to's `bumpCounter` example reads a row and then writes `counter + 1` inside a transaction:

```go
r, err := qtx.GetRecord(ctx, id)
...
qtx.UpdateRecord(ctx, tutorial.UpdateRecordParams{ID: r.ID, Counter: r.Counter + 1})
```

Under the default isolation level (`READ COMMITTED`, on both PostgreSQL and MySQL/InnoDB), two transactions running this concurrently can both read the same `counter` and both write the same `counter + 1` — a lost update. The page presents this as the standard pattern with no caveat, which is what #3485 flags.

## Change

Docs only. Adds a short **Concurrent read-modify-write** section after the examples:

- explains the lost-update window
- shows a `GetRecordForUpdate` query using `SELECT ... FOR UPDATE`
- mentions `SERIALIZABLE` + retry as the alternative, noting sqlc doesn't manage isolation levels or retries

Existing examples are unchanged — they still demonstrate `WithTx`, which is the page's purpose.

Closes #3485