### PR TITLE
Upgrade cel-go to cel.dev/cel-go v0.32.0

### DIFF
--- a/docs/howto/vet.md
+++ b/docs/howto/vet.md
@@ -7,7 +7,7 @@
 Rules are defined in the `sqlc` [configuration](../reference/config.md) file. They
 consist of a name, message, and a [Common Expression Language
 (CEL)](https://github.com/google/cel-spec) expression. Expressions are evaluated
-using [cel-go](https://github.com/google/cel-go).  If an expression evaluates to
+using [cel-go](https://github.com/cel-expr/cel-go).  If an expression evaluates to
 `true`, `sqlc vet` will report an error using the given message.
 
 ## Defining lint rules

--- a/docs/reference/changelog.md
+++ b/docs/reference/changelog.md
@@ -1208,7 +1208,7 @@ Released 2023-07-06
 
 Rules are defined in the `sqlc` [configuration](config.md) file. They consist
 of a name, message, and a [Common Expression Language (CEL)](https://github.com/google/cel-spec)
-expression. Expressions are evaluated using [cel-go](https://github.com/google/cel-go).
+expression. Expressions are evaluated using [cel-go](https://github.com/cel-expr/cel-go).
 If an expression evaluates to `true`, an error is reported using the given message.
 
 While these examples are simplistic, they give you a flavor of the types of

--- a/go.mod
+++ b/go.mod
@@ -5,11 +5,11 @@ go 1.26.0
 toolchain go1.26.5
 
 require (
+	cel.dev/cel-go v0.32.0
 	github.com/cubicdaiya/gonp v1.0.4
 	github.com/davecgh/go-spew v1.1.1
 	github.com/fatih/structtag v1.2.0
 	github.com/go-sql-driver/mysql v1.10.0
-	github.com/google/cel-go v0.31.0
 	github.com/google/go-cmp v0.7.0
 	github.com/jackc/pgx/v5 v5.10.0
 	github.com/jinzhu/inflection v1.0.0

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,5 @@
+cel.dev/cel-go v0.32.0 h1:irvpFKr5EuGPyxeME03ERh0rii1TX+BDAnB9eL3IvNk=
+cel.dev/cel-go v0.32.0/go.mod h1:DnVip7tpJSsgZymwfT+m1tnEVy3ivAjSMXPx12YrMkU=
 cel.dev/expr v0.25.2 h1:K6j46C81hXtZQfuX60cVWQFBJahKSE2gfRbNuvr5bFs=
 cel.dev/expr v0.25.2/go.mod h1:hrXvqGP6G6gyx8UAHSHJ5RGk//1Oj5nXQ2NI02Nrsg4=
 filippo.io/edwards25519 v1.2.0 h1:crnVqOiS4jqYleHd9vaKZ+HKtHfllngJIiOpNpoJsjo=
@@ -23,8 +25,6 @@ github.com/go-sql-driver/mysql v1.10.0 h1:Q+1LV8DkHJvSYAdR83XzuhDaTykuDx0l6fkXxo
 github.com/go-sql-driver/mysql v1.10.0/go.mod h1:M+cqaI7+xxXGG9swrdeUIoPG3Y3KCkF0pZej+SK+nWk=
 github.com/golang/protobuf v1.5.4 h1:i7eJL8qZTpSEXOPTxNKhASYpMn+8e5Q6AdndVa1dWek=
 github.com/golang/protobuf v1.5.4/go.mod h1:lnTiLA8Wa4RWRcIUkrtSVa5nRhsEGBg48fD6rSs7xps=
-github.com/google/cel-go v0.31.0 h1:H0bhpFTqOvmHrBGrWKp7ZlhBm5Hh8PYUEXnwxT1LL7A=
-github.com/google/cel-go v0.31.0/go.mod h1:X0bD6iVNR8pkROSOoHVdgTkzmRcosof7WQqCD6wcMc8=
 github.com/google/go-cmp v0.7.0 h1:wk8382ETsv4JYUZwIsn6YpYiWiBsYLSJiTsyBybVuN8=
 github.com/google/go-cmp v0.7.0/go.mod h1:pXiqmnSA92OHEEa9HXL2W4E7lf9JzCmGVUdgjX3N/iU=
 github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=

--- a/internal/cmd/vet.go
+++ b/internal/cmd/vet.go
@@ -18,8 +18,8 @@ import (
 	"time"
 
 	_ "github.com/go-sql-driver/mysql"
-	"github.com/google/cel-go/cel"
-	"github.com/google/cel-go/ext"
+	"cel.dev/cel-go/cel"
+	"cel.dev/cel-go/ext"
 	"github.com/jackc/pgx/v5"
 	"github.com/spf13/cobra"
 	"google.golang.org/protobuf/encoding/protojson"
@@ -140,7 +140,7 @@ func Vet(ctx context.Context, dir, filename string, opts *Options) error {
 		rule := rule{Program: &prg, Message: c.Msg}
 
 		// TODO There's probably a nicer way to do this from the ast
-		// https://pkg.go.dev/github.com/google/cel-go/common/ast#AllMatcher
+		// https://pkg.go.dev/cel.dev/cel-go/common/ast#AllMatcher
 		if strings.Contains(c.Rule, "postgresql.explain") ||
 			strings.Contains(c.Rule, "mysql.explain") {
 			rule.NeedsExplain = true


### PR DESCRIPTION
cel-go moved from `github.com/google/cel-go` to the `cel.dev/cel-go` module path, with the source now hosted at https://github.com/cel-expr/cel-go.

## Changes

- Replace `github.com/google/cel-go v0.31.0` with `cel.dev/cel-go v0.32.0` in `go.mod` / `go.sum`.
- Switch the imports in `internal/cmd/vet.go` to the new module path. No API changes were required.
- Point the cel-go links in `docs/howto/vet.md` and `docs/reference/changelog.md` at the `cel-expr/cel-go` repository.

## Testing

- `go build ./...` and `go vet ./internal/cmd/` are clean.
- `go test ./internal/endtoend -run 'TestReplay/base/vet_'` passes, which compiles and evaluates CEL vet rules through the CLI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018CPujacpgZc2qAebVCmbjw

---
_Generated by [Claude Code](https://claude.ai/code/session_018CPujacpgZc2qAebVCmbjw)_