### PR TITLE
docs: document SQLCDEBUG=databases=managed

### DIFF
--- a/docs/reference/environment-variables.md
+++ b/docs/reference/environment-variables.md
@@ -182,6 +182,15 @@ The `dumpexplain` command prints the JSON-formatted result from running
 
 `SQLCDEBUG=dumpexplain=1`
 
+### databases
+
+Setting this value to `managed` prevents `sqlc vet` from opening connections to
+databases configured with a `uri`. Rules that need a database connection will
+only run against a managed database; evaluating such a rule against a `uri`
+database returns an error.
+
+`SQLCDEBUG=databases=managed`
+
 ## SQLCTMPDIR
 
 If specified, use the given directory as the base for temporary folders. Only


### PR DESCRIPTION
## What
Document the `SQLCDEBUG=databases=managed` setting on the environment-variables reference page.

## Why / evidence
`internal/sqlcdebug/sqlcdebug.go` registers `databases` in its master `Settings`
table ("set to 'managed' to disable database connections via URI"), and
`internal/cmd/vet.go` reads it (`debugDatabases = sqlcdebug.New("databases")`,
`OnlyManagedDB: debugDatabases.Value() == "managed"`) to reject `uri` databases
during `sqlc vet`. The option shipped in #2898 and appears in the changelog, but
`docs/reference/environment-variables.md` documents every other SQLCDEBUG key
(`dumpast`, `dumpcatalog`, `trace`, `processplugins`, `dumpvetenv`,
`dumpexplain`) except this one.

## Change
Adds a `### databases` subsection under `## SQLCDEBUG`, matching the style of the
surrounding entries. Docs-only, one file.

## Verified
Built `sqlc` at HEAD (`go build -o /tmp/sqlc-dev ./cmd/sqlc`, reports v1.31.1)
and ran `sqlc vet` on a config with a `database.uri` and the `sqlc/db-prepare`
rule:

- without the env var: `failed to connect to user=postgres database=nope ...`
  (sqlc attempts the URI connection)
- `SQLCDEBUG=databases=managed sqlc vet`:
  `database: connections disabled via SQLCDEBUG=databases=managed`

`go test ./internal/sqlcdebug/` passes.
