### PR TITLE
gen: run each engine's dialect generation as a separate job

### DIFF
--- a/.github/workflows/gen.yml
+++ b/.github/workflows/gen.yml
@@ -2,8 +2,8 @@ name: gen
 on:
   workflow_dispatch:
 jobs:
-  generate:
-    name: generate dialects
+  postgresql:
+    name: generate postgresql dialect
     runs-on: ubuntu-24.04
     services:
       postgres:
@@ -22,18 +22,56 @@ jobs:
       with:
         go-version-file: internal/goldeneye/go.mod
         check-latest: true
-    - run: go run ./cmd/goldeneye install clickhouse
-      working-directory: internal/goldeneye
-    - run: go run ./cmd/goldeneye install sqlite
-      working-directory: internal/goldeneye
-    - run: go run ./cmd/goldeneye generate
+    - run: go run ./cmd/goldeneye generate postgresql
       working-directory: internal/goldeneye
       env:
         POSTGRESQL_SERVER_URI: postgres://postgres:postgres@localhost:${{ job.services.postgres.ports['5432'] }}/postgres?sslmode=disable
     - name: Save results
       uses: actions/upload-artifact@v7
       with:
-        name: dialects
-        path: internal/engine/*/dialect
-    - name: Fail if the committed dialects differ
-      run: git add -N internal/engine && git diff --exit-code --stat -- internal/engine
+        name: dialect-postgresql
+        path: internal/engine/postgresql/dialect
+    - name: Fail if the committed dialect differs
+      run: git add -N internal/engine/postgresql && git diff --exit-code --stat -- internal/engine/postgresql
+
+  clickhouse:
+    name: generate clickhouse dialect
+    runs-on: ubuntu-24.04
+    steps:
+    - uses: actions/checkout@v7
+    - uses: actions/setup-go@v7
+      with:
+        go-version-file: internal/goldeneye/go.mod
+        check-latest: true
+    - run: go run ./cmd/goldeneye install clickhouse
+      working-directory: internal/goldeneye
+    - run: go run ./cmd/goldeneye generate clickhouse
+      working-directory: internal/goldeneye
+    - name: Save results
+      uses: actions/upload-artifact@v7
+      with:
+        name: dialect-clickhouse
+        path: internal/engine/clickhouse/dialect
+    - name: Fail if the committed dialect differs
+      run: git add -N internal/engine/clickhouse && git diff --exit-code --stat -- internal/engine/clickhouse
+
+  sqlite:
+    name: generate sqlite dialect
+    runs-on: ubuntu-24.04
+    steps:
+    - uses: actions/checkout@v7
+    - uses: actions/setup-go@v7
+      with:
+        go-version-file: internal/goldeneye/go.mod
+        check-latest: true
+    - run: go run ./cmd/goldeneye install sqlite
+      working-directory: internal/goldeneye
+    - run: go run ./cmd/goldeneye generate sqlite
+      working-directory: internal/goldeneye
+    - name: Save results
+      uses: actions/upload-artifact@v7
+      with:
+        name: dialect-sqlite
+        path: internal/engine/sqlite/dialect
+    - name: Fail if the committed dialect differs
+      run: git add -N internal/engine/sqlite && git diff --exit-code --stat -- internal/engine/sqlite


### PR DESCRIPTION
## Summary

The `gen` workflow generated every dialect in one job, so a failure in one engine hid the results of the others, and the PostgreSQL service container ran for engines that do not need it.

This splits it into one job per generated engine:

- **postgresql** keeps the Postgres 16 service container and runs `goldeneye generate postgresql`.
- **clickhouse** installs the pinned ClickHouse binary and generates only that engine, with no service.
- **sqlite** builds the pinned sqlite3 shells and generates only that engine, with no service.

Each job uploads its own artifact (`dialect-<engine>`) and the "committed dialect differs" check is scoped to that engine's directory.

DuckDB still has no job: the DuckDB 2.0 CLI goldeneye needs has no release to download yet, so the previous single job skipped it too.

## Test plan

- [x] Workflow YAML parses with the three expected jobs
- [ ] Dispatch the `gen` workflow on this branch and confirm all three jobs pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PDAdd694tS93jQsF4X5Hqb

---
_Generated by [Claude Code](https://claude.ai/code/session_01PDAdd694tS93jQsF4X5Hqb)_