### PR TITLE
Use sqlc-gen-typescript-native for TypeScript support

### DIFF
--- a/.github/workflows/ci-typescript.yml
+++ b/.github/workflows/ci-typescript.yml
@@ -26,8 +26,8 @@ jobs:
         with:
           repository: bonakodo/sqlc-gen-typescript-native
           path: typescript
-          # v0.3.0
-          ref: 8eac5960f4ccffac60cccdf73d4a884998e77acf
+          # v0.4.0
+          ref: 1942c66cebc201e85fbd79fbe162a2ce6b47a666
           persist-credentials: false
       - uses: denoland/setup-deno@v2
         with:

--- a/.github/workflows/ci-typescript.yml
+++ b/.github/workflows/ci-typescript.yml
@@ -10,21 +10,45 @@ on:
       - 'docs/**'
 jobs:
   build:
-    if: false
     name: test
     runs-on: ubuntu-latest
+    timeout-minutes: 25
     steps:
       - uses: actions/checkout@v7
       - uses: actions/setup-go@v7
         with:
           go-version: '1.26.5'
-      - name: install ./...
-        run: go install ./...
+      - name: Build sqlc from this checkout
+        run: |
+          go build -o "$RUNNER_TEMP/sqlc" ./cmd/sqlc
+          echo "SQLC=$RUNNER_TEMP/sqlc" >> "$GITHUB_ENV"
       - uses: actions/checkout@v7
         with:
-          repository: sqlc-dev/sqlc-gen-typescript
+          repository: bonakodo/sqlc-gen-typescript-native
           path: typescript
