### PR TITLE
docs: explain how to use the Go 1.27 stdlib uuid package via overrides

### DIFF
--- a/docs/reference/datatypes.md
+++ b/docs/reference/datatypes.md
@@ -122,8 +122,8 @@ type Author struct {
 
 ## UUIDs
 
-The Go standard library does not come with a `uuid` package. For UUID support,
-sqlc uses the excellent `github.com/google/uuid` package. The pgx/v5 sql package uses `pgtype.UUID`.
+For UUID support, sqlc uses the `github.com/google/uuid` package by default.
+The pgx/v5 sql package uses `pgtype.UUID`.
 
 ```sql
 CREATE TABLE records (
@@ -142,6 +142,70 @@ type Author struct {
 	ID uuid.UUID
 }
 ```
+
+### Using the standard library uuid package
+
+Go 1.27 added a [`uuid`](https://pkg.go.dev/uuid) package to the standard
+library. sqlc will use this package by default in a future release. Until
+then, use it today with type overrides
+(see [Overriding types](../howto/overrides.md) for details).
+
+Two overrides are required: one for non-nullable columns and one for nullable
+columns. The standard library does not include a `NullUUID` type, so nullable
+columns map to `*uuid.UUID` instead.
+
+```yaml
+version: "2"
+sql:
+  - engine: "postgresql"
+    schema: "schema.sql"
+    queries: "query.sql"
+    gen:
+      go:
+        package: "db"
+        out: "db"
+        sql_package: "pgx/v5"
+        overrides:
+          - db_type: "uuid"
+            go_type: "uuid.UUID"
+          - db_type: "uuid"
+            nullable: true
+            go_type:
+              import: "uuid"
+              type: "UUID"
+              pointer: true
+```
+
+With this configuration, a table with both nullable and non-nullable `uuid`
+columns:
+
+```sql
+CREATE TABLE records (
+  id          uuid PRIMARY KEY,
+  external_id uuid
+);
+```
+
+generates:
+
+```go
+package db
+
+import (
+	"uuid"
+)
+
+type Record struct {
+	ID         uuid.UUID
+	ExternalID *uuid.UUID
+}
+```
+
+These overrides work with both the `pgx/v5` and `database/sql` sql packages.
+pgx supports any type whose underlying type is `[16]byte`, and as of Go 1.27
+`database/sql` converts `uuid.UUID` values in both directions: parameters are
+bound via `driver.DefaultParameterConverter` and results are scanned into
+`uuid.UUID` and `*uuid.UUID` destinations, with `nil` representing `NULL`.
 
 For MySQL, there is no native `uuid` data type. When using `UUID_TO_BIN` to store a `UUID()`, the underlying field type is `BINARY(16)` which by default sqlc would map to `sql.NullString`. To have sqlc automatically convert these fields to a `uuid.UUID` type, use an overide on the column storing the `uuid`
 (see [Overriding types](../howto/overrides.md) for details).


### PR DESCRIPTION
Go 1.27 added a `uuid` package to the standard library (#4590). This documents the type overrides that let users adopt it today, ahead of sqlc switching its default UUID type:

```yaml
overrides:
  - db_type: "uuid"
    go_type: "uuid.UUID"
  - db_type: "uuid"
    nullable: true
    go_type:
      import: "uuid"
      type: "UUID"
      pointer: true
```

Nullable columns map to `*uuid.UUID` since the standard library has no `NullUUID` type. No code changes were needed: the override machinery already parses the stdlib import path, and the existing special-casing in `imports.go` suppresses the hardcoded `github.com/google/uuid` import whenever an override renders as `uuid.UUID`.

Verified end-to-end against PostgreSQL 16 with the generated code compiled under go1.27.0, for both sql packages:

- **pgx/v5** handles the type via its underlying-`[16]byte` wrap plans (`TryFindUnderlyingTypeScanPlan` / `TryWrapFindUnderlyingTypeEncodePlan`).
- **database/sql** gained first-class support in Go 1.27: `driver.DefaultParameterConverter` binds `uuid.UUID` parameters and `convertAssign` scans `string`/`[]byte` values into `uuid.UUID` and `*uuid.UUID` destinations, with `nil` as `NULL`.

Round-trips covered v4 and v7 UUIDs plus NULL and non-NULL nullable columns.

No endtoend testdata case is included because generated code importing the stdlib `uuid` package requires Go 1.27+, and the testdata module builds under the repo's Go 1.26 toolchain. `uuid[]` array columns were not verified, so the docs make no claims about them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01N9jm9kAWEiXHxg3LGsNP4p

---
_Generated by [Claude Code](https://claude.ai/code/session_01N9jm9kAWEiXHxg3LGsNP4p)_