### PR TITLE
core: carry enums, views and missing placeholders through the analysis core

### DIFF
--- a/internal/compiler/catalog_core.go
+++ b/internal/compiler/catalog_core.go
@@ -10,17 +10,19 @@ import (
 
 // coreResultCatalog dumps the core catalog into the legacy catalog shape a
 // Result carries, so codegen sees the same table models either way a query
-// set was analyzed. Only relations make the trip: codegen reads tables and
-// their columns to build models, and none of the types, functions or
-// operators the core catalog also holds.
+// set was analyzed. Relations and enums make the trip: codegen reads tables
+// and their columns to build models and enums to build their Go types, and
+// none of the functions or operators the core catalog also holds.
 func coreResultCatalog(c *core.Catalog) (*catalog.Catalog, error) {
 	cat := catalog.New("public")
 	namespaces, err := c.Namespaces()
 	if err != nil {
 		return nil, err
 	}
+	schemas := map[string]*catalog.Schema{}
 	for _, ns := range namespaces {
 		schema := &catalog.Schema{Name: ns.Name}
+		schemas[ns.Name] = schema
 		tables, err := c.TablesInNamespace(ns.OID)
 		if err != nil {
 			return nil, err
@@ -51,6 +53,30 @@ func coreResultCatalog(c *core.Catalog) (*catalog.Catalog, error) {
 			schema.Tables = append(schema.Tables, t)
 		}
 		cat.Schemas = append(cat.Schemas, schema)
+	}
+
+	// The catalog spells an enum's schema in its name, and a schema that
+	// holds only types has no namespace of its own, so one is made here.
+	enums, err := c.Enums()
+	if err != nil {
+		return nil, err
+	}
+	for _, enum := range enums {
+		labels, err := c.EnumLabels(enum.OID)
+		if err != nil {
+			return nil, err
+		}
+		schemaName, name := core.SplitTypeName(enum.Name)
+		if schemaName == "" {
+			schemaName = cat.DefaultSchema
+		}
+		schema, ok := schemas[schemaName]
+		if !ok {
+			schema = &catalog.Schema{Name: schemaName}
+			schemas[schemaName] = schema
+			cat.Schemas = append(cat.Schemas, schema)
+		}
+		schema.Types = append(schema.Types, &catalog.Enum{Name: name, Vals: labels})
 	}
 	return cat, nil
 }

--- a/internal/compiler/catalog_core.go
+++ b/internal/compiler/catalog_core.go
@@ -11,8 +11,8 @@ import (
 // coreResultCatalog dumps the core catalog into the legacy catalog shape a
 // Result carries, so codegen sees the same table models either way a query
 // set was analyzed. Relations and enums make the trip: codegen reads tables
-// and their columns to build models and enums to build their Go types, and
-// none of the functions or operators the core catalog also holds.
+// and views with their columns to build models and enums to build their Go
+// types, and none of the functions or operators the core catalog also holds.
 func coreResultCatalog(c *core.Catalog) (*catalog.Catalog, error) {
 	cat := catalog.New("public")
 	namespaces, err := c.Namespaces()
@@ -23,7 +23,7 @@ func coreResultCatalog(c *core.Catalog) (*catalog.Catalog, error) {
 	for _, ns := range namespaces {
 		schema := &catalog.Schema{Name: ns.Name}
 		schemas[ns.Name] = schema
-		tables, err := c.TablesInNamespace(ns.OID)
+		tables, err := c.ModelClassesInNamespace(ns.OID)
 		if err != nil {
 			return nil, err
 		}

--- a/internal/compiler/parse_core.go
+++ b/internal/compiler/parse_core.go
@@ -54,7 +54,7 @@ func (c *Compiler) parseQueryCore(raw *ast.RawStmt, src string, pre *preprocess.
 	var cols []*Column
 	var params []Parameter
 	switch raw.Stmt.(type) {
-	case *ast.SelectStmt, *ast.InsertStmt, *ast.UpdateStmt, *ast.DeleteStmt:
+	case *ast.SelectStmt, *ast.InsertStmt, *ast.UpdateStmt, *ast.DeleteStmt, *ast.CallStmt:
 		res, err := coreanalyzer.Prepare(c.coreCatalog, raw)
 		if err != nil {
 			return nil, err

--- a/internal/core/analysis.go
+++ b/internal/core/analysis.go
@@ -7,6 +7,7 @@ const (
 	CommandInsert Command = "INSERT"
 	CommandUpdate Command = "UPDATE"
 	CommandDelete Command = "DELETE"
+	CommandCall   Command = "CALL"
 )
 
 type PrepareResult struct {

--- a/internal/core/analyzer/analyzer.go
+++ b/internal/core/analyzer/analyzer.go
@@ -37,6 +37,11 @@ func Prepare(cat *core.Catalog, stmt ast.Node) (core.PrepareResult, error) {
 			return core.PrepareResult{}, err
 		}
 		a.command = core.CommandDelete
+	case *ast.CallStmt:
+		if err := a.analyzeCall(s); err != nil {
+			return core.PrepareResult{}, err
+		}
+		a.command = core.CommandCall
 	default:
 		return core.PrepareResult{}, fmt.Errorf("analyzer: unsupported statement %T", stmt)
 	}
@@ -174,7 +179,7 @@ func (a *analyzer) analyzeSelect(s *ast.SelectStmt) error {
 		if err := a.analyzeSetOperation(s); err != nil {
 			return err
 		}
-		return nil
+		return a.typeLimits(s)
 	}
 
 	sc, err := a.buildScope(s.FromClause)
@@ -234,6 +239,11 @@ func (a *analyzer) analyzeSelect(s *ast.SelectStmt) error {
 			}
 		}
 	}
+	return a.typeLimits(s)
+}
+
+// typeLimits types a SELECT's LIMIT and OFFSET.
+func (a *analyzer) typeLimits(s *ast.SelectStmt) error {
 	for _, n := range []ast.Node{s.LimitCount, s.LimitOffset} {
 		if err := a.typeLimit(n); err != nil {
 			return fmt.Errorf("limit: %w", err)

--- a/internal/core/analyzer/dml.go
+++ b/internal/core/analyzer/dml.go
@@ -24,7 +24,93 @@ func (a *analyzer) analyzeInsert(s *ast.InsertStmt) error {
 	if err := a.bindInsertValues(s.SelectStmt, rel, targets); err != nil {
 		return err
 	}
+	if s.OnDuplicateKeyUpdate != nil {
+		if err := a.bindAssignments(rel, s.OnDuplicateKeyUpdate.TargetList); err != nil {
+			return fmt.Errorf("on duplicate key update: %w", err)
+		}
+	}
 	return a.projectReturning(s.ReturningList)
+}
+
+// bindAssignments types the values a SET-style list assigns to the
+// relation's columns.
+func (a *analyzer) bindAssignments(rel scopeRel, targets *ast.List) error {
+	for _, item := range listItems(targets) {
+		rt, ok := item.(*ast.ResTarget)
+		if !ok || rt.Name == nil {
+			continue
+		}
+		col, ok := findColumn(rel, *rt.Name)
+		if !ok {
+			return fmt.Errorf("unknown column %q", *rt.Name)
+		}
+		if err := a.bindValue(rel, &col, rt.Val); err != nil {
+			return fmt.Errorf("set %s: %w", *rt.Name, err)
+		}
+	}
+	return nil
+}
+
+// analyzeCall types the arguments of a CALL from the procedure's declared
+// parameters: a placeholder takes the parameter's type and name, whether
+// it is passed by position or by name.
+func (a *analyzer) analyzeCall(s *ast.CallStmt) error {
+	if s.FuncCall == nil {
+		return fmt.Errorf("call: missing procedure")
+	}
+	name := funcCallName(s.FuncCall)
+	overloads, err := a.cat.FindProcs(name, nil)
+	if err != nil {
+		return err
+	}
+	args := listItems(s.FuncCall.Args)
+	var procs []core.ProcOverload
+	for _, p := range overloads {
+		if p.Kind == "p" {
+			procs = append(procs, p)
+		}
+	}
+	if len(procs) == 0 {
+		return fmt.Errorf("unknown procedure %q", name)
+	}
+	proc := procs[0]
+	for _, p := range procs {
+		if len(p.ArgTypes) == len(args) {
+			proc = p
+			break
+		}
+	}
+	params, err := a.cat.ProcArgs(proc.OID)
+	if err != nil {
+		return err
+	}
+	for i, arg := range args {
+		var param *core.ProcArg
+		value := arg
+		if named, ok := arg.(*ast.NamedArgExpr); ok {
+			value = named.Arg
+			if named.Name != nil {
+				for j := range params {
+					if params[j].Name == *named.Name {
+						param = &params[j]
+						break
+					}
+				}
+			}
+		} else if i < len(params) {
+			param = &params[i]
+		}
+		pr, ok := value.(*ast.ParamRef)
+		if !ok || param == nil {
+			if _, err := a.typeExpr(value); err != nil {
+				return err
+			}
+			continue
+		}
+		a.inferParam(pr.Number, exprType{typeOID: param.TypeOID})
+		a.nameParam(pr.Number, param.Name)
+	}
+	return nil
 }
 
 func (a *analyzer) analyzeUpdate(s *ast.UpdateStmt) error {
@@ -57,6 +143,9 @@ func (a *analyzer) analyzeUpdate(s *ast.UpdateStmt) error {
 			return fmt.Errorf("where: %w", err)
 		}
 	}
+	if err := a.typeLimit(s.LimitCount); err != nil {
+		return fmt.Errorf("limit: %w", err)
+	}
 	return a.projectReturning(s.ReturningList)
 }
 
@@ -74,6 +163,9 @@ func (a *analyzer) analyzeDelete(s *ast.DeleteStmt) error {
 		if _, err := a.typeExpr(s.WhereClause); err != nil {
 			return fmt.Errorf("where: %w", err)
 		}
+	}
+	if err := a.typeLimit(s.LimitCount); err != nil {
+		return fmt.Errorf("limit: %w", err)
 	}
 	return a.projectReturning(s.ReturningList)
 }
@@ -140,10 +232,22 @@ func (a *analyzer) bindInsertValues(n ast.Node, rel scopeRel, targets []core.Cla
 		return fmt.Errorf("insert: unsupported source %T", n)
 	}
 	// INSERT ... SELECT inserts whatever the query returns. The rows are not
-	// the statement's result, but the query still holds placeholders.
-	if sel.ValuesLists == nil {
-		_, err := a.subqueryColumns(sel)
-		return err
+	// the statement's result, but the query still holds placeholders, and a
+	// placeholder selected directly stands in for the column it lands in.
+	if len(listItems(sel.ValuesLists)) == 0 {
+		if _, err := a.subqueryColumns(sel); err != nil {
+			return err
+		}
+		for i, item := range listItems(sel.TargetList) {
+			rt, ok := item.(*ast.ResTarget)
+			if !ok || i >= len(targets) {
+				continue
+			}
+			if pr, ok := rt.Val.(*ast.ParamRef); ok {
+				a.inferParam(pr.Number, columnType(rel, targets[i]))
+			}
+		}
+		return nil
 	}
 	for _, row := range listItems(sel.ValuesLists) {
 		values, ok := row.(*ast.List)

--- a/internal/core/analyzer/expr.go
+++ b/internal/core/analyzer/expr.go
@@ -78,7 +78,7 @@ func (a *analyzer) typeExpr(n ast.Node) (exprType, error) {
 		return a.typeSubLink(e)
 
 	case *ast.CollateExpr:
-		return a.typeExpr(e.Arg)
+		return a.typeExpr(collated(e))
 
 	case *ast.IntervalExpr:
 		// A dialect with no interval type of its own leaves it untyped.
@@ -231,6 +231,18 @@ func (a *analyzer) inferParam(number int, t exprType) {
 	a.params[number] = cur
 }
 
+// nameParam gives a placeholder a name when nothing has named it yet.
+func (a *analyzer) nameParam(number int, name string) {
+	if name == "" {
+		return
+	}
+	cur := a.params[number]
+	if cur.Name == "" && cur.Source == nil {
+		cur.Name = name
+		a.params[number] = cur
+	}
+}
+
 // nameParamAfter names a placeholder compared with a function call after
 // the function, the way a placeholder compared with a column is named after
 // the column.
@@ -296,12 +308,12 @@ func (a *analyzer) typeAExpr(e *ast.A_Expr) (exprType, error) {
 		return exprType{}, err
 	}
 
-	if pr, ok := e.Lexpr.(*ast.ParamRef); ok && rightT.typeOID != 0 {
+	if pr, ok := bareParam(e.Lexpr); ok && rightT.typeOID != 0 {
 		a.inferParam(pr.Number, rightT)
 		a.nameParamAfter(pr.Number, e.Rexpr)
 		leftT = rightT
 	}
-	if pr, ok := e.Rexpr.(*ast.ParamRef); ok && leftT.typeOID != 0 {
+	if pr, ok := bareParam(e.Rexpr); ok && leftT.typeOID != 0 {
 		a.inferParam(pr.Number, leftT)
 		a.nameParamAfter(pr.Number, e.Lexpr)
 		rightT = leftT
@@ -351,10 +363,8 @@ func (a *analyzer) typePredicateList(e *ast.A_Expr) (exprType, error) {
 		return exprType{}, err
 	}
 	if l, ok := e.Rexpr.(*ast.List); ok {
-		for _, item := range listItems(l) {
-			if err := a.typeOperands(item, leftT); err != nil {
-				return exprType{}, err
-			}
+		if err := a.typeMembers(e.Lexpr, leftT, listItems(l)); err != nil {
+			return exprType{}, err
 		}
 		return a.boolType(false)
 	}
@@ -364,6 +374,33 @@ func (a *analyzer) typePredicateList(e *ast.A_Expr) (exprType, error) {
 	return a.boolType(false)
 }
 
+// typeMembers types the members of an IN list against the expression on
+// the left. When that expression is a bare placeholder, the members type
+// it instead, the way the other operand of a comparison would.
+func (a *analyzer) typeMembers(left ast.Node, leftT exprType, members []ast.Node) error {
+	for _, item := range members {
+		if err := a.typeOperands(item, leftT); err != nil {
+			return err
+		}
+	}
+	pr, ok := bareParam(left)
+	if !ok || leftT.typeOID != 0 {
+		return nil
+	}
+	for _, item := range members {
+		t, err := a.typeExpr(item)
+		if err != nil {
+			return err
+		}
+		if t.typeOID != 0 {
+			a.inferParam(pr.Number, t)
+			a.nameParamAfter(pr.Number, item)
+			return nil
+		}
+	}
+	return nil
+}
+
 // typeIn types the IN node the engines that have one report, where the values
 // compared against are held apart from the expression.
 func (a *analyzer) typeIn(e *ast.In) (exprType, error) {
@@ -371,14 +408,17 @@ func (a *analyzer) typeIn(e *ast.In) (exprType, error) {
 	if err != nil {
 		return exprType{}, err
 	}
-	for _, item := range e.List {
-		if err := a.typeOperands(item, leftT); err != nil {
-			return exprType{}, err
-		}
+	if err := a.typeMembers(e.Expr, leftT, e.List); err != nil {
+		return exprType{}, err
 	}
 	// "x IN (SELECT ...)" compares x against the subquery's column, and the
-	// subquery's own placeholders are reported with the rest.
-	if sel, ok := e.Sel.(*ast.SelectStmt); ok {
+	// subquery's own placeholders are reported with the rest. An engine may
+	// report the subquery wrapped in a sublink.
+	subselect := e.Sel
+	if sl, ok := subselect.(*ast.SubLink); ok {
+		subselect = sl.Subselect
+	}
+	if sel, ok := subselect.(*ast.SelectStmt); ok {
 		cols, err := a.subqueryColumns(sel)
 		if err != nil {
 			return exprType{}, err
@@ -582,10 +622,30 @@ func (a *analyzer) typeNullIf(e *ast.A_Expr) (exprType, error) {
 	return leftT, nil
 }
 
+// collated is the expression a COLLATE clause applies to. Engines disagree
+// on which field holds it: PostgreSQL puts the expression in Arg, SQLite
+// puts it in Xpr and the collation's name in Arg.
+func collated(e *ast.CollateExpr) ast.Node {
+	if _, isName := e.Arg.(*ast.String); e.Arg == nil || isName {
+		return e.Xpr
+	}
+	return e.Arg
+}
+
+// bareParam reports whether n is a placeholder, looking through a COLLATE
+// clause, which changes how a value compares and not what it is.
+func bareParam(n ast.Node) (*ast.ParamRef, bool) {
+	if c, ok := n.(*ast.CollateExpr); ok {
+		n = collated(c)
+	}
+	pr, ok := n.(*ast.ParamRef)
+	return pr, ok
+}
+
 // typeOperands types a node standing opposite one of known type, giving a bare
 // placeholder that type.
 func (a *analyzer) typeOperands(n ast.Node, other exprType) error {
-	if pr, ok := n.(*ast.ParamRef); ok {
+	if pr, ok := bareParam(n); ok {
 		if other.typeOID != 0 || other.typeName != "" {
 			a.inferParam(pr.Number, other)
 		}

--- a/internal/core/catalogdb/models.go
+++ b/internal/core/catalogdb/models.go
@@ -59,6 +59,12 @@ type SqlDialectFlag struct {
 	Value      string
 }
 
+type SqlEnumLabel struct {
+	TypeOid int64
+	Ord     int64
+	Label   string
+}
+
 type SqlNamespace struct {
 	Oid  int64
 	Name string

--- a/internal/core/catalogdb/query.sql.go
+++ b/internal/core/catalogdb/query.sql.go
@@ -210,6 +210,21 @@ func (q *Queries) CreateDialect(ctx context.Context, name string) (int64, error)
 	return result.LastInsertId()
 }
 
+const createEnumLabel = `-- name: CreateEnumLabel :exec
+INSERT INTO sql_enum_label (type_oid, ord, label) VALUES (?, ?, ?)
+`
+
+type CreateEnumLabelParams struct {
+	TypeOid int64
+	Ord     int64
+	Label   string
+}
+
+func (q *Queries) CreateEnumLabel(ctx context.Context, arg CreateEnumLabelParams) error {
+	_, err := q.db.ExecContext(ctx, createEnumLabel, arg.TypeOid, arg.Ord, arg.Label)
+	return err
+}
+
 const createNamespace = `-- name: CreateNamespace :execlastid
 
 
@@ -392,6 +407,24 @@ DELETE FROM sql_class WHERE oid = ?
 
 func (q *Queries) DeleteClass(ctx context.Context, oid int64) error {
 	_, err := q.db.ExecContext(ctx, deleteClass, oid)
+	return err
+}
+
+const deleteEnumLabels = `-- name: DeleteEnumLabels :exec
+DELETE FROM sql_enum_label WHERE type_oid = ?
+`
+
+func (q *Queries) DeleteEnumLabels(ctx context.Context, typeOid int64) error {
+	_, err := q.db.ExecContext(ctx, deleteEnumLabels, typeOid)
+	return err
+}
+
+const deleteType = `-- name: DeleteType :exec
+DELETE FROM sql_type WHERE oid = ?
+`
+
+func (q *Queries) DeleteType(ctx context.Context, oid int64) error {
+	_, err := q.db.ExecContext(ctx, deleteType, oid)
 	return err
 }
 
@@ -639,6 +672,67 @@ func (q *Queries) ListClassColumns(ctx context.Context, classOid int64) ([]ListC
 	return items, nil
 }
 
+const listEnumLabels = `-- name: ListEnumLabels :many
+SELECT label FROM sql_enum_label WHERE type_oid = ? ORDER BY ord
+`
+
+func (q *Queries) ListEnumLabels(ctx context.Context, typeOid int64) ([]string, error) {
+	rows, err := q.db.QueryContext(ctx, listEnumLabels, typeOid)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []string
+	for rows.Next() {
+		var label string
+		if err := rows.Scan(&label); err != nil {
+			return nil, err
+		}
+		items = append(items, label)
+	}
+	if err := rows.Close(); err != nil {
+		return nil, err
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
+const listEnumTypes = `-- name: ListEnumTypes :many
+SELECT oid, name FROM sql_type
+WHERE typtype = 'e'
+ORDER BY oid
+`
+
+type ListEnumTypesRow struct {
+	Oid  int64
+	Name string
+}
+
+func (q *Queries) ListEnumTypes(ctx context.Context) ([]ListEnumTypesRow, error) {
+	rows, err := q.db.QueryContext(ctx, listEnumTypes)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []ListEnumTypesRow
+	for rows.Next() {
+		var i ListEnumTypesRow
+		if err := rows.Scan(&i.Oid, &i.Name); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Close(); err != nil {
+		return nil, err
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
 const listNamespaces = `-- name: ListNamespaces :many
 SELECT oid, name FROM sql_namespace ORDER BY oid
 `
@@ -848,6 +942,20 @@ type RenameClassParams struct {
 
 func (q *Queries) RenameClass(ctx context.Context, arg RenameClassParams) error {
 	_, err := q.db.ExecContext(ctx, renameClass, arg.NewName, arg.Oid)
+	return err
+}
+
+const renameType = `-- name: RenameType :exec
+UPDATE sql_type SET name = ?1 WHERE oid = ?2
+`
+
+type RenameTypeParams struct {
+	Name string
+	Oid  int64
+}
+
+func (q *Queries) RenameType(ctx context.Context, arg RenameTypeParams) error {
+	_, err := q.db.ExecContext(ctx, renameType, arg.Name, arg.Oid)
 	return err
 }
 

--- a/internal/core/catalogdb/query.sql.go
+++ b/internal/core/catalogdb/query.sql.go
@@ -733,19 +733,26 @@ func (q *Queries) ListEnumTypes(ctx context.Context) ([]ListEnumTypesRow, error)
 	return items, nil
 }
 
-const listNamespaces = `-- name: ListNamespaces :many
-SELECT oid, name FROM sql_namespace ORDER BY oid
+const listModelClassesInNamespace = `-- name: ListModelClassesInNamespace :many
+SELECT oid, name FROM sql_class
+WHERE namespace_oid = ? AND kind IN ('r', 'v')
+ORDER BY oid
 `
 
-func (q *Queries) ListNamespaces(ctx context.Context) ([]SqlNamespace, error) {
-	rows, err := q.db.QueryContext(ctx, listNamespaces)
+type ListModelClassesInNamespaceRow struct {
+	Oid  int64
+	Name string
+}
+
+func (q *Queries) ListModelClassesInNamespace(ctx context.Context, namespaceOid int64) ([]ListModelClassesInNamespaceRow, error) {
+	rows, err := q.db.QueryContext(ctx, listModelClassesInNamespace, namespaceOid)
 	if err != nil {
 		return nil, err
 	}
 	defer rows.Close()
-	var items []SqlNamespace
+	var items []ListModelClassesInNamespaceRow
 	for rows.Next() {
-		var i SqlNamespace
+		var i ListModelClassesInNamespaceRow
 		if err := rows.Scan(&i.Oid, &i.Name); err != nil {
 			return nil, err
 		}
@@ -760,26 +767,19 @@ func (q *Queries) ListNamespaces(ctx context.Context) ([]SqlNamespace, error) {
 	return items, nil
 }
 
-const listTablesInNamespace = `-- name: ListTablesInNamespace :many
-SELECT oid, name FROM sql_class
-WHERE namespace_oid = ? AND kind = 'r'
-ORDER BY oid
+const listNamespaces = `-- name: ListNamespaces :many
+SELECT oid, name FROM sql_namespace ORDER BY oid
 `
 
-type ListTablesInNamespaceRow struct {
-	Oid  int64
-	Name string
-}
-
-func (q *Queries) ListTablesInNamespace(ctx context.Context, namespaceOid int64) ([]ListTablesInNamespaceRow, error) {
-	rows, err := q.db.QueryContext(ctx, listTablesInNamespace, namespaceOid)
+func (q *Queries) ListNamespaces(ctx context.Context) ([]SqlNamespace, error) {
+	rows, err := q.db.QueryContext(ctx, listNamespaces)
 	if err != nil {
 		return nil, err
 	}
 	defer rows.Close()
-	var items []ListTablesInNamespaceRow
+	var items []SqlNamespace
 	for rows.Next() {
-		var i ListTablesInNamespaceRow
+		var i SqlNamespace
 		if err := rows.Scan(&i.Oid, &i.Name); err != nil {
 			return nil, err
 		}

--- a/internal/core/catalogdb/query.sql.go
+++ b/internal/core/catalogdb/query.sql.go
@@ -915,6 +915,47 @@ func (q *Queries) ProcArgTypes(ctx context.Context, procOid int64) ([]int64, err
 	return items, nil
 }
 
+const procArgs = `-- name: ProcArgs :many
+SELECT name, type_oid, mode, has_default FROM sql_proc_arg
+WHERE proc_oid = ?
+ORDER BY ord
+`
+
+type ProcArgsRow struct {
+	Name       string
+	TypeOid    int64
+	Mode       string
+	HasDefault int64
+}
+
+func (q *Queries) ProcArgs(ctx context.Context, procOid int64) ([]ProcArgsRow, error) {
+	rows, err := q.db.QueryContext(ctx, procArgs, procOid)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []ProcArgsRow
+	for rows.Next() {
+		var i ProcArgsRow
+		if err := rows.Scan(
+			&i.Name,
+			&i.TypeOid,
+			&i.Mode,
+			&i.HasDefault,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Close(); err != nil {
+		return nil, err
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
 const renameAttribute = `-- name: RenameAttribute :exec
 UPDATE sql_attribute SET name = ?1
 WHERE class_oid = ?2 AND name = ?3

--- a/internal/core/catalogdef/query.sql
+++ b/internal/core/catalogdef/query.sql
@@ -67,6 +67,26 @@ SELECT oid, name, category, typtype, preferred
 FROM sql_type
 WHERE oid = ?;
 
+-- name: ListEnumTypes :many
+SELECT oid, name FROM sql_type
+WHERE typtype = 'e'
+ORDER BY oid;
+
+-- name: RenameType :exec
+UPDATE sql_type SET name = sqlc.arg(name) WHERE oid = sqlc.arg(oid);
+
+-- name: DeleteType :exec
+DELETE FROM sql_type WHERE oid = ?;
+
+-- name: CreateEnumLabel :exec
+INSERT INTO sql_enum_label (type_oid, ord, label) VALUES (?, ?, ?);
+
+-- name: ListEnumLabels :many
+SELECT label FROM sql_enum_label WHERE type_oid = ? ORDER BY ord;
+
+-- name: DeleteEnumLabels :exec
+DELETE FROM sql_enum_label WHERE type_oid = ?;
+
 -- =============================== sql_class =============================
 
 -- name: CreateClass :execlastid

--- a/internal/core/catalogdef/query.sql
+++ b/internal/core/catalogdef/query.sql
@@ -201,6 +201,11 @@ INSERT INTO sql_proc
      return_type_oid, return_set, return_nullable, strict, variadic_kind)
 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?);
 
+-- name: ProcArgs :many
+SELECT name, type_oid, mode, has_default FROM sql_proc_arg
+WHERE proc_oid = ?
+ORDER BY ord;
+
 -- name: CreateProcArg :exec
 INSERT INTO sql_proc_arg (proc_oid, ord, name, type_oid, mode, has_default)
 VALUES (?, ?, ?, ?, ?, ?);

--- a/internal/core/catalogdef/query.sql
+++ b/internal/core/catalogdef/query.sql
@@ -98,9 +98,9 @@ SELECT oid FROM sql_class WHERE namespace_oid = ? AND name = ?;
 -- name: ClassOIDByName :one
 SELECT oid FROM sql_class WHERE name = ? LIMIT 1;
 
--- name: ListTablesInNamespace :many
+-- name: ListModelClassesInNamespace :many
 SELECT oid, name FROM sql_class
-WHERE namespace_oid = ? AND kind = 'r'
+WHERE namespace_oid = ? AND kind IN ('r', 'v')
 ORDER BY oid;
 
 -- name: DeleteClass :exec

--- a/internal/core/catalogdef/schema.sql
+++ b/internal/core/catalogdef/schema.sql
@@ -41,6 +41,16 @@ CREATE TABLE sql_type (
 );
 CREATE INDEX idx_sql_type_name ON sql_type(name);
 
+-- sql_enum_label: the labels of an enum type, in declaration order.
+--   Modeled on pg_enum. A MySQL ENUM or SET column declares one of these
+--   for the column alone, under the name the legacy catalog gives it.
+CREATE TABLE sql_enum_label (
+    type_oid INTEGER NOT NULL REFERENCES sql_type(oid),
+    ord      INTEGER NOT NULL,
+    label    TEXT NOT NULL,
+    PRIMARY KEY (type_oid, ord)
+);
+
 -- sql_class: relations (tables, views, indexes).
 --   kind: 'r' = table, 'v' = view, 'i' = index, 'c' = composite type, 'f' = foreign
 CREATE TABLE sql_class (

--- a/internal/core/class.go
+++ b/internal/core/class.go
@@ -65,10 +65,13 @@ type ClassInfo struct {
 	Name string
 }
 
-func (c *Catalog) TablesInNamespace(namespaceOID int64) ([]ClassInfo, error) {
-	rows, err := c.q.ListTablesInNamespace(context.Background(), namespaceOID)
+// ModelClassesInNamespace lists the relations codegen builds a model for, in
+// declaration order: the tables, and the views and tables created from a
+// query, whose rows a query selects the same way.
+func (c *Catalog) ModelClassesInNamespace(namespaceOID int64) ([]ClassInfo, error) {
+	rows, err := c.q.ListModelClassesInNamespace(context.Background(), namespaceOID)
 	if err != nil {
-		return nil, fmt.Errorf("list tables in namespace %d: %w", namespaceOID, err)
+		return nil, fmt.Errorf("list model classes in namespace %d: %w", namespaceOID, err)
 	}
 	out := make([]ClassInfo, 0, len(rows))
 	for _, r := range rows {

--- a/internal/core/enum.go
+++ b/internal/core/enum.go
@@ -1,0 +1,105 @@
+package core
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/sqlc-dev/sqlc/internal/core/catalogdb"
+)
+
+// EnumInfo describes an enum type the schema declared.
+type EnumInfo struct {
+	OID int64
+	// Name is the name the catalog stores, which carries the schema when the
+	// type was declared with one ("foo.mood").
+	Name string
+}
+
+// CreateEnumType registers an enum type with its labels in declaration order.
+func (c *Catalog) CreateEnumType(name string, labels []string) (int64, error) {
+	oid, err := c.CreateUserType(name, "E")
+	if err != nil {
+		return 0, err
+	}
+	if err := c.SetEnumLabels(oid, labels); err != nil {
+		return 0, err
+	}
+	return oid, nil
+}
+
+// EnumLabels returns an enum type's labels in declaration order.
+func (c *Catalog) EnumLabels(oid int64) ([]string, error) {
+	labels, err := c.q.ListEnumLabels(context.Background(), oid)
+	if err != nil {
+		return nil, fmt.Errorf("enum labels of type oid %d: %w", oid, err)
+	}
+	return labels, nil
+}
+
+// SetEnumLabels replaces an enum type's labels.
+func (c *Catalog) SetEnumLabels(oid int64, labels []string) error {
+	ctx := context.Background()
+	if err := c.q.DeleteEnumLabels(ctx, oid); err != nil {
+		return fmt.Errorf("enum labels of type oid %d: %w", oid, err)
+	}
+	for i, label := range labels {
+		if err := c.q.CreateEnumLabel(ctx, catalogdb.CreateEnumLabelParams{TypeOid: oid, Ord: int64(i + 1), Label: label}); err != nil {
+			return fmt.Errorf("enum label %q of type oid %d: %w", label, oid, err)
+		}
+	}
+	return nil
+}
+
+// Enums lists the enum types the schema declared, in declaration order.
+func (c *Catalog) Enums() ([]EnumInfo, error) {
+	rows, err := c.q.ListEnumTypes(context.Background())
+	if err != nil {
+		return nil, fmt.Errorf("list enum types: %w", err)
+	}
+	out := make([]EnumInfo, 0, len(rows))
+	for _, r := range rows {
+		out = append(out, EnumInfo{OID: r.Oid, Name: r.Name})
+	}
+	return out, nil
+}
+
+// RenameType gives a type a new name. Columns refer to the type by OID, so
+// they follow the rename.
+func (c *Catalog) RenameType(oid int64, name string) error {
+	if err := c.q.RenameType(context.Background(), catalogdb.RenameTypeParams{Oid: oid, Name: strings.ToLower(name)}); err != nil {
+		return fmt.Errorf("rename type oid %d to %q: %w", oid, name, err)
+	}
+	return nil
+}
+
+// DropType removes a type and, when it is an enum, its labels.
+func (c *Catalog) DropType(oid int64) error {
+	ctx := context.Background()
+	if err := c.q.DeleteEnumLabels(ctx, oid); err != nil {
+		return fmt.Errorf("drop type oid %d: %w", oid, err)
+	}
+	if err := c.q.DeleteType(ctx, oid); err != nil {
+		return fmt.Errorf("drop type oid %d: %w", oid, err)
+	}
+	return nil
+}
+
+// SplitTypeName separates the schema a type name carries from the name
+// itself: "foo.mood" is the type mood in schema foo, and a bare name is in
+// the default schema.
+func SplitTypeName(name string) (schema, typ string) {
+	if i := strings.LastIndex(name, "."); i >= 0 {
+		return name[:i], name[i+1:]
+	}
+	return "", name
+}
+
+// JoinTypeName is the inverse of SplitTypeName: the name the catalog stores
+// for a type in a schema. The default schema is not spelled.
+func JoinTypeName(schema, typ string) string {
+	if schema == "" || schema == "public" {
+		return typ
+	}
+	return schema + "." + typ
+}

--- a/internal/core/proc.go
+++ b/internal/core/proc.go
@@ -163,3 +163,30 @@ func (c *Catalog) FindProcs(name string, namespaceOIDs []int64) ([]ProcOverload,
 func (c *Catalog) procArgTypes(procOID int64) ([]int64, error) {
 	return c.q.ProcArgTypes(context.Background(), procOID)
 }
+
+// ProcArgs returns a proc's declared arguments in order, names included.
+func (c *Catalog) ProcArgs(procOID int64) ([]ProcArg, error) {
+	rows, err := c.q.ProcArgs(context.Background(), procOID)
+	if err != nil {
+		return nil, fmt.Errorf("proc args %d: %w", procOID, err)
+	}
+	out := make([]ProcArg, 0, len(rows))
+	for _, r := range rows {
+		out = append(out, ProcArg{
+			Name:       r.Name,
+			TypeOID:    r.TypeOid,
+			Mode:       r.Mode,
+			HasDefault: r.HasDefault != 0,
+		})
+	}
+	return out, nil
+}
+
+// VoidTypeOID is the pseudo type a procedure returns, which is nothing. A
+// dialect's seed lists no such type, so the first procedure registers it.
+func (c *Catalog) VoidTypeOID() (int64, error) {
+	if oid, err := c.TypeOID("void"); err == nil {
+		return oid, nil
+	}
+	return c.CreateTypeSpec(TypeSpec{Name: "void", Typtype: "p", Category: "P", DialectOID: c.dialectOID})
+}

--- a/internal/core/schema/schema.go
+++ b/internal/core/schema/schema.go
@@ -2,6 +2,7 @@ package schema
 
 import (
 	"fmt"
+	"slices"
 	"strings"
 
 	"github.com/sqlc-dev/sqlc/internal/core"
@@ -28,6 +29,16 @@ func Apply(cat *core.Catalog, n ast.Node) error {
 		return applyDropTable(cat, v)
 	case *ast.CreateEnumStmt:
 		return applyCreateEnum(cat, v)
+	case *ast.AlterTypeAddValueStmt:
+		return applyAlterTypeAddValue(cat, v)
+	case *ast.AlterTypeRenameValueStmt:
+		return applyAlterTypeRenameValue(cat, v)
+	case *ast.AlterTypeSetSchemaStmt:
+		return applyAlterTypeSetSchema(cat, v)
+	case *ast.RenameTypeStmt:
+		return applyRenameType(cat, v)
+	case *ast.DropTypeStmt:
+		return applyDropType(cat, v)
 	case *ast.CreateExtensionStmt:
 		if v.Extname == nil {
 			return nil
@@ -158,7 +169,7 @@ func applyCreateTable(cat *core.Catalog, stmt *ast.CreateTableStmt) error {
 		if col == nil || col.TypeName == nil {
 			return fmt.Errorf("column %d on %q: missing type", i+1, stmt.Name.Name)
 		}
-		typeOID, err := columnTypeOID(cat, col)
+		typeOID, err := columnTypeOID(cat, stmt.Name, col)
 		if err != nil {
 			return fmt.Errorf("column %s.%s: %w", stmt.Name.Name, col.Colname, err)
 		}
@@ -197,6 +208,17 @@ func applyDropTable(cat *core.Catalog, stmt *ast.DropTableStmt) error {
 			}
 			return fmt.Errorf("drop table %q: %w", tn.Name, err)
 		}
+		cols, err := cat.ClassColumns(classOID)
+		if err != nil {
+			return fmt.Errorf("drop table %q: %w", tn.Name, err)
+		}
+		names := make([]string, 0, len(cols))
+		for _, col := range cols {
+			names = append(names, col.Name)
+		}
+		if err := dropLinkedEnums(cat, classOID, tn, names); err != nil {
+			return fmt.Errorf("drop table %q: %w", tn.Name, err)
+		}
 		if err := cat.DropClass(classOID); err != nil {
 			return fmt.Errorf("drop table %q: %w", tn.Name, err)
 		}
@@ -226,7 +248,7 @@ func applyAlterTable(cat *core.Catalog, stmt *ast.AlterTableStmt) error {
 			if cmd.Def == nil {
 				continue
 			}
-			typeOID, err := columnTypeOID(cat, cmd.Def)
+			typeOID, err := columnTypeOID(cat, table, cmd.Def)
 			if err != nil {
 				return err
 			}
@@ -249,6 +271,9 @@ func applyAlterTable(cat *core.Catalog, stmt *ast.AlterTableStmt) error {
 			if cmd.Name == nil {
 				continue
 			}
+			if err := dropLinkedEnums(cat, classOID, table, []string{*cmd.Name}); err != nil {
+				return err
+			}
 			if err := cat.DropAttribute(classOID, *cmd.Name); err != nil {
 				return err
 			}
@@ -260,7 +285,12 @@ func applyAlterTable(cat *core.Catalog, stmt *ast.AlterTableStmt) error {
 			if cmd.Name != nil && *cmd.Name != "" {
 				name = *cmd.Name
 			}
-			typeOID, err := columnTypeOID(cat, cmd.Def)
+			// The column's own enum, if it declares one, is named after
+			// the column, which an engine may report on the command
+			// rather than the definition.
+			def := *cmd.Def
+			def.Colname = name
+			typeOID, err := columnTypeOID(cat, table, &def)
 			if err != nil {
 				return err
 			}
@@ -305,6 +335,14 @@ func applyRenameColumn(cat *core.Catalog, stmt *ast.RenameColumnStmt) error {
 	if name == "" {
 		return nil
 	}
+	// An enum the column declared for itself is named after the column.
+	if oid, ok, err := linkedEnumOID(cat, classOID, stmt.Table, name); err != nil {
+		return err
+	} else if ok {
+		if err := cat.RenameType(oid, linkedEnumName(stmt.Table, *stmt.NewName)); err != nil {
+			return err
+		}
+	}
 	return cat.RenameAttribute(classOID, name, *stmt.NewName)
 }
 
@@ -318,6 +356,24 @@ func applyRenameTable(cat *core.Catalog, stmt *ast.RenameTableStmt) error {
 			return nil
 		}
 		return err
+	}
+	// The enums its columns declared for themselves are named after the
+	// table.
+	cols, err := cat.ClassColumns(classOID)
+	if err != nil {
+		return err
+	}
+	renamed := &ast.TableName{Schema: stmt.Table.Schema, Name: *stmt.NewName}
+	for _, col := range cols {
+		oid, ok, err := linkedEnumOID(cat, classOID, stmt.Table, col.Name)
+		if err != nil {
+			return err
+		}
+		if ok {
+			if err := cat.RenameType(oid, linkedEnumName(renamed, col.Name)); err != nil {
+				return err
+			}
+		}
 	}
 	return cat.RenameClass(classOID, *stmt.NewName)
 }
@@ -362,8 +418,151 @@ func applyCreateEnum(cat *core.Catalog, stmt *ast.CreateEnumStmt) error {
 	if _, err := cat.TypeOID(name); err == nil {
 		return nil
 	}
-	_, err := cat.CreateUserType(name, "E")
+	_, err := cat.CreateEnumType(name, stringSlice(stmt.Vals))
 	return err
+}
+
+func stringSlice(list *ast.List) []string {
+	items := []string{}
+	for _, item := range listItems(list) {
+		if n, ok := item.(*ast.String); ok {
+			items = append(items, n.Str)
+		}
+	}
+	return items
+}
+
+// enumOID finds the enum type a statement names.
+func enumOID(cat *core.Catalog, tn *ast.TypeName) (int64, string, error) {
+	name := core.TypeNameString(tn)
+	if name == "" {
+		return 0, "", fmt.Errorf("missing type name")
+	}
+	oid, err := cat.TypeOID(name)
+	if err != nil {
+		return 0, "", err
+	}
+	info, err := cat.LookupType(oid)
+	if err != nil {
+		return 0, "", err
+	}
+	if info.Typtype != "e" {
+		return 0, "", fmt.Errorf("type %q is not an enum", name)
+	}
+	return oid, name, nil
+}
+
+func applyAlterTypeAddValue(cat *core.Catalog, stmt *ast.AlterTypeAddValueStmt) error {
+	if stmt.NewValue == nil {
+		return fmt.Errorf("alter type add value: missing value")
+	}
+	oid, name, err := enumOID(cat, stmt.Type)
+	if err != nil {
+		return err
+	}
+	labels, err := cat.EnumLabels(oid)
+	if err != nil {
+		return err
+	}
+	if slices.Contains(labels, *stmt.NewValue) {
+		if stmt.SkipIfNewValExists {
+			return nil
+		}
+		return fmt.Errorf("enum %s already has value %s", name, *stmt.NewValue)
+	}
+	at := len(labels)
+	if stmt.NewValHasNeighbor {
+		if stmt.NewValNeighbor == nil {
+			return fmt.Errorf("alter type add value: missing neighbor")
+		}
+		i := slices.Index(labels, *stmt.NewValNeighbor)
+		if i < 0 {
+			return fmt.Errorf("enum %s unable to find existing neighbor value %s for new value %s", name, *stmt.NewValNeighbor, *stmt.NewValue)
+		}
+		at = i
+		if stmt.NewValIsAfter {
+			at = i + 1
+		}
+	}
+	labels = slices.Insert(labels, at, *stmt.NewValue)
+	return cat.SetEnumLabels(oid, labels)
+}
+
+func applyAlterTypeRenameValue(cat *core.Catalog, stmt *ast.AlterTypeRenameValueStmt) error {
+	if stmt.OldValue == nil || stmt.NewValue == nil {
+		return fmt.Errorf("alter type rename value: missing value")
+	}
+	oid, name, err := enumOID(cat, stmt.Type)
+	if err != nil {
+		return err
+	}
+	labels, err := cat.EnumLabels(oid)
+	if err != nil {
+		return err
+	}
+	i := slices.Index(labels, *stmt.OldValue)
+	if i < 0 {
+		return fmt.Errorf("enum %s does not have value %s", name, *stmt.OldValue)
+	}
+	if slices.Contains(labels, *stmt.NewValue) {
+		return fmt.Errorf("enum %s already has value %s", name, *stmt.NewValue)
+	}
+	labels[i] = *stmt.NewValue
+	return cat.SetEnumLabels(oid, labels)
+}
+
+// applyAlterTypeSetSchema moves a type to another schema. The catalog spells
+// the schema in the type's name, so the move is a rename.
+func applyAlterTypeSetSchema(cat *core.Catalog, stmt *ast.AlterTypeSetSchemaStmt) error {
+	if stmt.NewSchema == nil {
+		return fmt.Errorf("alter type set schema: missing schema")
+	}
+	name := core.TypeNameString(stmt.Type)
+	if name == "" {
+		return fmt.Errorf("missing type name")
+	}
+	oid, err := cat.TypeOID(name)
+	if err != nil {
+		return err
+	}
+	_, typ := core.SplitTypeName(name)
+	return cat.RenameType(oid, core.JoinTypeName(*stmt.NewSchema, typ))
+}
+
+func applyRenameType(cat *core.Catalog, stmt *ast.RenameTypeStmt) error {
+	if stmt.NewName == nil {
+		return fmt.Errorf("rename type: empty name")
+	}
+	name := core.TypeNameString(stmt.Type)
+	if name == "" {
+		return fmt.Errorf("missing type name")
+	}
+	oid, err := cat.TypeOID(name)
+	if err != nil {
+		return err
+	}
+	schema, _ := core.SplitTypeName(name)
+	return cat.RenameType(oid, core.JoinTypeName(schema, *stmt.NewName))
+}
+
+func applyDropType(cat *core.Catalog, stmt *ast.DropTypeStmt) error {
+	for _, tn := range stmt.Types {
+		name := core.TypeNameString(tn)
+		if name == "" {
+			return fmt.Errorf("missing type name")
+		}
+		oid, err := cat.TypeOID(name)
+		if err != nil {
+			if stmt.IfExists {
+				continue
+			}
+			return err
+		}
+		if err := cat.DropType(oid); err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 func applyCreateFunction(cat *core.Catalog, stmt *ast.CreateFunctionStmt) error {
@@ -422,9 +621,66 @@ func resolveOrCreateNamespace(cat *core.Catalog, schema string) (int64, error) {
 	return cat.CreateNamespace(name)
 }
 
+// linkedEnumName is the name of the enum type a column declares for itself.
+func linkedEnumName(table *ast.TableName, column string) string {
+	return core.JoinTypeName(table.Schema, fmt.Sprintf("%s_%s", table.Name, column))
+}
+
+// linkedEnumOID finds the enum type a column declared for itself, if the
+// column has one: an enum named after the table and the column.
+func linkedEnumOID(cat *core.Catalog, classOID int64, table *ast.TableName, column string) (int64, bool, error) {
+	cols, err := cat.ClassColumns(classOID)
+	if err != nil {
+		return 0, false, err
+	}
+	for _, col := range cols {
+		if col.Name != column {
+			continue
+		}
+		info, err := cat.LookupType(col.TypeOID)
+		if err != nil {
+			return 0, false, err
+		}
+		if info.Typtype == "e" && info.Name == linkedEnumName(table, column) {
+			return col.TypeOID, true, nil
+		}
+		return 0, false, nil
+	}
+	return 0, false, nil
+}
+
+// dropLinkedEnums drops the enum types the given columns declared for
+// themselves, which go with the columns.
+func dropLinkedEnums(cat *core.Catalog, classOID int64, table *ast.TableName, columns []string) error {
+	for _, column := range columns {
+		oid, ok, err := linkedEnumOID(cat, classOID, table, column)
+		if err != nil {
+			return err
+		}
+		if ok {
+			if err := cat.DropType(oid); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
 // columnTypeOID resolves a column's type. Engines report an array column
 // either on the type name or on the column itself.
-func columnTypeOID(cat *core.Catalog, col *ast.ColumnDef) (int64, error) {
+//
+// A column that declares its own values, the way a MySQL ENUM or SET column
+// does, is an enum type of its own. The type is named after the table and
+// the column, which is the name codegen has always given it.
+func columnTypeOID(cat *core.Catalog, table *ast.TableName, col *ast.ColumnDef) (int64, error) {
+	if col.Vals != nil && len(col.Vals.Items) > 0 && table != nil {
+		name := linkedEnumName(table, col.Colname)
+		if oid, err := cat.TypeOID(name); err == nil {
+			// The column was redefined with new values.
+			return oid, cat.SetEnumLabels(oid, stringSlice(col.Vals))
+		}
+		return cat.CreateEnumType(name, stringSlice(col.Vals))
+	}
 	name := core.TypeNameString(col.TypeName)
 	if name == "" {
 		return 0, fmt.Errorf("missing type name")

--- a/internal/core/schema/schema.go
+++ b/internal/core/schema/schema.go
@@ -566,12 +566,23 @@ func applyDropType(cat *core.Catalog, stmt *ast.DropTypeStmt) error {
 }
 
 func applyCreateFunction(cat *core.Catalog, stmt *ast.CreateFunctionStmt) error {
-	// A procedure returns nothing, so there is no result for a query to
-	// select and nothing worth recording.
-	if stmt.Func == nil || stmt.Func.Name == "" || stmt.ReturnType == nil {
+	if stmt.Func == nil || stmt.Func.Name == "" {
 		return nil
 	}
-	returnOID, err := cat.ResolveType(stmt.ReturnType)
+	// A procedure returns nothing, so there is no result for a query to
+	// select; it is recorded for the arguments a CALL passes it.
+	kind := "f"
+	var returnOID int64
+	var err error
+	switch {
+	case stmt.IsProcedure:
+		kind = "p"
+		returnOID, err = cat.VoidTypeOID()
+	case stmt.ReturnType == nil:
+		return nil
+	default:
+		returnOID, err = cat.ResolveType(stmt.ReturnType)
+	}
 	if err != nil {
 		return fmt.Errorf("function %q: %w", stmt.Func.Name, err)
 	}
@@ -599,6 +610,7 @@ func applyCreateFunction(cat *core.Catalog, stmt *ast.CreateFunctionStmt) error 
 	}
 	_, err = cat.CreateProc(core.ProcSpec{
 		Name:          stmt.Func.Name,
+		Kind:          kind,
 		ReturnTypeOID: returnOID,
 		ReturnSet:     stmt.ReturnType != nil && stmt.ReturnType.Setof,
 		Args:          args,

--- a/internal/core/typename.go
+++ b/internal/core/typename.go
@@ -15,11 +15,14 @@ func TypeNameString(tn *ast.TypeName) string {
 		return ""
 	}
 	name := strings.TrimSpace(tn.Name)
+	if name != "" && tn.Schema != "" && tn.Schema != "pg_catalog" && tn.Schema != "public" {
+		name = tn.Schema + "." + name
+	}
 	if name == "" && tn.Names != nil {
 		parts := make([]string, 0, len(tn.Names.Items))
 		for _, item := range tn.Names.Items {
 			s, ok := item.(*ast.String)
-			if !ok || s.Str == "pg_catalog" {
+			if !ok || s.Str == "pg_catalog" || s.Str == "public" {
 				continue
 			}
 			parts = append(parts, s.Str)

--- a/internal/engine/dolphin/convert.go
+++ b/internal/engine/dolphin/convert.go
@@ -1788,7 +1788,8 @@ func (c *cc) convertProcedureInfo(n *pcast.ProcedureInfo) ast.Node {
 		})
 	}
 	return &ast.CreateFunctionStmt{
-		Params: &params,
+		IsProcedure: true,
+		Params:      &params,
 		Func: &ast.FuncName{
 			Schema: n.ProcedureName.Schema.L,
 			Name:   n.ProcedureName.Name.L,

--- a/internal/engine/postgresql/convert.go
+++ b/internal/engine/postgresql/convert.go
@@ -1095,11 +1095,12 @@ func convertCreateFunctionStmt(n *pg.CreateFunctionStmt) *ast.CreateFunctionStmt
 		panic(err)
 	}
 	return &ast.CreateFunctionStmt{
-		Replace:    n.Replace,
-		Func:       rel.FuncName(),
-		Params:     convertSlice(n.Parameters),
-		ReturnType: convertTypeName(n.ReturnType),
-		Options:    convertSlice(n.Options),
+		Replace:     n.Replace,
+		IsProcedure: n.IsProcedure,
+		Func:        rel.FuncName(),
+		Params:      convertSlice(n.Parameters),
+		ReturnType:  convertTypeName(n.ReturnType),
+		Options:     convertSlice(n.Options),
 	}
 }
 

--- a/internal/engine/postgresql/parse.go
+++ b/internal/engine/postgresql/parse.go
@@ -555,11 +555,12 @@ func translate(node *nodes.Node) (ast.Node, error) {
 			rt = rel.TypeName()
 		}
 		stmt := &ast.CreateFunctionStmt{
-			Func:       fn.FuncName(),
-			ReturnType: rt,
-			Replace:    n.Replace,
-			Params:     &ast.List{},
-			Options:    convertSlice(n.Options),
+			Func:        fn.FuncName(),
+			ReturnType:  rt,
+			Replace:     n.Replace,
+			IsProcedure: n.IsProcedure,
+			Params:      &ast.List{},
+			Options:     convertSlice(n.Options),
 		}
 		for _, item := range n.Parameters {
 			arg := item.Node.(*nodes.Node_FunctionParameter).FunctionParameter

--- a/internal/sql/ast/create_function_stmt.go
+++ b/internal/sql/ast/create_function_stmt.go
@@ -5,10 +5,13 @@ import "github.com/sqlc-dev/sqlc/internal/sql/format"
 type CreateFunctionStmt struct {
 	Tag NodeTag[CreateFunctionStmt] `json:"tag"`
 
-	Replace    bool      `json:"replace"`
-	Params     *List     `json:"params,omitempty"`
-	ReturnType *TypeName `json:"return_type,omitempty"`
-	Func       *FuncName `json:"func,omitempty"`
+	Replace bool `json:"replace"`
+	// IsProcedure marks CREATE PROCEDURE, which is called rather than
+	// selected from and returns nothing.
+	IsProcedure bool      `json:"is_procedure"`
+	Params      *List     `json:"params,omitempty"`
+	ReturnType  *TypeName `json:"return_type,omitempty"`
+	Func        *FuncName `json:"func,omitempty"`
 	// TODO: Understand these two fields
 	Options    *List `json:"options,omitempty"`
 	WithClause *List `json:"with_clause,omitempty"`


### PR DESCRIPTION
Three fixes from a triage of every `internal/endtoend` replay case that passes as committed but fails under `SQLCEXPERIMENT=coreanalyzer`. Together they take the core context from 347 failing cases to 281, with no case regressing and the base context still fully green. Each commit stands on its own.

## Enums absent from models (50 cases, 45 fixed)

The core catalog created an enum type on `CREATE TYPE ... AS ENUM` but kept none of its labels, and the dump that hands the catalog to codegen carried relations only. Every enum was missing from `models.go`, PostgreSQL enum columns were typed `any` and MySQL ENUM columns `string`.

- `sql_enum_label` stores an enum's labels, modeled on `pg_enum`.
- The schema package applies `ALTER TYPE ADD VALUE` (with `BEFORE`/`AFTER` and `IF NOT EXISTS`), `RENAME VALUE`, `RENAME TO`, `SET SCHEMA` and `DROP TYPE`.
- A MySQL ENUM or SET column declares an enum of its own, named `<table>_<column>` as the legacy catalog names it. It follows the column and the table through renames, is replaced on `MODIFY`, and goes with a dropped column or table.
- Type names keep the schema an engine reports on the `TypeName` itself and drop a spelled-out `public.`, so `foo.mood` and `DROP TYPE public.status` resolve the way their column references do.

The five leftovers are blocked by other buckets (`varchar` typed `any`, MySQL BOOLEAN, `sqlc.embed`).

## Views absent from models (10 cases, 8 fixed)

The catalog dump listed kind `r` relations only, so views, materialized views and `CREATE TABLE AS` had no model, and a query selecting all of one got a row struct of its own. The listing now covers the relations a query selects rows from the same way. The two leftovers are the anonymous-column naming bucket (`SELECT 1` as a view) and `CREATE SCHEMA`.

## Placeholders the analyzer walked past (17 cases, 14 fixed)

- `INSERT ... SELECT`: the engines report the source query with an empty VALUES list rather than none, so the analyzer took the VALUES branch and walked nothing. A placeholder selected directly now takes the type of the column it lands in.
- `LIMIT` on `UPDATE`, `DELETE`, and on `UNION`/`INTERSECT`/`EXCEPT` was never looked at.
- `ON DUPLICATE KEY UPDATE` assignments bind the way `SET` does.
- `x IN (SELECT ...)` on MySQL arrives wrapped in a sublink, which the IN node now looks through.
- `x COLLATE c`: SQLite puts the expression in the node's other field, so the placeholder underneath was neither found nor typed.
- `CALL`: the compiler now sends it through the core, `CREATE PROCEDURE` is recorded with a void pseudo type as its result, and a call types each placeholder from the declared parameter, by position or by `name =>`. The AST gains `IsProcedure`, set by both parsers, since a function with only OUT parameters also declares no return type.
- A placeholder on the left of an IN list takes its type from the members.

The three leftovers are MySQL BOOLEAN and LIMIT parameter naming. I tried naming `LIMIT`/`OFFSET` placeholders in the core and backed it out: it changed `analyze` output for SQLite and ClickHouse, where the database reports no name, so that convention belongs in the compiler bridge rather than the analysis.

## Notes for review

- One judgement call: a MySQL ENUM column is now reported by `sqlc analyze` with the synthetic `<table>_<column>` type name rather than `enum`. That is what codegen needs and what the legacy compiler always did, but it is not what MySQL itself reports. goldeneye has no MySQL analyze check today.
- No test cases were added; the existing corpus covers the changes. Verified by running `TestReplay/base` (all green) and `SQLC_TEST_CORE=1 TestReplay/core` (347 → 281) before and after each commit.
- `internal/core/catalogdb` is regenerated from the catalog schema and query changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XZcKb4GFiZQbeo9oVmyF3m