-          # v0.1.3
-          ref: daaf539092421adc15f6c3164279a3470716b560
-      - run: sqlc diff
-        working-directory: typescript/examples
+          # v0.3.0
+          ref: 8eac5960f4ccffac60cccdf73d4a884998e77acf
+          persist-credentials: false
+      - uses: denoland/setup-deno@v2
+        with:
+          deno-version: "v2.9.6"
+      - uses: actions/setup-node@v7
+        with:
+          node-version: "26.8.1"
+          cache: npm
+          cache-dependency-path: typescript/tests/integration/package-lock.json
+      - name: Install SQLite shared library
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libsqlite3-0
+          sqlite_library=$(dpkg -L libsqlite3-0 | sed -n '/\/libsqlite3\.so\.0$/p')
+          test -f "$sqlite_library"
+          echo "DENO_SQLITE_PATH=$sqlite_library" >> "$GITHUB_ENV"
+      - run: deno task tools
+        working-directory: typescript
+      - name: Test generation and driver runtimes
+        run: deno task integration
+        working-directory: typescript
+      - name: Check generated example
+        run: '"$SQLC" diff'
+        working-directory: typescript/examples/deno-sqlite

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Check out [an interactive example](https://play.sqlc.dev/) to see it in action, 
 - [sqlc-gen-go](https://github.com/sqlc-dev/sqlc-gen-go)
 - [sqlc-gen-kotlin](https://github.com/sqlc-dev/sqlc-gen-kotlin)
 - [sqlc-gen-python](https://github.com/sqlc-dev/sqlc-gen-python)
-- [sqlc-gen-typescript](https://github.com/sqlc-dev/sqlc-gen-typescript)
+- [sqlc-gen-typescript-native](https://github.com/bonakodo/sqlc-gen-typescript-native)
 
 Additional languages can be added via [plugins](https://docs.sqlc.dev/en/latest/reference/language-support.html#community-language-support).
 

--- a/docs/reference/changelog.md
+++ b/docs/reference/changelog.md
@@ -417,7 +417,7 @@ If you run into any issues with the updated dependencies, please [open an issue]
 
 - Add name to query set configuration (#3011)
 - Add a sidebar link for `push`, add Go plugin link (#3023)
-- Update banner for sqlc-gen-typescript (#3036)
+- Update banner for the TypeScript plugin (#3036)
 - Add strict_order_by in doc (#3044)
 - Re-order the migration tools list (#3064)
 
@@ -434,7 +434,7 @@ If you run into any issues with the updated dependencies, please [open an issue]
 
 - (endtoend) Enable for more build targets (#3041)
 - (endtoend) Run MySQL and PostgreSQL locally on the runner (#3095)
-- (typescript) Test against sqlc-gen-typescript (#3046)
+- (typescript) Test against the TypeScript plugin (#3046)
 - Add tests for omit_sqlc_version (#3020)
 - Split schema and query for test (#3094)
 

--- a/docs/reference/language-support.md
+++ b/docs/reference/language-support.md
@@ -6,7 +6,7 @@
 | Go         | [sqlc-gen-go](https://github.com/sqlc-dev/sqlc-gen-go)                 | Stable | Stable     | Beta            |
 | Kotlin     | [sqlc-gen-kotlin](https://github.com/sqlc-dev/sqlc-gen-kotlin)         | Beta   | Beta       | Not implemented |
 | Python     | [sqlc-gen-python](https://github.com/sqlc-dev/sqlc-gen-python)         | Beta   | Beta       | Not implemented |
-| TypeScript | [sqlc-gen-typescript](https://github.com/sqlc-dev/sqlc-gen-typescript) | Beta   | Beta       | Not implemented |
+| TypeScript | [sqlc-gen-typescript-native](https://github.com/bonakodo/sqlc-gen-typescript-native) | Beta   | Beta       | Beta            |
 
 ## Community language support
 


### PR DESCRIPTION
This switches the TypeScript links in the README and language support table to [sqlc-gen-typescript-native](https://github.com/bonakodo/sqlc-gen-typescript-native/tree/v0.4.0), marks SQLite support as Beta, and re-enables TypeScript CI. The job pins v0.4.0 by commit and tests it with the sqlc built from this checkout.

The current plugin builds TypeScript syntax trees and prints them through the TypeScript compiler inside Javy. The replacement implements generation directly in WebAssembly text. It uses the same sqlc plugin protocol, without an embedded JavaScript runtime or TypeScript compiler. This PR changes the plugin integration and docs; it requires no changes to sqlc's compiler or plugin API. See the [existing build](https://github.com/sqlc-dev/sqlc-gen-typescript/blob/v0.1.3/Makefile) and [new implementation](https://github.com/bonakodo/sqlc-gen-typescript-native/tree/v0.4.0/src).

The published WASM file drops from **72,685,305 bytes to 86,712 bytes: 99.88% smaller**. These are the files from [sqlc-gen-typescript v0.1.3](https://github.com/sqlc-dev/sqlc-gen-typescript/releases/tag/v0.1.3) and [sqlc-gen-typescript-native v0.4.0](https://github.com/bonakodo/sqlc-gen-typescript-native/releases/tag/v0.4.0), verified against their published SHA-256 checksums.

I measured complete `sqlc generate` runs for both releases using the same PostgreSQL fixtures. The releases were measured in separate runs:

| PostgreSQL fixture | Cache | v0.1.3 | Native v0.4.0 |
| --- | --- | ---: | ---: |
| 1 table, 8 queries | Cold | 921.9 ms | 128.8 ms |
| 1 table, 8 queries | Warm | 485.9 ms | 37.6 ms |
| 100 tables, 800 queries | Cold | 8,562.7 ms | 350.6 ms |
| 100 tables, 800 queries | Warm | 8,298.7 ms | 269.4 ms |

These are medians on an Apple M1 Max running macOS 26.6.2, using sqlc commit `23e357a414310aa8846e64624da8b8a626b3a610`, built with Go 1.26.5. Both plugins received the same schemas, queries, and `runtime: node` / `driver: pg` options. Cold results use three runs with fresh `SQLCCACHE` directories; warm results use seven runs after one untimed warmup. Downloads sit outside the timer; SQL analysis, plugin loading, generation, and file writes sit inside it. Every run must emit all expected query functions with the same output as that plugin's other runs. These numbers measure generation, not database query speed.

The feature gains also matter:

- **Deno SQLite and exact integers.** It adds `@bonakodo/sqlite` support and an opt-in native mode for both SQLite drivers, with `bigint` integers, boolean/date conversions, and synchronous calls that work inside transaction callbacks. Upstream main already has `better-sqlite3`; the new Deno driver and native value handling extend that support.
- **More query commands.** It handles `:execrows` and `:execresult`, and adds `:execlastid` for `better-sqlite3`. The existing plugin's dispatch handles only `:one`, `:many`, `:exec`, and `:execlastid`; its SQLite driver rejects the last one. See [dispatch](https://github.com/sqlc-dev/sqlc-gen-typescript/blob/395a0baf65ec47f189ae033f86d461c7da1431b9/src/app.ts) and [SQLite output](https://github.com/sqlc-dev/sqlc-gen-typescript/blob/395a0baf65ec47f189ae033f86d461c7da1431b9/src/drivers/better-sqlite3.ts).
- **Shared types and custom conversions.** It emits table models, enum values and types, and typed JSON. Column, database-type, and query overrides can supply application types and codecs. Conversion failures include field and query context.
- **Optional API controls.** Connection-bound query factories, types-only output, nullable-argument options, and control over exported SQL constants let applications choose the API they need. PostgreSQL `pg`/`postgres.js` and MySQL `mysql2` remain supported. The [plugin README](https://github.com/bonakodo/sqlc-gen-typescript-native/blob/v0.4.0/README.md) documents the options and driver behavior.

Generated TypeScript size depends on the workload. [Native v0.4.0](https://github.com/bonakodo/sqlc-gen-typescript-native/releases/tag/v0.4.0) shares query types, encoders, decoders, and field metadata across SQL files. It splits runtime helpers into a common file and one file per engine, and emits only the helpers the queries use. Running the same PostgreSQL fixtures gives:

| Plugin | 1 table, 8 queries | 100 tables, 800 queries |
| --- | ---: | ---: |
| sqlc-gen-typescript v0.1.3 | 7,620 bytes | 762,000 bytes |
| Native v0.4.0 | 14,193 bytes | 634,032 bytes |

The small fixture remains larger than the old plugin; the large fixture is now **16.8% smaller**. These totals include all generated files before bundling.

Migration starts with changing the WASM URL and checksum, keeping the shared runtime, driver, and mysql2 options, then regenerating and type-checking the application. Output is not byte-compatible: it adds files and corrects some field types and names. The module also uses fixed 64 MiB memory, with 16 MiB limits on the request and combined generated file contents, and a 1,024-file limit. The [migration notes](https://github.com/bonakodo/sqlc-gen-typescript-native/blob/v0.4.0/README.md#migration) cover these differences and the other capacity limits.

Local validation passed: the sqlc build, the pinned plugin's full integration task, generated TypeScript and Deno checks, the 100-table/800-query/202-override test, 42 Deno runtime tests, 11 Node tests, 11 Bun tests, the example's `sqlc diff`, and actionlint. SQLite tests execute real queries; server-driver adapter tests use test doubles. Live PostgreSQL/MySQL tests remain unverified. The [TypeScript CI job](https://github.com/sqlc-dev/sqlc/actions/runs/34213443840) passed on the updated PR commit.
